### PR TITLE
fix: m size of 0

### DIFF
--- a/crates/cubek-matmul/src/routines/selector/unit.rs
+++ b/crates/cubek-matmul/src/routines/selector/unit.rs
@@ -250,7 +250,7 @@ fn matvec_unit_selector(
         PartitionBuffering::Single,
         plane_dim,
         StageSelection::Fixed {
-            m: plane_dim / 2,
+            m: (plane_dim / 2).max(1),
             n: 2,
         },
         num_sms,
@@ -284,7 +284,7 @@ fn vecmat_unit_selector(
         plane_dim,
         StageSelection::Fixed {
             m: 2,
-            n: plane_dim / 2,
+            n: (plane_dim / 2).max(1),
         },
         num_sms,
         GlobalOrderBlueprint::Default,
@@ -323,7 +323,7 @@ fn scalarvec_unit_selector(
         plane_dim,
         StageSelection::Fixed {
             m: 2,
-            n: plane_dim / 2,
+            n: (plane_dim / 2).max(1),
         },
         num_sms,
         GlobalOrderBlueprint::Default,
@@ -355,7 +355,7 @@ fn vecscalar_unit_selector(
         PartitionBuffering::Single,
         plane_dim,
         StageSelection::Fixed {
-            m: plane_dim / 2,
+            m: (plane_dim / 2).max(1),
             n: 2,
         },
         num_sms,


### PR DESCRIPTION
Fixes #16, which occurs when plane_dim is 1. I ran into the same issue and traced the division by zero to this code.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
