### PR TITLE
fix: Fix quantized naive matmul

### DIFF
--- a/crates/cubek-matmul/src/launch/launch_naive.rs
+++ b/crates/cubek-matmul/src/launch/launch_naive.rs
@@ -85,6 +85,15 @@ pub fn launch_ref<R: Runtime>(
         out: 1,
     };
 
+    let mut view_vector_sizes = vector_sizes;
+
+    if let MatmulInputBinding::Quantized { scheme, .. } = lhs {
+        view_vector_sizes.lhs *= scheme.num_quants();
+    }
+    if let MatmulInputBinding::Quantized { scheme, .. } = rhs {
+        view_vector_sizes.rhs *= scheme.num_quants();
+    }
+
     let address_type = lhs
         .required_address_type()
         .max(rhs.required_address_type())
@@ -103,7 +112,7 @@ pub fn launch_ref<R: Runtime>(
         rhs.scheme(),
     )?;
 
-    let device_settings = NaiveRoutine::device_settings(client, vector_sizes);
+    let device_settings = NaiveRoutine::device_settings(client, view_vector_sizes);
     let expand_info = NaiveRoutine::expand_blueprint(
         &problem,
         &device_settings,
@@ -140,6 +149,6 @@ pub fn launch_ref<R: Runtime>(
         launch_info.cube_count_plan.as_args(),
         launch_info.blueprint,
         dtypes,
-        &vector_sizes,
+        &launch_info.vector_sizes,
     )
 }


### PR DESCRIPTION
Fixes line size calculation for naive matmul. The other kernels already do this.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
