### PR TITLE
fix(cubek-reduce): Fix reduce kernels with non-contiguous out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,12 @@ version = "0.1.0"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 
 ### For the main cubek branch. ###
-# cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "d060bfd58126b790ea0f9794dd3b3d791eb74fd6", default-features = false }
-# cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "d060bfd58126b790ea0f9794dd3b3d791eb74fd6", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "56efabb3569256e38e0d19cfeca5efc7cd57f888", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "56efabb3569256e38e0d19cfeca5efc7cd57f888", default-features = false }
 
 ### For releases ###
-# cubecl = { version = "=0.9.0", default-features = false }
-# cubecl-common = { version = "=0.9.0", default-features = false }
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "91630e96a1518642f64e239026c0cc532e602eb0", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "91630e96a1518642f64e239026c0cc532e602eb0", default-features = false }
+# # cubecl = { version = "=0.9.0", default-features = false }
+# # cubecl-common = { version = "=0.9.0", default-features = false }
 
 bitflags = { version = "2.9.1", features = ["serde"] }
 derive-new = { version = "0.7.0", default-features = false }

--- a/crates/cubek-reduce/src/components/args.rs
+++ b/crates/cubek-reduce/src/components/args.rs
@@ -1,9 +1,9 @@
-use cubecl::prelude::*;
 use cubecl::std::{
     CubeOption, CubeOptionExpand,
     tensor::r#virtual::{VirtualTensor, VirtualTensorOperations, VirtualTensorOperationsExpand},
 };
 use cubecl::unexpanded;
+use cubecl::{prelude::*, std::tensor::layout::linear::LinearLayout};
 use std::marker::PhantomData;
 
 pub trait ReduceDType {
@@ -52,13 +52,19 @@ pub trait ReduceArgs: Send + Sync + 'static + Clone {
 
     fn line_size_input<P: ReduceDType>(state: &Self::State<P>) -> comptime_type!(LineSize);
     fn line_size_output<P: ReduceDType>(state: &Self::State<P>) -> comptime_type!(LineSize);
+
+    fn out_layout<P: ReduceDType>(state: &Self::State<P>) -> LinearLayout;
 }
 
 #[cube]
 pub fn init_tensors<RA: ReduceArgs, In: Numeric, Out: Numeric>(
     input: &RA::Input<In>,
     output: &mut RA::Output<Out>,
-) -> (VirtualTensor<In>, VirtualTensor<Out, ReadWrite>) {
+) -> (
+    VirtualTensor<In>,
+    VirtualTensor<Out, ReadWrite>,
+    LinearLayout,
+) {
     let mut state = RA::init_state::<(In, Out)>(input, output);
 
     let input = TensorArg::new_input(&state);
@@ -67,8 +73,9 @@ pub fn init_tensors<RA: ReduceArgs, In: Numeric, Out: Numeric>(
     let input = VirtualTensor::<In>::new::<TensorArg<(In, Out), RA, Input>>(&input);
     let output =
         VirtualTensor::<Out, ReadWrite>::new::<TensorArg<(In, Out), RA, Output>>(&mut output);
+    let out_layout = RA::out_layout(&state);
 
-    (input, output)
+    (input, output, out_layout)
 }
 
 #[derive(Clone)]
@@ -77,14 +84,19 @@ pub struct TensorArgs;
 #[cube]
 impl ReduceArgs for TensorArgs {
     type Input<EG: Numeric> = Tensor<Line<EG>>;
-    type Output<EG: Numeric> = Tensor<Line<EG>>;
-    type State<P: ReduceDType> = (*const Tensor<Line<P::In>>, *mut Tensor<Line<P::Out>>);
+    type Output<EG: Numeric> = (Tensor<Line<EG>>, LinearLayout);
+    type State<P: ReduceDType> = (
+        *const Tensor<Line<P::In>>,
+        *mut Tensor<Line<P::Out>>,
+        LinearLayout,
+    );
 
     fn init_state<P: ReduceDType>(
         input: &Self::Input<P::In>,
         output: &mut Self::Output<P::Out>,
     ) -> Self::State<P> {
-        (input, output)
+        let out: *mut Tensor<Line<P::Out>> = &mut output.0;
+        (input, out, comptime![output.1.clone()])
     }
 
     fn read_input<P: ReduceDType>(state: &Self::State<P>, index: usize) -> Line<P::In> {
@@ -144,6 +156,10 @@ impl ReduceArgs for TensorArgs {
 
     fn line_size_output<P: ReduceDType>(state: &Self::State<P>) -> comptime_type!(LineSize) {
         unsafe { (*state.1).line_size() }
+    }
+
+    fn out_layout<P: ReduceDType>(state: &Self::State<P>) -> LinearLayout {
+        comptime![state.2.clone()]
     }
 }
 

--- a/crates/cubek-reduce/src/components/global/cube.rs
+++ b/crates/cubek-reduce/src/components/global/cube.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 use cubecl::{
     prelude::*,
-    std::{CubeOption, tensor::r#virtual::VirtualTensor},
+    std::{
+        CubeOption,
+        tensor::{layout::linear::LinearLayout, r#virtual::VirtualTensor},
+    },
 };
 
 #[derive(CubeType)]
@@ -21,6 +24,7 @@ impl GlobalFullCubeReduce {
     pub fn execute<P: ReducePrecision, Out: Numeric, I: ReduceInstruction<P>>(
         input: &VirtualTensor<P::EI>,
         output: &mut VirtualTensor<Out, ReadWrite>,
+        out_layout: LinearLayout,
         reduce_axis: usize,
         inst: &I,
         #[comptime] line_mode: LineMode,
@@ -32,8 +36,13 @@ impl GlobalFullCubeReduce {
         let accumulator_size = blueprint.num_shared_accumulators;
         let worker_pos = Self::worker_pos(blueprint);
 
-        let mut writer =
-            Writer::<Out>::new::<P>(input, output, reduce_axis, write_index, line_mode);
+        let mut writer = Writer::<Out>::new::<P>(
+            input,
+            output.view_mut(out_layout),
+            reduce_axis,
+            write_index,
+            line_mode,
+        );
 
         let write_count = writer.write_count();
 

--- a/crates/cubek-reduce/src/components/global/plane.rs
+++ b/crates/cubek-reduce/src/components/global/plane.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 use cubecl::{
     prelude::*,
-    std::{CubeOption, tensor::r#virtual::VirtualTensor},
+    std::{
+        CubeOption,
+        tensor::{layout::linear::LinearLayout, r#virtual::VirtualTensor},
+    },
 };
 
 #[derive(CubeType)]
@@ -21,6 +24,7 @@ impl GlobalFullPlaneReduce {
     pub fn execute<P: ReducePrecision, Out: Numeric, I: ReduceInstruction<P>>(
         input: &VirtualTensor<P::EI>,
         output: &mut VirtualTensor<Out, ReadWrite>,
+        out_layout: LinearLayout,
         reduce_axis: usize,
         inst: &I,
         #[comptime] line_mode: LineMode,
@@ -28,8 +32,13 @@ impl GlobalFullPlaneReduce {
     ) {
         let write_index = CUBE_POS * CUBE_DIM_Y as usize + UNIT_POS_Y as usize;
 
-        let mut writer =
-            Writer::<Out>::new::<P>(input, output, reduce_axis, write_index, line_mode);
+        let mut writer = Writer::<Out>::new::<P>(
+            input,
+            output.view_mut(out_layout),
+            reduce_axis,
+            write_index,
+            line_mode,
+        );
 
         let write_count = writer.write_count();
         let reduce_index_start = write_index * write_count;

--- a/crates/cubek-reduce/src/components/global/unit.rs
+++ b/crates/cubek-reduce/src/components/global/unit.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 use cubecl::{
     prelude::*,
-    std::{CubeOption, tensor::r#virtual::VirtualTensor},
+    std::{
+        CubeOption,
+        tensor::{layout::linear::LinearLayout, r#virtual::VirtualTensor},
+    },
 };
 
 #[derive(CubeType)]
@@ -21,14 +24,20 @@ impl GlobalFullUnitReduce {
     pub fn execute<P: ReducePrecision, Out: Numeric, I: ReduceInstruction<P>>(
         input: &VirtualTensor<P::EI>,
         output: &mut VirtualTensor<Out, ReadWrite>,
+        out_layout: LinearLayout,
         reduce_axis: usize,
         inst: &I,
         #[comptime] line_mode: LineMode,
         #[comptime] blueprint: UnitReduceBlueprint,
     ) {
         let write_index = ABSOLUTE_POS;
-        let mut writer =
-            Writer::<Out>::new::<P>(input, output, reduce_axis, write_index, line_mode);
+        let mut writer = Writer::<Out>::new::<P>(
+            input,
+            output.view_mut(out_layout),
+            reduce_axis,
+            write_index,
+            line_mode,
+        );
 
         let write_count = writer.write_count();
         let reduce_index_start = write_index * write_count;

--- a/crates/cubek-reduce/src/components/readers/parallel.rs
+++ b/crates/cubek-reduce/src/components/readers/parallel.rs
@@ -41,10 +41,16 @@ impl<P: ReducePrecision> ParallelReader<P> {
         #[comptime] bound_checks: BoundChecks,
     ) -> ParallelReader<P> {
         let line_size = input.line_size();
+        let rank = input.rank();
 
+        let mut reduce_index = reduce_index;
         let mut batch_offset = 0;
-        for axis in 0..input.rank() {
-            let coordinate = output.coordinate(reduce_index, axis);
+        for axis in 0..rank {
+            let axis = rank - axis - 1;
+            let shape = output.shape(axis);
+            let coordinate = reduce_index % shape;
+            reduce_index /= shape;
+
             batch_offset += coordinate * input.stride(axis);
         }
         batch_offset /= line_size;

--- a/crates/cubek-reduce/src/components/readers/perpendicular.rs
+++ b/crates/cubek-reduce/src/components/readers/perpendicular.rs
@@ -42,11 +42,17 @@ impl<P: ReducePrecision> PerpendicularReader<P> {
         #[comptime] bound_checks: BoundChecks,
     ) -> PerpendicularReader<P> {
         let line_size = input.line_size();
+        let rank = input.rank();
         let output_index = reduce_index * line_size;
 
+        let mut reduce_index = output_index;
         let mut batch_offset = 0;
-        for axis in 0..input.rank() {
-            let coordinate = output.coordinate(output_index, axis);
+        for axis in 0..rank {
+            let axis = rank - axis - 1;
+            let shape = output.shape(axis);
+            let coordinate = reduce_index % shape;
+            reduce_index /= shape;
+
             batch_offset += coordinate * input.stride(axis);
         }
         batch_offset /= line_size;

--- a/crates/cubek-reduce/src/components/writer.rs
+++ b/crates/cubek-reduce/src/components/writer.rs
@@ -3,7 +3,7 @@ use cubecl::{
     prelude::*,
     std::tensor::{
         View,
-        layout::{Coords1d, plain::PlainLayout},
+        layout::{Coords1d, linear::LinearView},
         r#virtual::VirtualTensor,
     },
 };
@@ -22,7 +22,7 @@ pub enum Writer<Out: Numeric> {
 impl<Out: Numeric> Writer<Out> {
     pub fn new<P: ReducePrecision>(
         input: &VirtualTensor<P::EI>,
-        output: &mut VirtualTensor<Out, ReadWrite>,
+        output: LinearView<Line<Out>, ReadWrite>,
         reduce_axis: usize,
         write_index: usize,
         #[comptime] line_mode: LineMode,
@@ -86,12 +86,12 @@ pub struct ParallelWriter<Out: Numeric> {
 impl<Out: Numeric> ParallelWriter<Out> {
     pub fn new<P: ReducePrecision>(
         input: &VirtualTensor<P::EI>,
-        output: &mut VirtualTensor<Out, ReadWrite>,
+        output: LinearView<Line<Out>, ReadWrite>,
         reduce_axis: usize,
         write_index: usize,
     ) -> ParallelWriter<Out> {
         ParallelWriter::<Out> {
-            output: output.view_mut(PlainLayout::new(output.len())),
+            output,
             buffer: Line::empty(output.line_size()),
             axis_size: input.shape(reduce_axis),
             write_index,
@@ -136,7 +136,7 @@ pub struct PerpendicularWriter<Out: Numeric> {
 impl<Out: Numeric> PerpendicularWriter<Out> {
     pub fn new<P: ReducePrecision>(
         input: &VirtualTensor<P::EI>,
-        output: &mut VirtualTensor<Out, ReadWrite>,
+        output: LinearView<Line<Out>, ReadWrite>,
         reduce_axis: usize,
         write_index: usize,
     ) -> PerpendicularWriter<Out> {
@@ -144,7 +144,7 @@ impl<Out: Numeric> PerpendicularWriter<Out> {
         let output_line_size = output.line_size();
 
         PerpendicularWriter::<Out> {
-            output: output.view_mut(PlainLayout::new(output.len())),
+            output,
             axis_size: input.shape(reduce_axis),
             write_index,
             input_line_size,

--- a/crates/cubek-reduce/src/launch/base.rs
+++ b/crates/cubek-reduce/src/launch/base.rs
@@ -13,7 +13,13 @@ use crate::{
         cube::CubeRoutine, plane::PlaneRoutine, unit::UnitRoutine,
     },
 };
-use cubecl::{prelude::*, std::tensor::r#virtual::VirtualTensor};
+use cubecl::{
+    prelude::*,
+    std::tensor::{
+        layout::linear::{LinearLayout, LinearLayoutArgs},
+        r#virtual::VirtualTensor,
+    },
+};
 
 #[derive(Clone, Copy, Debug)]
 pub struct ReduceDtypes {
@@ -81,7 +87,10 @@ pub(crate) fn launch_reduce<Run: Runtime>(
             settings.cube_count,
             settings.cube_dim,
             input.as_tensor_arg(settings.line.line_size_input),
-            output.as_tensor_arg(settings.line.line_size_output),
+            (
+                output.as_tensor_arg(settings.line.line_size_output),
+                LinearLayoutArgs::from_handle(client, &output, settings.line.line_size_output),
+            ),
             ScalarArg::new(axis),
             blueprint,
             inst,
@@ -104,14 +113,22 @@ pub fn reduce_kernel<In: Numeric, Out: Numeric, Acc: Numeric, RA: ReduceArgs>(
     #[define(Out)] _output_dtype: StorageType,
     #[define(Acc)] _acc_dtype: StorageType,
 ) {
-    let (input, mut output) = init_tensors::<RA, In, Out>(input, output);
-    reduce_kernel_virtual::<In, Out, Acc>(&input, &mut output, axis_reduce, blueprint, config);
+    let (input, mut output, out_layout) = init_tensors::<RA, In, Out>(input, output);
+    reduce_kernel_virtual::<In, Out, Acc>(
+        &input,
+        &mut output,
+        out_layout,
+        axis_reduce,
+        blueprint,
+        config,
+    );
 }
 
 #[cube]
 pub fn reduce_kernel_virtual<In: Numeric, Out: Numeric, Acc: Numeric>(
     input: &VirtualTensor<In>,
     output: &mut VirtualTensor<Out, ReadWrite>,
+    out_layout: LinearLayout,
     axis_reduce: usize,
     #[comptime] blueprint: ReduceBlueprint,
     #[comptime] config: ReduceOperationConfig,
@@ -119,6 +136,7 @@ pub fn reduce_kernel_virtual<In: Numeric, Out: Numeric, Acc: Numeric>(
     reduce_kernel_inner::<(In, Acc), Out, ReduceOperation>(
         input,
         output,
+        out_layout,
         axis_reduce,
         blueprint,
         config,
@@ -129,6 +147,7 @@ pub fn reduce_kernel_virtual<In: Numeric, Out: Numeric, Acc: Numeric>(
 fn reduce_kernel_inner<P: ReducePrecision, Out: Numeric, R: ReduceFamily>(
     input: &VirtualTensor<P::EI>,
     output: &mut VirtualTensor<Out, ReadWrite>,
+    out_layout: LinearLayout,
     axis_reduce: usize,
     #[comptime] blueprint: ReduceBlueprint,
     #[comptime] config: R::Config,
@@ -140,6 +159,7 @@ fn reduce_kernel_inner<P: ReducePrecision, Out: Numeric, R: ReduceFamily>(
             GlobalFullCubeReduce::execute::<P, Out, R::Instruction<P>>(
                 input,
                 output,
+                out_layout,
                 axis_reduce,
                 inst,
                 blueprint.line_mode,
@@ -150,6 +170,7 @@ fn reduce_kernel_inner<P: ReducePrecision, Out: Numeric, R: ReduceFamily>(
             GlobalFullPlaneReduce::execute::<P, Out, R::Instruction<P>>(
                 input,
                 output,
+                out_layout,
                 axis_reduce,
                 inst,
                 blueprint.line_mode,
@@ -160,6 +181,7 @@ fn reduce_kernel_inner<P: ReducePrecision, Out: Numeric, R: ReduceFamily>(
             GlobalFullUnitReduce::execute::<P, Out, R::Instruction<P>>(
                 input,
                 output,
+                out_layout,
                 axis_reduce,
                 inst,
                 blueprint.line_mode,

--- a/crates/cubek-reduce/src/launch/utils.rs
+++ b/crates/cubek-reduce/src/launch/utils.rs
@@ -136,6 +136,7 @@ pub fn generate_line_size<R: Runtime>(
         && line_mode == LineMode::Parallel
         && line_size_input > 1
         && is_contiguous(input.shape, input.strides)
+        && is_contiguous(output.shape, output.strides)
         && axis == input.shape.len() - 1
     {
         let supported_line_sizes = client.io_optimized_line_sizes_unchecked(dtype.size());

--- a/crates/cubek-reduce/src/routines/shared_sum.rs
+++ b/crates/cubek-reduce/src/routines/shared_sum.rs
@@ -1,6 +1,6 @@
-use cubecl::features::TypeUsage;
-use cubecl::ir::ElemType;
-use cubecl::prelude::*;
+use cubecl::{features::TypeUsage, std::tensor::layout::linear::LinearView};
+use cubecl::{ir::ElemType, std::tensor::layout::linear::linear_view};
+use cubecl::{prelude::*, std::tensor::is_contiguous, tensor_line_size_parallel};
 
 use crate::ReduceError;
 
@@ -71,11 +71,20 @@ pub fn shared_sum<R: Runtime>(
     let input_len = input.shape.iter().product::<usize>();
 
     // Compute the optimal line size.
-    let line_size = client
-        .io_optimized_line_sizes_unchecked(input.elem_size)
-        .filter(|line_size| input_len % *line_size == 0)
-        .max()
-        .unwrap_or(1);
+    let line_size = if is_contiguous(input.shape, input.strides) {
+        client
+            .io_optimized_line_sizes_unchecked(input.elem_size)
+            .filter(|line_size| input_len % *line_size == 0)
+            .max()
+            .unwrap_or(1)
+    } else {
+        tensor_line_size_parallel(
+            client.io_optimized_line_sizes_unchecked(input.elem_size),
+            input.shape,
+            input.strides,
+            input.shape.len() - 1,
+        )
+    };
 
     // Compute extra parameters.
     let cube_dim = CubeDim::new_2d(32, 8); // NOTE: If you change that, keep the unit count a power of 2.
@@ -89,7 +98,7 @@ pub fn shared_sum<R: Runtime>(
             client,
             cube_count,
             cube_dim,
-            input.as_tensor_arg(line_size),
+            linear_view(client, &input, line_size),
             output.as_tensor_arg(1),
             cube_dim.num_elems() as usize,
             line_size,
@@ -106,7 +115,7 @@ pub fn shared_sum<R: Runtime>(
 
 #[cube(launch_unchecked)]
 fn shared_sum_kernel<N: Numeric>(
-    input: &Tensor<Line<N>>,
+    input: &LinearView<Line<N>>,
     output: &mut Tensor<Atomic<N>>,
     #[comptime] shared_memory_size: usize,
     #[comptime] line_size: LineSize,
@@ -121,8 +130,8 @@ fn shared_sum_kernel<N: Numeric>(
     let end = start + num_lines_per_unit;
 
     // Prevent out-of-bound access
-    let start = select(start < input.len(), start, input.len());
-    let end = select(end < input.len(), end, input.len());
+    let start = select(start < input.shape(), start, input.shape());
+    let end = select(end < input.shape(), end, input.shape());
 
     // Each unit sum its lines.
     for k in start..end {


### PR DESCRIPTION
Fixes reduce kernels to support non-contiguous outputs. While this is mainly for making optimized tensors the default in `burn`, this also ensures things don't break if an end user passes a non-contiguous output for whatever reason (i.e. reusing an existing tensor).
Also fixes non-contiguous inputs on shared sum.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
