### PR TITLE
chore: Remove unused workspace deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,54 +26,22 @@ cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "20585bb73e
 # cubecl = { version = "=0.10.0-pre.2", default-features = false }
 # cubecl-common = { version = "=0.10.0-pre.2", default-features = false }
 
-bitflags = { version = "2.9.1", features = ["serde"] }
 derive-new = { version = "0.7.0", default-features = false }
-derive_more = { version = "2", default-features = false }
 log = { default-features = false, version = "0.4.22" }
 
-bincode = { version = "2.0.1", features = [
-    "alloc",
-    "serde",
-], default-features = false }
-fnv = "1"
 serde = { version = "1.0.204", default-features = false, features = [
     "derive",
     "alloc",
 ] } # alloc is for no_std, derive is needed
-serde_bytes = { version = "0.11.17", default-features = false, features = [
-    "alloc",
-] } # alloc for no_std
-serde_json = { version = "1.0.119", default-features = false }
-toml = "0.9.1"
-variadics_please = "1"
-
-# no_std compatibility
-dashmap = "6.1.0"
-foldhash = { version = "0.1.2", default-features = false }
-hashbrown = "0.15.5"
-smallvec = { version = "1", features = ["union", "const_generics"] }
-spin = { version = "0.10.0", features = ["mutex", "spin_mutex"] }
 
 rand = { version = "0.10.0", default-features = false, features = [
     "std_rng",
 ] } # std_rng is for no_std
 
-async-channel = "2.3"
-dirs = "6.0.0"
-embassy-time = { version = "0.4.0", default-features = false }
-md5 = "0.8.0"
-sanitize-filename = "0.6"
-wasm-bindgen-futures = "0.4.45"
-weak-table = "0.3"
-web-time = "1.1.0"
-
 # Testing
-rstest = "0.25.0"
-serial_test = "3.1.1"
+rstest = "0.26"
 
 bytemuck = "1.16.1"
-float4 = "0.1"
-float8 = { version = "0.4", default-features = false }
 half = { version = "2.5", features = [
     "alloc",
     "num-traits",
@@ -83,55 +51,14 @@ num-traits = { version = "0.2.19", default-features = false, features = [
     "libm",
 ] } # libm is for no_std
 
-cfg-if = "1.0.0"
-darling = "0.21.0"
 enumset = { version = "1.1.10", default-features = false }
-ident_case = "1"
-paste = "1"
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", features = ["full", "extra-traits", "visit-mut"] }
 thiserror = { version = "2", default-features = false }
-tracy-client = { version = "0.18.0" }
 
 ### For xtask crate ###
-strum = { version = "0.27.1", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 tracel-xtask = { version = "4.8" }
 
-portable-atomic = { version = "1.11", default-features = false, features = [
-    "serde",
-] }
-portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
 pretty_assertions = "1.4"
-
-# Async
-embassy-futures = { version = "0.1.1" }                        # for no-std
-futures-lite = { version = "2.3.0", default-features = false }
-
-# CubeCL-CPU
-sysinfo = "0.36.1"
-tracel-llvm = { version = "20.1.4-5", features = ["mlir-helpers"] }
-# tracel-llvm = { git = "https://github.com/tracel-ai/tracel-llvm.git", branch = "fix/linux", package = "tracel-llvm", features = ["mlir-helpers"] }
-# tracel-llvm = { path = "../tracel-llvm/crates/tracel-llvm", features = ["mlir-helpers"] }
-
-cudarc = { version = "0.18.1", features = [
-    "std",
-    "driver",
-    "nvrtc",
-    "dynamic-loading",
-    "cuda-version-from-build-system",
-    "fallback-latest",
-], default-features = false } # CubeCL-CUDA
-
-# CubeCL-SPIR-V
-rspirv = { package = "tracel-rspirv", version = "0.12.0" }
-
-# CubeCL-WGPU
-ash = "0.38"
-tracel-ash = "0.38.0"
-
-# Build deps
-cfg_aliases = "0.2.1"
 
 [profile.dev]
 debug = 1     # Speed up compilation time and not necessary.

--- a/crates/cubek-attention/Cargo.toml
+++ b/crates/cubek-attention/Cargo.toml
@@ -17,9 +17,8 @@ std = ["cubecl/std"]
 [dependencies]
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true }
-cubek-std = { path = "../cubek-std", default-features = false }
 cubek-matmul = { path = "../cubek-matmul", version = "=0.2.0-pre.2", default-features = false }
-cubek-random = { path = "../cubek-random", version = "=0.2.0-pre.2", default-features = false }
+cubek-std = { path = "../cubek-std", default-features = false }
 
 bytemuck = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }

--- a/crates/cubek-attention/tests/attention/launcher.rs
+++ b/crates/cubek-attention/tests/attention/launcher.rs
@@ -110,7 +110,9 @@ pub fn test_launch(
 
     match client.flush() {
         Ok(_) => {}
-        Err(ServerError::ServerUnhealthy { errors, .. }) => {
+        Err(ServerError::ServerUnhealthy { errors, .. }) =>
+        {
+            #[allow(clippy::never_loop)]
             for error in errors.iter() {
                 match error {
                     cubecl::server::ServerError::Launch(_) => {

--- a/crates/cubek-attention/tests/attention/reference.rs
+++ b/crates/cubek-attention/tests/attention/reference.rs
@@ -74,7 +74,7 @@ pub fn flash_attention_v2_reference(
     let mut k_index: [usize; 4];
     let mut v_index: [usize; 4];
     let mut m_index: [usize; 4];
-    let mut out_index = vec![0usize; 4];
+    let mut out_index = [0usize; 4];
 
     for b in 0..batch {
         for h in 0..num_heads {


### PR DESCRIPTION
Removes a bunch of leftover workspace dependencies from left over from the cubecl split

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.
