### PR TITLE
chore: update cubecl rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ version = "0.1.0"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "941d806bb6d59cc425557d6008c1edd83221da53", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "941d806bb6d59cc425557d6008c1edd83221da53", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "a3987c60e410d77b6b38e99d1c2a6bc0979d38ba", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "a3987c60e410d77b6b38e99d1c2a6bc0979d38ba", default-features = false }
 
 ### For releases ###
 # cubecl = { version = "=0.9.0", default-features = false }


### PR DESCRIPTION
In order to unblock the macOS CI, we need changes made in cubecl, but we can't update the rev without also updating's cubek as well.