### PR TITLE
Flash attention : reject problems that are not divisible in seq q

### DIFF
--- a/crates/cubek-attention/src/routines/blackbox_accelerated.rs
+++ b/crates/cubek-attention/src/routines/blackbox_accelerated.rs
@@ -197,6 +197,14 @@ fn validate(
     problem: &AttentionProblem,
     blueprint: AttentionBlueprint,
 ) -> Result<AttentionBlueprint, AttentionSetupError> {
+    if !(problem.dims.seq_q as u32)
+        .is_multiple_of(blueprint.tiling_scheme.elements_in_stage_seq_q())
+    {
+        return Err(AttentionSetupError::InvalidConfig(Box::new(
+            "Stage seq_q must divide problem seq_q".to_string(),
+        )));
+    }
+
     if !(problem.dims.head_dim as u32).is_multiple_of(blueprint.tiling_scheme.tile_size.head_dim) {
         return Err(AttentionSetupError::InvalidConfig(Box::new(
             "Tile size head dim must divide problem head dim".to_string(),

--- a/crates/cubek-attention/tests/attention/extended/blueprint_tests.rs
+++ b/crates/cubek-attention/tests/attention/extended/blueprint_tests.rs
@@ -811,7 +811,7 @@ fn partition_many_planes() {
             val_dim: 1,
         },
         stage_size: AttentionStageSize {
-            seq_q: 10 * minimal_seq_q_stage(),
+            seq_q: 5 * minimal_seq_q_stage(),
         },
     };
     let problem = AttentionProblem {


### PR DESCRIPTION
Because query fragment were read directly from global memory, if the slice was out of bounds we had undefined behaviour.