### PR TITLE
Fix Gemv lhs/rhs vec contiguous

### DIFF
--- a/crates/cubek-matmul/src/launch/launch_vecmat_plane_parallel.rs
+++ b/crates/cubek-matmul/src/launch/launch_vecmat_plane_parallel.rs
@@ -36,42 +36,11 @@ fn vector_size_for<R: Runtime>(
         .ok_or(VectorizationError::NoValidVectorization)
 }
 
-fn validate_layout(problem: &MatmulProblem, kind: &GemvKind) -> Result<(), MatmulSetupError> {
-    let rank = problem.rhs_shape.len();
-
-    match kind {
-        GemvKind::MatVecRowMajor | GemvKind::MatVecColMajor => {
-            // RHS (vec) inner-most stride must be 1
-            let rhs_inner_stride = problem.rhs_strides[rank - 1];
-            if rhs_inner_stride != 1 {
-                return Err(MatmulSetupError::InvalidConfig(Box::new(format!(
-                    "GemvPlaneParallel: RHS vector must be contiguous. \
-                     Got inner stride {} (expected 1)",
-                    rhs_inner_stride
-                ))));
-            }
-        }
-        GemvKind::VecMatRowMajor | GemvKind::VecMatColMajor => {
-            // LHS (vec) inner-most stride must be 1
-            let lhs_inner_stride = problem.lhs_strides[rank - 1];
-            if lhs_inner_stride != 1 {
-                return Err(MatmulSetupError::InvalidConfig(Box::new(format!(
-                    "GemvPlaneParallel: LHS vector must be contiguous. \
-                     Got inner stride {} (expected 1)",
-                    lhs_inner_stride
-                ))));
-            }
-        }
-    }
-
-    Ok(())
-}
-
 #[allow(clippy::result_large_err)]
 pub fn launch_ref<R: Runtime>(
     client: &ComputeClient<R>,
-    lhs: InputBinding<R>,
-    rhs: InputBinding<R>,
+    mut lhs: InputBinding<R>,
+    mut rhs: InputBinding<R>,
     out: TensorBinding<R>,
     strategy: &BlueprintStrategy<(), GemvPlaneParallelRoutine>,
     dtypes: &MatmulElems,
@@ -128,11 +97,26 @@ pub fn launch_ref<R: Runtime>(
         address_type,
     );
 
+    match GemvKind::from_problem(&problem)? {
+        GemvKind::MatVecRowMajor | GemvKind::MatVecColMajor => {
+            // RHS (vec) must be contiguous
+            let rhs_inner_stride = problem.rhs_strides[rank - 1];
+            if rhs_inner_stride != 1 {
+                rhs = rhs.into_contiguous(client)?;
+            }
+        }
+        GemvKind::VecMatRowMajor | GemvKind::VecMatColMajor => {
+            // LHS (vec) must be contiguous
+            let lhs_inner_stride = problem.lhs_strides[rank - 1];
+            if lhs_inner_stride != 1 {
+                lhs = lhs.into_contiguous(client)?;
+            }
+        }
+    }
+
     let device_settings = GemvPlaneParallelRoutine::device_settings(client, vector_sizes);
     let expand_info =
         GemvPlaneParallelRoutine::expand_blueprint(&problem, &device_settings, strategy)?;
-
-    validate_layout(&problem, &expand_info.blueprint.kind)?;
 
     if device_settings.plane_dim > 1 {
         if matches!(expand_info.blueprint.kind, GemvKind::MatVecColMajor) {

--- a/crates/cubek-matmul/src/launch/launch_vecmat_plane_parallel.rs
+++ b/crates/cubek-matmul/src/launch/launch_vecmat_plane_parallel.rs
@@ -36,6 +36,37 @@ fn vector_size_for<R: Runtime>(
         .ok_or(VectorizationError::NoValidVectorization)
 }
 
+fn validate_layout(problem: &MatmulProblem, kind: &GemvKind) -> Result<(), MatmulSetupError> {
+    let rank = problem.rhs_shape.len();
+
+    match kind {
+        GemvKind::MatVecRowMajor | GemvKind::MatVecColMajor => {
+            // RHS (vec) inner-most stride must be 1
+            let rhs_inner_stride = problem.rhs_strides[rank - 1];
+            if rhs_inner_stride != 1 {
+                return Err(MatmulSetupError::InvalidConfig(Box::new(format!(
+                    "GemvPlaneParallel: RHS vector must be contiguous. \
+                     Got inner stride {} (expected 1)",
+                    rhs_inner_stride
+                ))));
+            }
+        }
+        GemvKind::VecMatRowMajor | GemvKind::VecMatColMajor => {
+            // LHS (vec) inner-most stride must be 1
+            let lhs_inner_stride = problem.lhs_strides[rank - 1];
+            if lhs_inner_stride != 1 {
+                return Err(MatmulSetupError::InvalidConfig(Box::new(format!(
+                    "GemvPlaneParallel: LHS vector must be contiguous. \
+                     Got inner stride {} (expected 1)",
+                    lhs_inner_stride
+                ))));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[allow(clippy::result_large_err)]
 pub fn launch_ref<R: Runtime>(
     client: &ComputeClient<R>,
@@ -100,6 +131,8 @@ pub fn launch_ref<R: Runtime>(
     let device_settings = GemvPlaneParallelRoutine::device_settings(client, vector_sizes);
     let expand_info =
         GemvPlaneParallelRoutine::expand_blueprint(&problem, &device_settings, strategy)?;
+
+    validate_layout(&problem, &expand_info.blueprint.kind)?;
 
     if device_settings.plane_dim > 1 {
         if matches!(expand_info.blueprint.kind, GemvKind::MatVecColMajor) {


### PR DESCRIPTION
https://github.com/tracel-ai/burn/issues/4828

Autotune would select `vecmat_plane_parallel_None` which always failed with
```
Tensors are not approx eq:
  => Position 0: 10421 != 37
     diff (rel = +9.96e-1, abs = +1.04e4), tol (rel = +0.00e0, abs = +7.52e-37)
  => Position 1: 26293 != 1061
     diff (rel = +9.60e-1, abs = +2.52e4), tol (rel = +0.00e0, abs = +7.52e-37)
  => Position 2: 42165 != 2085
     diff (rel = +9.51e-1, abs = +4.01e4), tol (rel = +0.00e0, abs = +7.52e-37)
  => Position 3: 172213 != 3077
     diff (rel = +9.82e-1, abs = +1.69e5), tol (rel = +0.00e0, abs = +7.52e-37)
  => Position 4: 220853 != 4101
     diff (rel = +9.81e-1, abs = +2.17e5), tol (rel = +0.00e0, abs = +7.52e-37)
```

In this case the vector strides were not contiguous 
```
rhs: TensorHandleRef { strides: Strides { dims: [64, 32, 1, 32] }, shape: Shape { dims: [1, 2, 32, 1] } }
```

Added a check to force vec contiguity.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
