### PR TITLE
require output type for ArgMax and ArgMin reduce fns

### DIFF
--- a/crates/cubek-reduce/src/components/instructions/mixed.rs
+++ b/crates/cubek-reduce/src/components/instructions/mixed.rs
@@ -36,7 +36,7 @@ pub enum ReduceOperationConfig {
 
 impl ReduceOperationConfig {
     /// Computes the best case precision for the given config.
-    pub fn precision(&self, input: ElemType) -> ReduceDtypes {
+    pub fn precision(&self, input: ElemType, output: Option<ElemType>) -> ReduceDtypes {
         match self {
             ReduceOperationConfig::Sum
             | ReduceOperationConfig::Prod
@@ -54,7 +54,9 @@ impl ReduceOperationConfig {
             ReduceOperationConfig::ArgMax | ReduceOperationConfig::ArgMin => {
                 return ReduceDtypes {
                     input: input.into(),
-                    output: i32::as_type_native_unchecked(),
+                    output: output
+                        .expect("ArgMax and ArgMin must specify output type")
+                        .into(),
                     accumulation: input.into(),
                 };
             }


### PR DESCRIPTION
This PR fixes the ArgMax/ArgMin reduction fns to require output tensor dtype to be specified. I ran into this using e.g. `max_dim_with_indices` in burn. I tried to call `to_data().into_vec()` on the tensor, which failed cause even though I was using i64 as int type, the data type was i32 (error `TypeMismatch("Invalid target element type (expected I32, got I64)")`).

Re-opened from https://github.com/tracel-ai/cubecl/pull/1092

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here: https://github.com/tracel-ai/burn/pull/4170
