### PR TITLE
Fix swizzle validation removed in `385fb29`

### DIFF
--- a/crates/cubek-std/src/cube_count/hypercube/cube_count/plan.rs
+++ b/crates/cubek-std/src/cube_count/hypercube/cube_count/plan.rs
@@ -108,8 +108,12 @@ impl CubeCountPlan {
         // does not evenly divide the problem dimension (m_cubes for Row, n_cubes for Col).
         // Without this check, the swizzle produces incorrect cube-to-tile mappings.
         let global_order = match blueprint.global_order {
-            GlobalOrder::SwizzleRow(w) if problem_count.x % w != 0 => GlobalOrder::RowMajor,
-            GlobalOrder::SwizzleCol(w) if problem_count.y % w != 0 => GlobalOrder::ColMajor,
+            GlobalOrder::SwizzleRow(w) if !problem_count.x.is_multiple_of(w) => {
+                GlobalOrder::RowMajor
+            }
+            GlobalOrder::SwizzleCol(w) if !problem_count.y.is_multiple_of(w) => {
+                GlobalOrder::ColMajor
+            }
             other => other,
         }
         .canonicalize();


### PR DESCRIPTION
## Summary

Commit 385fb29df2e674b9b056025580b9d6575dda7f5f removed the `GlobalOrderStrategy` type and replaced it with direct `GlobalOrder` values passed to `HypercubeBlueprint::builder().global_order(...)`.

The old `GlobalOrderStrategy::into_order()` contained a critical validation:
when `SwizzleRow { m, w }` was used, it checked whether `m_cubes % w == 0` and fell back to `RowMajor` if not (same for `SwizzleCol`/`ColMajor`).
This fallback was silently dropped in the refactor - all call sites now pass `GlobalOrder::SwizzleRow(4)` unconditionally.

When a matmul problem has M dimensions where `m_cubes` is not divisible by the swizzle width (w=4), the swizzle function produces incorrect cube-to-tile mappings, causing wrong results. This breaks e.g. [Whisper](https://github.com/AdrianEddy/fast-whisper-burn) inference where many matmul shapes hit non-divisible dimensions.

## Fix

Added swizzle divisibility validation in `CubeCountPlan::from_blueprint()`, right where the `problem_count` (m_cubes, n_cubes) is already available:

- `SwizzleRow(w)` falls back to `RowMajor` when `problem_count.x % w != 0`
- `SwizzleCol(w)` falls back to `ColMajor` when `problem_count.y % w != 0`

This restores the exact same semantics as the removed `GlobalOrderStrategy`.

The fix was verified against my Whisper model - before the fix (burn rev `0c6ac48`) the model produces invalid outputs. After the fix it produces correct output.

## Tests

Added 3 regression tests in `cubek-std`:
- `swizzle_row_falls_back_when_m_cubes_not_divisible_by_w`
- `swizzle_row_kept_when_m_cubes_divisible_by_w`
- `swizzle_col_falls_back_when_n_cubes_not_divisible_by_w`


## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
