### PR TITLE
fix: Fix typo in wgrad out layout

### DIFF
--- a/crates/cubek-convolution/src/kernels/backward_weight/args.rs
+++ b/crates/cubek-convolution/src/kernels/backward_weight/args.rs
@@ -205,7 +205,7 @@ impl<EG: Numeric> ConcreteOutputFactory for TensorOutput<EG> {
             problem.check_channel(),
         );
         let layout =
-            WeightLayoutLaunch::from_args_wgrad(client, problem, config.rhs_global_memory_config());
+            WeightLayoutLaunch::from_args_wgrad(client, problem, config.out_global_memory_config());
         let layout = ChainLaunch::new(global, TransposeLaunch::new(layout));
         let view = ViewArg::new::<Layout>(out.as_array_arg(line_sizes.out), layout);
         let batch = VirtualLayoutLaunch::new::<NoopLayout>(NoopLayoutLaunch::new());


### PR DESCRIPTION
Fix a typo in the output factory for weight gradients

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
