### PR TITLE
Fix attention unit routine line size alignment with tile size

### DIFF
--- a/crates/cubek-attention/src/definition/line_size.rs
+++ b/crates/cubek-attention/src/definition/line_size.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use cubecl::{Runtime, client::ComputeClient, tensor_line_size_parallel};
 
-use crate::definition::{AttentionIdent, AttentionProblem};
+use crate::definition::{AttentionIdent, AttentionProblem, AttentionTileSize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 /// Line size used for each tensor in global memory accesses.
@@ -56,6 +56,32 @@ impl AttentionLineSizes {
                 &problem.dims.shape(AttentionIdent::Out),
                 problem.global_dtypes.out.size(),
             ),
+        }
+    }
+
+    /// Cap line sizes to be compatible with the given tile size.
+    /// Line sizes must evenly divide the corresponding tile dimensions.
+    pub fn cap_to_tile_size(self, tile_size: &AttentionTileSize) -> AttentionLineSizes {
+        fn cap(line_size: usize, tile_dim: u32) -> usize {
+            let tile_dim = tile_dim as usize;
+            if line_size > tile_dim || tile_dim % line_size != 0 {
+                // Find largest power of 2 <= tile_dim that divides tile_dim
+                let mut capped = 1;
+                while capped * 2 <= tile_dim && tile_dim % (capped * 2) == 0 {
+                    capped *= 2;
+                }
+                capped
+            } else {
+                line_size
+            }
+        }
+
+        AttentionLineSizes {
+            query: cap(self.query, tile_size.head_dim),
+            key: cap(self.key, tile_size.head_dim),
+            value: cap(self.value, tile_size.val_dim),
+            mask: self.mask,
+            out: cap(self.out, tile_size.val_dim),
         }
     }
 }

--- a/crates/cubek-attention/src/routines/unit.rs
+++ b/crates/cubek-attention/src/routines/unit.rs
@@ -111,7 +111,10 @@ fn blueprint(
                 plane_dim,
                 reuse_key_value: false,
                 two_rows_in_array_tile: false,
-                line_sizes: launch_settings.line_sizes.clone(),
+                line_sizes: launch_settings
+                    .line_sizes
+                    .clone()
+                    .cap_to_tile_size(&tile_size),
                 masked: problem.masked,
                 causal: problem.options.causal,
                 check_bounds: tiling_scheme.check_bounds(&problem.dims),


### PR DESCRIPTION
Fixes: https://github.com/tracel-ai/burn/issues/4325

The flash attention kernel was failing with assertion `unit_tile.layout.num_cols % line_size == 0` because the unit routine uses fixed tile sizes of 4x4 but line sizes are computed based on tensor dimensions and can be 8 or larger and the assertion fails when `line_size > tile_dim`.

Added a `cap_to_tile_size()` that caps line sizes to be compatible with tile dimensions. The Unit routine now calls this before creating the blueprint.

This is more of a workaround though. A proper fix would be to change the tile size to meet or exceed, or better handle misalignment, but in theory the attention kernel is WIP according to @nathanielsimard. 