### PR TITLE
Fix/quant/packed contig

### DIFF
--- a/crates/cubek-quant/src/quantize.rs
+++ b/crates/cubek-quant/src/quantize.rs
@@ -3,7 +3,7 @@ use cubecl::features::TypeUsage;
 use cubecl::ir::ElemType;
 use cubecl::prelude::*;
 use cubecl::std::tensor::layout::linear::LinearView;
-use cubecl::std::tensor::{TensorHandle, into_contiguous_ref, is_contiguous};
+use cubecl::std::tensor::{TensorHandle, into_contiguous_ref};
 use cubecl::std::tensor::{View, layout::linear::linear_view};
 use cubecl::tensor_line_size_parallel;
 


### PR DESCRIPTION
https://github.com/tracel-ai/burn/issues/4491

`quantize_packed` previously assumed contiguous inputs when using vectorized packing (`line_size = num_quants`), which would produce incorrect packed values for strided tensors.

Fix: forced inputs into contiguous over a `num_elems` threshold (could be adjusted perhaps?), otherwise use line size of 1.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
