### PR TITLE
Fix vec2mat launch panic on unbatched (2D) tensors

### DIFF
--- a/crates/cubek-matmul/src/launch/launch_vec2mat.rs
+++ b/crates/cubek-matmul/src/launch/launch_vec2mat.rs
@@ -1,6 +1,6 @@
 //! Vec2Mat matmul kernel implementation
 use cubecl::std::tensor::{MatrixBatchLayout, matrix_batch_layout};
-use cubecl::zspace::shape;
+use cubecl::zspace::Shape;
 use cubecl::{VectorizationError, prelude::*};
 use cubek_std::MatrixLayout;
 
@@ -83,12 +83,15 @@ pub fn launch_ref<R: Runtime>(
         .max(rhs.required_address_type())
         .max(out.required_address_type(dtypes.acc_global.size()));
 
+    let lhs_batches: Shape = lhs.shape().to_vec()[..rank - 2].into();
+    let rhs_batches: Shape = rhs.shape().to_vec()[..rank - 2].into();
+
     let problem = MatmulProblem::from_parameters(
         1,
         n,
         k,
-        shape![1],
-        shape![1],
+        lhs_batches,
+        rhs_batches,
         MatrixLayout::RowMajor,
         MatrixLayout::from_shape_and_strides(rhs_shape, &rhs.data().strides, rhs.scheme())?,
         MatrixLayout::RowMajor,

--- a/crates/cubek-matmul/tests/suite/extended/vec2mat/suite.rs
+++ b/crates/cubek-matmul/tests/suite/extended/vec2mat/suite.rs
@@ -167,6 +167,85 @@ pub fn test_large_broadcast_batched() {
     test_vec2mat(case);
 }
 
+/// Regression test: launch_vec2mat::launch_ref used to hardcode batch dims as
+/// shape![1], which caused a sequence length mismatch panic when the actual
+/// tensors were 2D (no batch dimension). The BatchLayout's batch_shape had 1
+/// element but batch_strides had 0 elements, crashing in the #[unroll] loop.
+#[test]
+pub fn test_2d_no_batch_via_launch_ref() {
+    let client = TestRuntime::client(&Default::default());
+    let plane_size = client.properties().hardware.plane_size_max as usize;
+    let n = plane_size * 4;
+    let k = plane_size * 4;
+
+    // 2D shapes: no batch dimension
+    let lhs_shape = shape![1, k];
+    let rhs_shape = shape![k, n];
+    let out_shape = shape![1, n];
+
+    let global_elems = elems();
+    let all_elems = MatmulElems::from_globals(&global_elems);
+
+    let (lhs, lhs_data) = TestInput::new(
+        client.clone(),
+        lhs_shape.clone(),
+        global_elems.lhs,
+        layout_to_stride_spec(MatrixLayout::RowMajor),
+        DataKind::Random {
+            seed: 1234,
+            distribution: Distribution::Uniform(-1., 1.),
+        },
+    )
+    .generate_with_f32_host_data();
+
+    let (rhs, rhs_data) = TestInput::new(
+        client.clone(),
+        rhs_shape.clone(),
+        global_elems.rhs,
+        layout_to_stride_spec(MatrixLayout::RowMajor),
+        DataKind::Random {
+            seed: 5678,
+            distribution: Distribution::Uniform(-1., 1.),
+        },
+    )
+    .generate_with_f32_host_data();
+
+    let out = TestInput::new(
+        client.clone(),
+        out_shape.clone(),
+        global_elems.out,
+        layout_to_stride_spec(MatrixLayout::RowMajor),
+        DataKind::Zeros,
+    )
+    .generate_without_host_data();
+
+    let lhs_strides = lhs.strides().clone();
+    let rhs_strides = rhs.strides().clone();
+    let out_strides = out.strides().clone();
+
+    let lhs_handle = MatmulInputBinding::Normal(lhs.binding(), global_elems.lhs);
+    let rhs_handle = MatmulInputBinding::Normal(rhs.binding(), global_elems.rhs);
+    let out_handle = out.clone().binding();
+
+    launch_vec2mat::launch_ref(&client, lhs_handle, rhs_handle, out_handle, &all_elems).unwrap();
+
+    let problem = MatmulProblem::from_shapes_and_strides(
+        lhs_shape,
+        rhs_shape,
+        out_shape,
+        lhs_strides,
+        rhs_strides,
+        out_strides,
+        global_elems,
+        AddressType::U32,
+        None,
+        None,
+    )
+    .unwrap();
+
+    assert_result(&lhs_data, &rhs_data, &problem, &client, out, all_elems);
+}
+
 fn test_vec2mat(case: Vec2MatTestCase) {
     let client = TestRuntime::client(&Default::default());
     let plane_size = client.properties().hardware.plane_size_max as usize;


### PR DESCRIPTION
## Summary
`launch_vec2mat::launch_ref` panicked with index out of bounds: the len is 0 but the index is 0 during autotune when operating on 2D tensors (no batch dimensions). This occurred on first run with a clear autotune cache.

Fixes https://github.com/tracel-ai/burn/issues/4674

## Bug
`launch_vec2mat::launch_ref` hardcoded batch dimensions as `shape![1]` when constructing the `MatmulProblem`, regardless of the actual tensor rank. This created a mismatch between two data structures during kernel compilation:

`BatchLayout::batch_shape` was derived from `problem.out_batches` (length 1, from the hardcoded `shape![1]`)
`BatchLayout::batch_strides` was derived from `handle.strides[..rank - 2]` (length 0 for a 2D tensor)
The `#[unroll]` loop in `BatchLayout::to_source_pos` iterated `batch_shape.len()` times (1), but when it accessed `batch_strides[0]`, it indexed into an empty Sequence, causing the panic at `cubecl-core/src/frontend/container/sequence/base.rs:247`.

This only surfaced during autotune (fresh cache) because that is when kernels are compiled and the expand-time sequence indexing is exercised.

## Fix
Replaced hardcoded `shape![1]` with actual batch dimensions extracted from the input tensors (`shape[..rank - 2]`). For 2D tensors this produces empty batch dims, so both `batch_shape` and `batch_strides` are length 0 and the loop correctly iterates zero times. For 3D+ tensors it picks up the real batch dimensions.

## Testing
- Added `test_2d_no_batch_via_launch_ref` regression test that calls `launch_vec2mat::launch_ref` directly with 2D tensors (shape [1, k] × [k, n])
- Verified the test reproduces the exact panic without the fix


## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
