### PR TITLE
Fix typo: Correct `independant` to `independent` in `PlaneStrategy`

### DIFF
--- a/crates/cubek-reduce/src/routines/plane.rs
+++ b/crates/cubek-reduce/src/routines/plane.rs
@@ -14,7 +14,7 @@ pub struct PlaneRoutine;
 #[derive(Debug, Clone)]
 pub struct PlaneStrategy {
     /// How the accumulators are handled in a plane.
-    pub independant: bool,
+    pub independent: bool,
 }
 
 impl Routine for PlaneRoutine {
@@ -99,7 +99,7 @@ fn generate_blueprint<R: Runtime>(
         global: GlobalReduceBlueprint::FullPlane(PlaneReduceBlueprint {
             plane_idle,
             bound_checks,
-            independant: strategy.independant,
+            independant: strategy.independent,
         }),
     };
 


### PR DESCRIPTION
### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
