### PR TITLE
Test utils toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,57 +34,5 @@ If you want to contribute new kernels, please read the [`GUIDE.md`](./GUIDE.md).
 
 # Running tests
 
-> Note: This applies to most kernels, but `reduce` works slightly differently for now, see [its README](./crates/cubek-reduce/README.md).
-
-## Test suites
-
-Four test suites are available:
-
-- **Light test suite**: a tractable subset of representative tests that run on the CI.
-- **Basic test suite**: adds to light suite some tests that would be considered basic but may hang on CI (slow on CPU).
-- **Extended test suite**: usually auto-generated combinatorial tests covering many configurations. Good to run when developing kernels. Normally kept tractable.
-- **Full test suite**: all generable test combinations; may be too large to compile or run practically.
-
-Run tests with
-
-```bash
-# Replace <runtime> with cpu, cuda, rocm, wgpu, vulkan or metal
-
-# Basic test suite (light on cpu)
-cargo test-<runtime>
-
-# Extended test suite
-cargo test-<runtime>-extended
-
-# Full test suite
-cargo test-<runtime>-full
-```
-
-## Cube test mode
-
-You can control test behavior by setting the `CUBE_TEST_MODE` environment variable.  
-For more details, see [Test Mode](./crates/cubek-test-utils/src/test_mode/base.rs).
-
-### Modes
-
-- **`CUBE_TEST_MODE=correct`** _(default)_  
-  Tests pass if results are numerically correct **or** if the kernel was launched with an invalid configuration.
-  - Useful when tests are auto-generated from multiple parameter combinations, where some invalid configurations are expected.
-  - Failing tests display only the first index with a discrepancy.
-
-- **`CUBE_TEST_MODE=strict`**  
-  Tests pass **only** if they compile, run, and produce numerically accurate results.
-  - Ideal for debugging to avoid false positives that can occur in `correct` mode.
-
-- **`CUBE_TEST_MODE=printfail`**  
-  Similar to `correct` mode: tests pass if results are correct or if the kernel is invalid.
-  - Failing tests show **all tensor discrepancies**.
-  - Supports filtering, e.g.: `CUBE_TEST_MODE=printfail:0,.,10-20` shows elements from the 0th first dimension, all of the second, and elements 10–20 in the third.
-
-- **`CUBE_TEST_MODE=printall`**  
-  All tests fail, displaying **all tensor discrepancies**.
-  - Filtering works the same as in `printfail`.
-
-- **`CUBE_TEST_MODE=failifrun`**  
-  Only tests that **compile and run** will fail; others succeed.
-  - Useful for tracking critical tests in large suites.
+The full testing guide — suites, `CUBE_TEST_MODE`, failure-message format, and
+filter syntax — lives in [`cubek-test-utils`](./crates/cubek-test-utils/README.md).

--- a/crates/cubek-attention/tests/attention/launcher.rs
+++ b/crates/cubek-attention/tests/attention/launcher.rs
@@ -9,7 +9,7 @@ use cubek_attention::{
 };
 
 use cubecl::client::ComputeClient;
-use cubek_test_utils::{DataKind, Distribution, StrideSpec, TestInput, TestOutcome};
+use cubek_test_utils::{TestInput, TestOutcome};
 
 pub fn test_launch(
     client: ComputeClient<TestRuntime>,
@@ -22,68 +22,36 @@ pub fn test_launch(
     let mask_shape = problem.shape(AttentionIdent::Mask);
     let out_shape = problem.shape(AttentionIdent::Out);
 
-    let (query_handle, query_data) = TestInput::new(
-        client.clone(),
-        Shape::new(query_shape),
-        problem.global_dtypes.query,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 12,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (query_handle, query_data) = TestInput::builder(client.clone(), Shape::new(query_shape))
+        .dtype(problem.global_dtypes.query)
+        .uniform(/* seed */ 12, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let (key_handle, key_data) = TestInput::new(
-        client.clone(),
-        Shape::new(key_shape),
-        problem.global_dtypes.key,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 34,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (key_handle, key_data) = TestInput::builder(client.clone(), Shape::new(key_shape))
+        .dtype(problem.global_dtypes.key)
+        .uniform(/* seed */ 34, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let (value_handle, value_data) = TestInput::new(
-        client.clone(),
-        Shape::new(value_shape),
-        problem.global_dtypes.value,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 56,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (value_handle, value_data) = TestInput::builder(client.clone(), Shape::new(value_shape))
+        .dtype(problem.global_dtypes.value)
+        .uniform(/* seed */ 56, -1., 1.)
+        .generate_with_f32_host_data();
 
     let (mask_handle, mask_data) = if problem.masked {
-        let (mask_handle, mask_data) = TestInput::new(
-            client.clone(),
-            Shape::new(mask_shape),
-            problem.global_dtypes.mask,
-            StrideSpec::RowMajor,
-            DataKind::Random {
-                seed: 78,
-                distribution: Distribution::Bernoulli(0.1),
-            },
-        )
-        .generate_with_bool_host_data();
+        let (mask_handle, mask_data) = TestInput::builder(client.clone(), Shape::new(mask_shape))
+            .dtype(problem.global_dtypes.mask)
+            .bernoulli(/* seed */ 78, 0.1)
+            .generate_with_bool_host_data();
 
         (Some(mask_handle), Some(mask_data))
     } else {
         (None, None)
     };
 
-    let out_handle = TestInput::new(
-        client.clone(),
-        Shape::new(out_shape),
-        problem.global_dtypes.out,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate_without_host_data();
+    let out_handle = TestInput::builder(client.clone(), Shape::new(out_shape))
+        .dtype(problem.global_dtypes.out)
+        .zeros()
+        .generate_without_host_data();
 
     let client = client.clone();
     let client_cloned = client.clone();

--- a/crates/cubek-attention/tests/attention/launcher.rs
+++ b/crates/cubek-attention/tests/attention/launcher.rs
@@ -24,23 +24,23 @@ pub fn test_launch(
 
     let (query_handle, query_data) = TestInput::builder(client.clone(), Shape::new(query_shape))
         .dtype(problem.global_dtypes.query)
-        .uniform(/* seed */ 12, -1., 1.)
+        .uniform(12, -1., 1.)
         .generate_with_f32_host_data();
 
     let (key_handle, key_data) = TestInput::builder(client.clone(), Shape::new(key_shape))
         .dtype(problem.global_dtypes.key)
-        .uniform(/* seed */ 34, -1., 1.)
+        .uniform(34, -1., 1.)
         .generate_with_f32_host_data();
 
     let (value_handle, value_data) = TestInput::builder(client.clone(), Shape::new(value_shape))
         .dtype(problem.global_dtypes.value)
-        .uniform(/* seed */ 56, -1., 1.)
+        .uniform(56, -1., 1.)
         .generate_with_f32_host_data();
 
     let (mask_handle, mask_data) = if problem.masked {
         let (mask_handle, mask_data) = TestInput::builder(client.clone(), Shape::new(mask_shape))
             .dtype(problem.global_dtypes.mask)
-            .bernoulli(/* seed */ 78, 0.1)
+            .bernoulli(78, 0.1)
             .generate_with_bool_host_data();
 
         (Some(mask_handle), Some(mask_data))

--- a/crates/cubek-convolution/tests/suite/launcher_strategy.rs
+++ b/crates/cubek-convolution/tests/suite/launcher_strategy.rs
@@ -164,12 +164,12 @@ pub fn test_algo<A: Algorithm<Routine: Routine<RuntimeArgs, Blueprint = TilingBl
 
     let (lhs, lhs_data) = TestInput::builder(client.clone(), lhs_shape)
         .dtype(dtypes.lhs_global)
-        .uniform(/* seed */ 1234, -1., 1.)
+        .uniform(1234, -1., 1.)
         .generate_with_f32_host_data();
 
     let (rhs, rhs_data) = TestInput::builder(client.clone(), rhs_shape)
         .dtype(dtypes.rhs_global)
-        .uniform(/* seed */ 5678, -1., 1.)
+        .uniform(5678, -1., 1.)
         .generate_with_f32_host_data();
 
     let out = TestInput::builder(client.clone(), out_shape)

--- a/crates/cubek-convolution/tests/suite/launcher_strategy.rs
+++ b/crates/cubek-convolution/tests/suite/launcher_strategy.rs
@@ -34,7 +34,7 @@ use cubek_matmul::{
     routines::{BlueprintStrategy, Routine},
 };
 use cubek_std::{InputBinding, MatrixLayout};
-use cubek_test_utils::{DataKind, Distribution, StrideSpec, TestInput, TestOutcome};
+use cubek_test_utils::{TestInput, TestOutcome};
 
 use crate::suite::reference::assert_result;
 
@@ -162,38 +162,20 @@ pub fn test_algo<A: Algorithm<Routine: Routine<RuntimeArgs, Blueprint = TilingBl
     ];
     let out_shape: Shape = shape![problem.batches, out_h, out_w, problem.n];
 
-    let (lhs, lhs_data) = TestInput::new(
-        client.clone(),
-        lhs_shape,
-        dtypes.lhs_global,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 1234,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (lhs, lhs_data) = TestInput::builder(client.clone(), lhs_shape)
+        .dtype(dtypes.lhs_global)
+        .uniform(/* seed */ 1234, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let (rhs, rhs_data) = TestInput::new(
-        client.clone(),
-        rhs_shape,
-        dtypes.rhs_global,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 5678,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (rhs, rhs_data) = TestInput::builder(client.clone(), rhs_shape)
+        .dtype(dtypes.rhs_global)
+        .uniform(/* seed */ 5678, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let out = TestInput::new(
-        client.clone(),
-        out_shape,
-        dtypes.acc_global,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate_without_host_data();
+    let out = TestInput::builder(client.clone(), out_shape)
+        .dtype(dtypes.acc_global)
+        .zeros()
+        .generate_without_host_data();
 
     // Update problem strides to the physical NHWC layout coming out of TestInput.
     problem.lhs_strides = lhs.strides().clone();

--- a/crates/cubek-fft/tests/suite/fft_round_trip.rs
+++ b/crates/cubek-fft/tests/suite/fft_round_trip.rs
@@ -12,7 +12,7 @@ fn large_fft_roundtrip() {
 
     let (original_signal, signal_data) = TestInput::builder(client.clone(), shape)
         .dtype(dtype)
-        .uniform(/* seed */ 42, -1., 1.)
+        .uniform(42, -1., 1.)
         .generate_with_f32_host_data();
 
     let (spectrum_re, spectrum_im) = rfft(original_signal, shape.len() - 1, dtype);

--- a/crates/cubek-fft/tests/suite/fft_round_trip.rs
+++ b/crates/cubek-fft/tests/suite/fft_round_trip.rs
@@ -1,9 +1,7 @@
 use cubecl::{Runtime, TestRuntime, prelude::CubePrimitive};
 use cubek_fft::{irfft, rfft};
 //use cubefx_engine::{SignalSpec, phase_shift_effect};
-use cubek_test_utils::{
-    DataKind, Distribution, HostData, StrideSpec, TestInput, assert_equals_approx,
-};
+use cubek_test_utils::{HostData, TestInput, assert_equals_approx};
 
 #[test]
 fn large_fft_roundtrip() {
@@ -12,17 +10,10 @@ fn large_fft_roundtrip() {
 
     let shape = [431, 2, 2048];
 
-    let (original_signal, signal_data) = TestInput::new(
-        client.clone(),
-        shape,
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 42,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (original_signal, signal_data) = TestInput::builder(client.clone(), shape)
+        .dtype(dtype)
+        .uniform(/* seed */ 42, -1., 1.)
+        .generate_with_f32_host_data();
 
     let (spectrum_re, spectrum_im) = rfft(original_signal, shape.len() - 1, dtype);
     let signal_back = irfft(spectrum_re, spectrum_im, shape.len() - 1, dtype);

--- a/crates/cubek-fft/tests/suite/irfft.rs
+++ b/crates/cubek-fft/tests/suite/irfft.rs
@@ -6,8 +6,8 @@ use cubecl::{
 };
 use cubek_fft::irfft_launch;
 use cubek_test_utils::{
-    self, DataKind, Distribution, ExecutionOutcome, HostData, HostDataType, StrideSpec, TestInput,
-    TestOutcome, ValidationResult, assert_equals_approx,
+    self, ExecutionOutcome, HostData, HostDataType, TestInput, TestOutcome, ValidationResult,
+    assert_equals_approx,
 };
 
 use crate::suite::reference::irfft_ref;
@@ -17,38 +17,22 @@ fn test_launch(client: ComputeClient<TestRuntime>, spectrum_shape: Vec<usize>, d
     let mut signal_shape = spectrum_shape.clone();
     signal_shape[dim] = (spectrum_shape[dim] - 1) * 2;
 
-    let (random_spectrum_re_handle, random_spectrum_re_data) = TestInput::new(
-        client.clone(),
-        spectrum_shape.clone(),
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 43,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (random_spectrum_re_handle, random_spectrum_re_data) =
+        TestInput::builder(client.clone(), spectrum_shape.clone())
+            .dtype(dtype)
+            .uniform(/* seed */ 43, -1., 1.)
+            .generate_with_f32_host_data();
 
-    let (random_spectrum_im_handle, random_spectrum_im_data) = TestInput::new(
-        client.clone(),
-        spectrum_shape,
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 44,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (random_spectrum_im_handle, random_spectrum_im_data) =
+        TestInput::builder(client.clone(), spectrum_shape)
+            .dtype(dtype)
+            .uniform(/* seed */ 44, -1., 1.)
+            .generate_with_f32_host_data();
 
-    let signal_handle = TestInput::new(
-        client.clone(),
-        signal_shape,
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate_without_host_data();
+    let signal_handle = TestInput::builder(client.clone(), signal_shape)
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
 
     match irfft_launch::<TestRuntime>(
         &client,

--- a/crates/cubek-fft/tests/suite/irfft.rs
+++ b/crates/cubek-fft/tests/suite/irfft.rs
@@ -20,13 +20,13 @@ fn test_launch(client: ComputeClient<TestRuntime>, spectrum_shape: Vec<usize>, d
     let (random_spectrum_re_handle, random_spectrum_re_data) =
         TestInput::builder(client.clone(), spectrum_shape.clone())
             .dtype(dtype)
-            .uniform(/* seed */ 43, -1., 1.)
+            .uniform(43, -1., 1.)
             .generate_with_f32_host_data();
 
     let (random_spectrum_im_handle, random_spectrum_im_data) =
         TestInput::builder(client.clone(), spectrum_shape)
             .dtype(dtype)
-            .uniform(/* seed */ 44, -1., 1.)
+            .uniform(44, -1., 1.)
             .generate_with_f32_host_data();
 
     let signal_handle = TestInput::builder(client.clone(), signal_shape)

--- a/crates/cubek-fft/tests/suite/rfft.rs
+++ b/crates/cubek-fft/tests/suite/rfft.rs
@@ -17,10 +17,11 @@ fn test_launch(client: ComputeClient<TestRuntime>, signal_shape: Vec<usize>, dim
     let mut spectrum_shape = signal_shape.clone();
     spectrum_shape[dim] = signal_shape[dim] / 2 + 1;
 
-    let (white_noise_handle, white_noise_data) = TestInput::builder(client.clone(), signal_shape.clone())
-        .dtype(dtype)
-        .uniform(/* seed */ 42, -1., 1.)
-        .generate_with_f32_host_data();
+    let (white_noise_handle, white_noise_data) =
+        TestInput::builder(client.clone(), signal_shape.clone())
+            .dtype(dtype)
+            .uniform(/* seed */ 42, -1., 1.)
+            .generate_with_f32_host_data();
 
     let spectrum_re_handle = TestInput::builder(client.clone(), spectrum_shape.to_vec())
         .dtype(dtype)

--- a/crates/cubek-fft/tests/suite/rfft.rs
+++ b/crates/cubek-fft/tests/suite/rfft.rs
@@ -20,7 +20,7 @@ fn test_launch(client: ComputeClient<TestRuntime>, signal_shape: Vec<usize>, dim
     let (white_noise_handle, white_noise_data) =
         TestInput::builder(client.clone(), signal_shape.clone())
             .dtype(dtype)
-            .uniform(/* seed */ 42, -1., 1.)
+            .uniform(42, -1., 1.)
             .generate_with_f32_host_data();
 
     let spectrum_re_handle = TestInput::builder(client.clone(), spectrum_shape.to_vec())

--- a/crates/cubek-fft/tests/suite/rfft.rs
+++ b/crates/cubek-fft/tests/suite/rfft.rs
@@ -6,8 +6,8 @@ use cubecl::{
 };
 use cubek_fft::rfft_launch;
 use cubek_test_utils::{
-    self, DataKind, Distribution, ExecutionOutcome, HostData, HostDataType, StrideSpec, TestInput,
-    TestOutcome, ValidationResult, assert_equals_approx,
+    self, ExecutionOutcome, HostData, HostDataType, TestInput, TestOutcome, ValidationResult,
+    assert_equals_approx,
 };
 
 use crate::suite::reference::rfft_ref;
@@ -17,35 +17,20 @@ fn test_launch(client: ComputeClient<TestRuntime>, signal_shape: Vec<usize>, dim
     let mut spectrum_shape = signal_shape.clone();
     spectrum_shape[dim] = signal_shape[dim] / 2 + 1;
 
-    let (white_noise_handle, white_noise_data) = TestInput::new(
-        client.clone(),
-        signal_shape.clone(),
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 42,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (white_noise_handle, white_noise_data) = TestInput::builder(client.clone(), signal_shape.clone())
+        .dtype(dtype)
+        .uniform(/* seed */ 42, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let spectrum_re_handle = TestInput::new(
-        client.clone(),
-        spectrum_shape.to_vec(),
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate_without_host_data();
+    let spectrum_re_handle = TestInput::builder(client.clone(), spectrum_shape.to_vec())
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
 
-    let spectrum_im_handle = TestInput::new(
-        client.clone(),
-        spectrum_shape.to_vec(),
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate_without_host_data();
+    let spectrum_im_handle = TestInput::builder(client.clone(), spectrum_shape.to_vec())
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
 
     match rfft_launch::<TestRuntime>(
         &client,

--- a/crates/cubek-matmul/tests/suite/bias.rs
+++ b/crates/cubek-matmul/tests/suite/bias.rs
@@ -25,8 +25,7 @@ use cubek_matmul::{
 };
 use cubek_std::MatrixLayout;
 use cubek_test_utils::{
-    DataKind, Distribution, HostData, HostDataType, HostDataVec, StrideSpec, TestInput,
-    TestOutcome, assert_equals_approx,
+    HostData, HostDataType, HostDataVec, TestInput, TestOutcome, assert_equals_approx,
 };
 
 use crate::suite::{layout_to_stride_spec, reference::matmul_cpu_reference};
@@ -54,50 +53,27 @@ pub fn test_matmul_with_bias_simple_unit_f32() {
         AddressType::default(),
     );
 
-    let (lhs, lhs_data) = TestInput::new(
-        client.clone(),
-        problem.lhs_shape.clone(),
-        problem.global_dtypes.lhs,
-        layout_to_stride_spec(problem.lhs_layout),
-        DataKind::Random {
-            seed: 1234,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (lhs, lhs_data) = TestInput::builder(client.clone(), problem.lhs_shape.clone())
+        .dtype(problem.global_dtypes.lhs)
+        .stride(layout_to_stride_spec(problem.lhs_layout))
+        .uniform(/* seed */ 1234, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let (rhs, rhs_data) = TestInput::new(
-        client.clone(),
-        problem.rhs_shape.clone(),
-        problem.global_dtypes.rhs,
-        layout_to_stride_spec(problem.rhs_layout),
-        DataKind::Random {
-            seed: 5678,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (rhs, rhs_data) = TestInput::builder(client.clone(), problem.rhs_shape.clone())
+        .dtype(problem.global_dtypes.rhs)
+        .stride(layout_to_stride_spec(problem.rhs_layout))
+        .uniform(/* seed */ 5678, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let (bias, bias_data) = TestInput::new(
-        client.clone(),
-        problem.out_shape.clone(),
-        problem.global_dtypes.out,
-        StrideSpec::RowMajor,
-        DataKind::Random {
-            seed: 9999,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (bias, bias_data) = TestInput::builder(client.clone(), problem.out_shape.clone())
+        .dtype(problem.global_dtypes.out)
+        .uniform(/* seed */ 9999, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let out = TestInput::new(
-        client.clone(),
-        problem.out_shape.clone(),
-        problem.global_dtypes.out,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate_without_host_data();
+    let out = TestInput::builder(client.clone(), problem.out_shape.clone())
+        .dtype(problem.global_dtypes.out)
+        .zeros()
+        .generate_without_host_data();
 
     problem.lhs_strides = lhs.strides().clone();
     problem.rhs_strides = rhs.strides().clone();

--- a/crates/cubek-matmul/tests/suite/bias.rs
+++ b/crates/cubek-matmul/tests/suite/bias.rs
@@ -56,18 +56,18 @@ pub fn test_matmul_with_bias_simple_unit_f32() {
     let (lhs, lhs_data) = TestInput::builder(client.clone(), problem.lhs_shape.clone())
         .dtype(problem.global_dtypes.lhs)
         .stride(layout_to_stride_spec(problem.lhs_layout))
-        .uniform(/* seed */ 1234, -1., 1.)
+        .uniform(1234, -1., 1.)
         .generate_with_f32_host_data();
 
     let (rhs, rhs_data) = TestInput::builder(client.clone(), problem.rhs_shape.clone())
         .dtype(problem.global_dtypes.rhs)
         .stride(layout_to_stride_spec(problem.rhs_layout))
-        .uniform(/* seed */ 5678, -1., 1.)
+        .uniform(5678, -1., 1.)
         .generate_with_f32_host_data();
 
     let (bias, bias_data) = TestInput::builder(client.clone(), problem.out_shape.clone())
         .dtype(problem.global_dtypes.out)
-        .uniform(/* seed */ 9999, -1., 1.)
+        .uniform(9999, -1., 1.)
         .generate_with_f32_host_data();
 
     let out = TestInput::builder(client.clone(), problem.out_shape.clone())

--- a/crates/cubek-matmul/tests/suite/extended/quantization.rs
+++ b/crates/cubek-matmul/tests/suite/extended/quantization.rs
@@ -7,8 +7,8 @@ use cubek_matmul::{
 use cubek_quant::scheme::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue};
 use cubek_std::{InputBinding, MatrixLayout};
 use cubek_test_utils::{
-    DataKind, ExecutionOutcome, HostData, HostDataType, InputDataType, TestInput, TestOutcome,
-    TestTensor, assert_equals_approx,
+    ExecutionOutcome, HostData, HostDataType, InputDataType, TestInput, TestOutcome, TestTensor,
+    assert_equals_approx,
 };
 
 use crate::suite::layout_to_stride_spec;
@@ -115,38 +115,23 @@ fn run_quantized_matmul(case: QuantizedMatmulCase) {
         cubecl::ir::AddressType::U32,
     );
 
-    let lhs = TestInput::new(
-        client.clone(),
-        problem.lhs_shape.clone(),
-        lhs_dtype,
-        layout_to_stride_spec(problem.lhs_layout),
-        DataKind::Random {
-            seed: 1234,
-            distribution: cubek_test_utils::Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_test_tensor();
+    let lhs = TestInput::builder(client.clone(), problem.lhs_shape.clone())
+        .dtype(lhs_dtype)
+        .stride(layout_to_stride_spec(problem.lhs_layout))
+        .uniform(/* seed */ 1234, -1., 1.)
+        .generate_test_tensor();
 
-    let rhs = TestInput::new(
-        client.clone(),
-        problem.rhs_shape.clone(),
-        rhs_dtype,
-        layout_to_stride_spec(problem.rhs_layout),
-        DataKind::Random {
-            seed: 5678,
-            distribution: cubek_test_utils::Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_test_tensor();
+    let rhs = TestInput::builder(client.clone(), problem.rhs_shape.clone())
+        .dtype(rhs_dtype)
+        .stride(layout_to_stride_spec(problem.rhs_layout))
+        .uniform(/* seed */ 5678, -1., 1.)
+        .generate_test_tensor();
 
-    let out = TestInput::new(
-        client.clone(),
-        problem.out_shape.clone(),
-        out_dtype,
-        layout_to_stride_spec(MatrixLayout::RowMajor),
-        DataKind::Zeros,
-    )
-    .generate_without_host_data();
+    let out = TestInput::builder(client.clone(), problem.out_shape.clone())
+        .dtype(out_dtype)
+        .stride(layout_to_stride_spec(MatrixLayout::RowMajor))
+        .zeros()
+        .generate_without_host_data();
 
     // The handle strides for quantized tensors are packed-view strides and must NOT
     // replace the problem's float-level strides computed by `from_parameters`. For

--- a/crates/cubek-matmul/tests/suite/extended/quantization.rs
+++ b/crates/cubek-matmul/tests/suite/extended/quantization.rs
@@ -118,13 +118,13 @@ fn run_quantized_matmul(case: QuantizedMatmulCase) {
     let lhs = TestInput::builder(client.clone(), problem.lhs_shape.clone())
         .dtype(lhs_dtype)
         .stride(layout_to_stride_spec(problem.lhs_layout))
-        .uniform(/* seed */ 1234, -1., 1.)
+        .uniform(1234, -1., 1.)
         .generate_test_tensor();
 
     let rhs = TestInput::builder(client.clone(), problem.rhs_shape.clone())
         .dtype(rhs_dtype)
         .stride(layout_to_stride_spec(problem.rhs_layout))
-        .uniform(/* seed */ 5678, -1., 1.)
+        .uniform(5678, -1., 1.)
         .generate_test_tensor();
 
     let out = TestInput::builder(client.clone(), problem.out_shape.clone())

--- a/crates/cubek-matmul/tests/suite/launcher_strategy.rs
+++ b/crates/cubek-matmul/tests/suite/launcher_strategy.rs
@@ -6,7 +6,7 @@ use cubek_matmul::{
     launch::launch_ref,
 };
 use cubek_std::{InputBinding, MatrixLayout};
-use cubek_test_utils::{DataKind, Distribution, ExecutionOutcome, TestInput, TestOutcome};
+use cubek_test_utils::{ExecutionOutcome, TestInput, TestOutcome};
 
 use crate::{suite::assert_result, suite::layout_to_stride_spec};
 
@@ -32,38 +32,23 @@ where
         &mut MatmulElems,
     ) -> Result<(), MatmulSetupError>,
 {
-    let (lhs, lhs_data) = TestInput::new(
-        client.clone(),
-        problem.lhs_shape.clone(),
-        problem.global_dtypes.lhs,
-        layout_to_stride_spec(problem.lhs_layout),
-        DataKind::Random {
-            seed: 1234,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (lhs, lhs_data) = TestInput::builder(client.clone(), problem.lhs_shape.clone())
+        .dtype(problem.global_dtypes.lhs)
+        .stride(layout_to_stride_spec(problem.lhs_layout))
+        .uniform(/* seed */ 1234, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let (rhs, rhs_data) = TestInput::new(
-        client.clone(),
-        problem.rhs_shape.clone(),
-        problem.global_dtypes.rhs,
-        layout_to_stride_spec(problem.rhs_layout),
-        DataKind::Random {
-            seed: 5678,
-            distribution: Distribution::Uniform(-1., 1.),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (rhs, rhs_data) = TestInput::builder(client.clone(), problem.rhs_shape.clone())
+        .dtype(problem.global_dtypes.rhs)
+        .stride(layout_to_stride_spec(problem.rhs_layout))
+        .uniform(/* seed */ 5678, -1., 1.)
+        .generate_with_f32_host_data();
 
-    let out = TestInput::new(
-        client.clone(),
-        problem.out_shape.clone(),
-        problem.global_dtypes.out,
-        layout_to_stride_spec(MatrixLayout::RowMajor),
-        DataKind::Zeros,
-    )
-    .generate_without_host_data();
+    let out = TestInput::builder(client.clone(), problem.out_shape.clone())
+        .dtype(problem.global_dtypes.out)
+        .stride(layout_to_stride_spec(MatrixLayout::RowMajor))
+        .zeros()
+        .generate_without_host_data();
 
     problem.lhs_strides = lhs.strides().clone();
     problem.rhs_strides = rhs.strides().clone();

--- a/crates/cubek-matmul/tests/suite/launcher_strategy.rs
+++ b/crates/cubek-matmul/tests/suite/launcher_strategy.rs
@@ -35,13 +35,13 @@ where
     let (lhs, lhs_data) = TestInput::builder(client.clone(), problem.lhs_shape.clone())
         .dtype(problem.global_dtypes.lhs)
         .stride(layout_to_stride_spec(problem.lhs_layout))
-        .uniform(/* seed */ 1234, -1., 1.)
+        .uniform(1234, -1., 1.)
         .generate_with_f32_host_data();
 
     let (rhs, rhs_data) = TestInput::builder(client.clone(), problem.rhs_shape.clone())
         .dtype(problem.global_dtypes.rhs)
         .stride(layout_to_stride_spec(problem.rhs_layout))
-        .uniform(/* seed */ 5678, -1., 1.)
+        .uniform(5678, -1., 1.)
         .generate_with_f32_host_data();
 
     let out = TestInput::builder(client.clone(), problem.out_shape.clone())

--- a/crates/cubek-matmul/tests/suite/reference.rs
+++ b/crates/cubek-matmul/tests/suite/reference.rs
@@ -105,7 +105,7 @@ pub fn matmul_cpu_reference(lhs: &HostData, rhs: &HostData, problem: &MatmulProb
                     lhs_index[rank - 1] = kk;
                     rhs_index[rank - 2] = kk;
 
-                    sum += lhs.get_f32(&lhs_index) * rhs.get_f32(&rhs_index) + 1.;
+                    sum += lhs.get_f32(&lhs_index) * rhs.get_f32(&rhs_index);
                 }
 
                 // Compute linear index in the output buffer

--- a/crates/cubek-matmul/tests/suite/reference.rs
+++ b/crates/cubek-matmul/tests/suite/reference.rs
@@ -105,7 +105,7 @@ pub fn matmul_cpu_reference(lhs: &HostData, rhs: &HostData, problem: &MatmulProb
                     lhs_index[rank - 1] = kk;
                     rhs_index[rank - 2] = kk;
 
-                    sum += lhs.get_f32(&lhs_index) * rhs.get_f32(&rhs_index);
+                    sum += lhs.get_f32(&lhs_index) * rhs.get_f32(&rhs_index) + 1.;
                 }
 
                 // Compute linear index in the output buffer

--- a/crates/cubek-reduce/tests/it/reduce_shared.rs
+++ b/crates/cubek-reduce/tests/it/reduce_shared.rs
@@ -1,8 +1,8 @@
 use cubecl::{TestRuntime, prelude::*};
 use cubek_reduce::shared_sum;
 use cubek_test_utils::{
-    DataKind, ExecutionOutcome, HostData, HostDataType, HostDataVec, StrideSpec, TestInput,
-    TestOutcome, assert_equals_approx,
+    ExecutionOutcome, HostData, HostDataType, HostDataVec, StrideSpec, TestInput, TestOutcome,
+    assert_equals_approx,
 };
 
 #[test]
@@ -37,27 +37,19 @@ impl TestCase {
         let client = TestRuntime::client(&Default::default());
         let input_dtype = TestDType::as_type_native_unchecked().storage_type();
 
-        let (input_handle, input_host) = TestInput::new(
-            client.clone(),
-            self.shape.clone(),
-            input_dtype,
-            StrideSpec::Custom(self.stride.iter().copied().collect()),
-            DataKind::Custom {
-                data: self.input_raw_data(),
-            },
-        )
-        .generate_with_f32_host_data();
+        let (input_handle, input_host) = TestInput::builder(client.clone(), self.shape.clone())
+            .dtype(input_dtype)
+            .stride(StrideSpec::Custom(self.stride.iter().copied().collect()))
+            .custom(self.input_raw_data())
+            .generate_with_f32_host_data();
 
         let expected_sum = sum_all(&input_host);
 
-        let output_handle = TestInput::new(
-            client.clone(),
-            cubecl::zspace::shape![1],
-            input_dtype,
-            StrideSpec::Custom(vec![1]),
-            DataKind::Zeros,
-        )
-        .generate();
+        let output_handle = TestInput::builder(client.clone(), cubecl::zspace::shape![1])
+            .dtype(input_dtype)
+            .stride(StrideSpec::Custom(vec![1]))
+            .zeros()
+            .generate();
 
         let cube_count = 3;
         let result = shared_sum(

--- a/crates/cubek-reduce/tests/it/test_case.rs
+++ b/crates/cubek-reduce/tests/it/test_case.rs
@@ -171,7 +171,7 @@ impl TestCase {
         let (input_handle, input_host) = TestInput::builder(client.clone(), self.shape.clone())
             .dtype(self.input_dtype)
             .stride(StrideSpec::Custom(self.stride.iter().copied().collect()))
-            .uniform(/* seed */ 1234, -1., 1.)
+            .uniform(1234, -1., 1.)
             .generate_with_f32_host_data();
 
         let expected = cast_host_through_dtype(reference(&input_host, axis), output_dtype);

--- a/crates/cubek-reduce/tests/it/test_case.rs
+++ b/crates/cubek-reduce/tests/it/test_case.rs
@@ -11,8 +11,8 @@ use cubek_reduce::{
     reduce,
 };
 use cubek_test_utils::{
-    DataKind, ExecutionOutcome, HostData, HostDataType, HostDataVec, StrideSpec, TestInput,
-    TestOutcome, assert_equals_approx,
+    ExecutionOutcome, HostData, HostDataType, HostDataVec, StrideSpec, TestInput, TestOutcome,
+    assert_equals_approx,
 };
 
 use crate::it::reference::{
@@ -168,17 +168,11 @@ impl TestCase {
         let client = TestRuntime::client(&Default::default());
         let axis = self.axis.unwrap();
 
-        let (input_handle, input_host) = TestInput::new(
-            client.clone(),
-            self.shape.clone(),
-            self.input_dtype,
-            StrideSpec::Custom(self.stride.iter().copied().collect()),
-            DataKind::Random {
-                seed: 1234,
-                distribution: cubek_test_utils::Distribution::Uniform(-1., 1.),
-            },
-        )
-        .generate_with_f32_host_data();
+        let (input_handle, input_host) = TestInput::builder(client.clone(), self.shape.clone())
+            .dtype(self.input_dtype)
+            .stride(StrideSpec::Custom(self.stride.iter().copied().collect()))
+            .uniform(/* seed */ 1234, -1., 1.)
+            .generate_with_f32_host_data();
 
         let expected = cast_host_through_dtype(reference(&input_host, axis), output_dtype);
 
@@ -240,14 +234,11 @@ impl TestCase {
             }
             _ => contiguous_strides(output_shape.as_slice()),
         };
-        TestInput::new(
-            client.clone(),
-            output_shape.clone(),
-            output_dtype,
-            StrideSpec::Custom(strides.iter().copied().collect()),
-            DataKind::Zeros,
-        )
-        .generate()
+        TestInput::builder(client.clone(), output_shape.clone())
+            .dtype(output_dtype)
+            .stride(StrideSpec::Custom(strides.iter().copied().collect()))
+            .zeros()
+            .generate()
     }
 }
 

--- a/crates/cubek-reduce/tests/units/mod.rs
+++ b/crates/cubek-reduce/tests/units/mod.rs
@@ -5,7 +5,7 @@ use cubecl::{
     std::tensor::TensorHandle, zspace::Shape,
 };
 use cubek_reduce::components::instructions::{plane_topk_insert, plane_topk_merge};
-use cubek_test_utils::{DataKind, InputDataType, StrideSpec, TestInput};
+use cubek_test_utils::{InputDataType, StrideSpec, TestInput};
 
 use crate::it::reference::contiguous_strides;
 use cubecl::frontend::CompilationArg;
@@ -39,14 +39,11 @@ fn test_plane_reduce_inplace() {
         55.0, 55.1, 101.2, 55.3,
     ];
 
-    let (input_handle, _input_host) = TestInput::new(
-        client.clone(),
-        shape.clone(),
-        input_dtype,
-        StrideSpec::Custom(stride.iter().copied().collect()),
-        DataKind::Custom { data: data.clone() },
-    )
-    .generate_with_f32_host_data();
+    let (input_handle, _input_host) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .stride(StrideSpec::Custom(stride.iter().copied().collect()))
+        .custom(data.clone())
+        .generate_with_f32_host_data();
 
     let storage_type = f32::as_type_native_unchecked().storage_type();
 
@@ -74,14 +71,11 @@ fn build_output_tensor(
     output_shape: &Shape,
 ) -> TensorHandle<TestRuntime> {
     let strides = contiguous_strides(output_shape);
-    TestInput::new(
-        client.clone(),
-        output_shape.clone(),
-        output_dtype,
-        StrideSpec::Custom(strides.iter().copied().collect()),
-        DataKind::Zeros,
-    )
-    .generate()
+    TestInput::builder(client.clone(), output_shape.clone())
+        .dtype(output_dtype)
+        .stride(StrideSpec::Custom(strides.iter().copied().collect()))
+        .zeros()
+        .generate()
 }
 
 #[cube(launch)]
@@ -175,27 +169,17 @@ fn test_plane_topk_insert() {
     let dtype = f32::as_type_native_unchecked().storage_type();
     let input_dtype = InputDataType::Standard(dtype);
 
-    let (acc_handle, _acc_host) = TestInput::new(
-        client.clone(),
-        acc_shape.clone(),
-        input_dtype.clone(),
-        StrideSpec::Custom(acc_stride.iter().copied().collect()),
-        DataKind::Custom {
-            data: acc_data.clone(),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (acc_handle, _acc_host) = TestInput::builder(client.clone(), acc_shape.clone())
+        .dtype(input_dtype.clone())
+        .stride(StrideSpec::Custom(acc_stride.iter().copied().collect()))
+        .custom(acc_data.clone())
+        .generate_with_f32_host_data();
 
-    let (item_handle, _item_host) = TestInput::new(
-        client.clone(),
-        item_shape.clone(),
-        input_dtype,
-        StrideSpec::Custom(item_stride.iter().copied().collect()),
-        DataKind::Custom {
-            data: item_data.clone(),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (item_handle, _item_host) = TestInput::builder(client.clone(), item_shape.clone())
+        .dtype(input_dtype)
+        .stride(StrideSpec::Custom(item_stride.iter().copied().collect()))
+        .custom(item_data.clone())
+        .generate_with_f32_host_data();
 
     let storage_type = f32::as_type_native_unchecked().storage_type();
 

--- a/crates/cubek-std/tests/mma/mod.rs
+++ b/crates/cubek-std/tests/mma/mod.rs
@@ -5,8 +5,7 @@ use cubecl::{
     {self, Runtime, TestRuntime},
 };
 use cubek_test_utils::{
-    DataKind, HostData, HostDataType, StrideSpec, TestInput, TestOutcome, ValidationResult,
-    pretty_print_zip,
+    HostData, HostDataType, TestInput, TestOutcome, ValidationResult, pretty_print_zip,
 };
 
 #[cube(launch)]
@@ -79,32 +78,20 @@ pub fn print_mma_layout<AB: CubeElement + Numeric, CD: CubeElement + Numeric>(
         MatrixIdent::Accumulator => (m, n, CD::as_type_native_unchecked().storage_type()),
     };
 
-    let lane_tensor = TestInput::new(
-        client.clone(),
-        [rows, cols],
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate();
+    let lane_tensor = TestInput::builder(client.clone(), [rows, cols])
+        .dtype(dtype)
+        .zeros()
+        .generate();
 
-    let vector_tensor = TestInput::new(
-        client.clone(),
-        [rows, cols],
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate();
+    let vector_tensor = TestInput::builder(client.clone(), [rows, cols])
+        .dtype(dtype)
+        .zeros()
+        .generate();
 
-    let within_vector_tensor = TestInput::new(
-        client.clone(),
-        [rows, cols],
-        dtype,
-        StrideSpec::RowMajor,
-        DataKind::Zeros,
-    )
-    .generate();
+    let within_vector_tensor = TestInput::builder(client.clone(), [rows, cols])
+        .dtype(dtype)
+        .zeros()
+        .generate();
 
     match ident {
         MatrixIdent::A | MatrixIdent::B => {

--- a/crates/cubek-test-utils/README.md
+++ b/crates/cubek-test-utils/README.md
@@ -4,9 +4,6 @@ Shared building blocks for kernel tests in CubeK: test-tensor builders,
 host-side reference comparisons, and a unified renderer that pretty-prints
 tensors (or diffs them) under a single config.
 
-This README is the testing guide for most CubeK kernels. (`cubek-reduce` is
-slightly different for now — see [its README](../cubek-reduce/README.md).)
-
 ---
 
 ## Configuration: `cubek.toml`
@@ -36,11 +33,11 @@ Set it to `true`, run a test, watch your tensors render. That's it.
 
 ### `[test] policy`
 
-| Policy        | No error      | Numerical error | Compilation error |
-| ------------- | ------------- | --------------- | ----------------- |
-| `correct`     | accept        | fail            | accept            |
-| `strict`      | accept        | fail            | fail              |
-| `fail-if-run` | fail          | accept          | accept            |
+| Policy        | No error | Numerical error | Compilation error |
+| ------------- | -------- | --------------- | ----------------- |
+| `correct`     | accept   | fail            | accept            |
+| `strict`      | accept   | fail            | fail              |
+| `fail-if-run` | fail     | accept          | accept            |
 
 If `[print] force-fail = true`, every passing test that printed is
 additionally rejected — useful so cargo surfaces the dump (it otherwise
@@ -77,8 +74,7 @@ print_tensors("input", &[&host], None);
 print_tensors("a vs b", &[&a, &b], Some(1e-3));
 ```
 
-The table view never shows Δ/ε numbers (cell color carries the same info,
-and adding columns would blow up the width). The lines view always shows
+The table view never shows Δ/ε numbers (cell color carries the info). The lines view always shows
 them.
 
 ### Table view example (with `show-expected = true`)
@@ -235,36 +231,3 @@ Builder finalizers (each returns a `TestInput` ready to generate):
 After a finalizer, call any of: `.generate()`, `.generate_with_f32_host_data()`,
 `.generate_with_bool_host_data()`, `.generate_test_tensor()`,
 `.f32_host_data()`, `.bool_host_data()`.
-
----
-
-## Walking host tensors
-
-`HostData` exposes typed accessors and indexed iterators that resolve
-through the tensor's strides, so non-contiguous tensors work without manual
-offset math:
-
-| API                          | Returns                            | On dtype mismatch |
-| ---------------------------- | ---------------------------------- | ----------------- |
-| `host.get_f32(&[i, j])`      | `f32`                              | panics            |
-| `host.get_i32(&[i, j])`      | `i32`                              | panics            |
-| `host.get_bool(&[i, j])`     | `bool`                             | panics            |
-| `host.try_get_f32(&[i, j])`  | `Option<f32>`                      | `None`            |
-| `host.try_get_i32(&[i, j])`  | `Option<i32>`                      | `None`            |
-| `host.try_get_bool(&[i, j])` | `Option<bool>`                     | `None`            |
-| `host.iter_indices()`        | `impl Iterator<Item = Vec<usize>>` | n/a               |
-| `host.iter_indexed_f32()`    | `(Vec<usize>, f32)` (row-major)    | panics            |
-| `host.iter_indexed_i32()`    | `(Vec<usize>, i32)`                | panics            |
-| `host.iter_indexed_bool()`   | `(Vec<usize>, bool)`               | panics            |
-
----
-
-## Pointers
-
-- Config (`CubekConfig`, `PrintSection`, `TestPolicy`) — `src/config.rs`
-- Test-policy decisions — `src/test_mode/`
-- `assert_equals_approx`, `assert_equals_approx_in_slice` — `src/correctness/base.rs`
-- Unified renderer — `src/correctness/render.rs`
-- `print_tensors`, `print_tensor` — `src/correctness/print_tensor.rs`
-- Tensor builders (`TestInput`, `TestInputBuilder`, `DataKind`, `StrideSpec`) — `src/test_tensor/`
-- Quantization helper — `src/test_tensor/quant.rs`

--- a/crates/cubek-test-utils/README.md
+++ b/crates/cubek-test-utils/README.md
@@ -1,74 +1,155 @@
 # cubek-test-utils
 
-Shared building blocks for kernel tests in CubeK: test-tensor builders, host-side
-reference comparisons, and a `CUBE_TEST_MODE` policy layer that decides what
-constitutes a passing test under a given environment variable.
+Shared building blocks for kernel tests in CubeK: test-tensor builders,
+host-side reference comparisons, and a unified renderer that pretty-prints
+tensors (or diffs them) under a single config.
 
-This README documents the testing workflow used across most CubeK kernels.
+This README is the testing guide for most CubeK kernels. (`cubek-reduce` is
+slightly different for now — see [its README](../cubek-reduce/README.md).)
 
 ---
 
-## Test suites
+## Configuration: `cubek.toml`
 
-Four test suites are available:
+There is **one** place to configure test behavior: a `cubek.toml` file at
+the workspace root. The file is read once at process start; the loader
+walks up from the current working directory until it finds it.
 
-- **Light test suite** — a tractable subset of representative tests that runs in CI.
-- **Basic test suite** — adds tests considered basic but that may hang on CI (slow on CPU).
-- **Extended test suite** — usually auto-generated combinatorial tests covering many
-  configurations. Good to run when developing kernels. Normally kept tractable.
-- **Full test suite** — all generable test combinations; may be too large to compile or
-  run practically.
+The shipped `cubek.toml` documents every field with comments. Two sections,
+nothing more:
 
-Run them with:
+```toml
+[test]
+policy = "correct"   # "correct" | "strict" | "fail-if-run"
 
-```bash
-# Replace <runtime> with cpu, cuda, rocm, wgpu, vulkan or metal
+[print]
+enabled = false       # toggle all printing
+view = "table"        # "table" | "lines"
+force-fail = true     # fail every test that prints, so cargo shows stdout
+fail-only = false     # diff: only render cells where Δ > ε
+show-expected = false # diff: render `got/expected` per cell (else just `got`)
+filter = ""           # per-axis filter, same DSL as the slice helper
+```
 
-# Basic test suite (light on cpu)
-cargo test-<runtime>
+**The whole pipeline obeys one rule:** if `enabled = false`, nothing prints.
+Set it to `true`, run a test, watch your tensors render. That's it.
 
-# Extended test suite
-cargo test-<runtime>-extended
+### `[test] policy`
 
-# Full test suite
-cargo test-<runtime>-full
+| Policy        | No error      | Numerical error | Compilation error |
+| ------------- | ------------- | --------------- | ----------------- |
+| `correct`     | accept        | fail            | accept            |
+| `strict`      | accept        | fail            | fail              |
+| `fail-if-run` | fail          | accept          | accept            |
+
+If `[print] force-fail = true`, every passing test that printed is
+additionally rejected — useful so cargo surfaces the dump (it otherwise
+swallows stdout from passing tests). Compile errors are also rejected when
+`force-fail = true`, regardless of policy.
+
+---
+
+## Rendering: one path for everything
+
+Both `assert_equals_approx(actual, expected, ε)` and the free
+`print_tensors(label, &[&a, &b], Some(ε))` go through the same renderer.
+There is no "diff path" vs "pretty-print path"; comparing actual-vs-expected
+and pretty-printing two unrelated same-shape tensors are literally the same
+call.
+
+Rules:
+
+- One tensor → just values, no color.
+- Two tensors of the **same rank and shape** → cells colored green
+  (`Δ ≤ ε`) or red (`Δ > ε`). With `show-expected = true` the cell shows
+  `got/expected`; otherwise just `got`.
+- Two tensors of **different rank or shape** → silently skipped. The
+  renderer never panics on bad input.
+- Filter rank ≠ tensor rank → silently skipped.
+
+```rust
+use cubek_test_utils::print_tensors;
+
+// Single tensor — table or lines per [print] view, no color.
+print_tensors("input", &[&host], None);
+
+// Two tensors — colored diff. Same path used by assert_equals_approx.
+print_tensors("a vs b", &[&a, &b], Some(1e-3));
+```
+
+The table view never shows Δ/ε numbers (cell color carries the same info,
+and adding columns would blow up the width). The lines view always shows
+them.
+
+### Table view example (with `show-expected = true`)
+
+```
+=== diff  shape=[2, 3] ===
+    |                 0                 1                 2
+----+------------------------------------------------------
+  0 | 0.000000/0.000000 1.000000/1.000000 2.000000/2.000000   ← green
+  1 | 4.000000/3.000000 5.000000/4.000000 6.000000/5.000000   ← red
+```
+
+### Table view + `fail-only = true`
+
+```
+=== diff  shape=[2, 3] ===
+    |        0        1        2
+----+---------------------------
+  0 |                            ← matching cells blanked out
+  1 | 4.000000 5.000000 6.000000 ← red
+```
+
+### Lines view + `fail-only = true`
+
+```
+=== diff  shape=[2, 3] ===
+ index |      got | expected |        Δ |        ε | status
+-----------------------------------------------------------
+[1, 0] | 4.000000 | 3.000000 | 1.000000 | 0.003000 | FAIL    ← red
+[1, 1] | 5.000000 | 4.000000 | 1.000000 | 0.004000 | FAIL    ← red
+[1, 2] | 6.000000 | 5.000000 | 1.000000 | 0.005000 | FAIL    ← red
 ```
 
 ---
 
-## Cube test mode
+## Filter syntax
 
-Set the `CUBE_TEST_MODE` environment variable to control how tests respond to
-numerical errors and compilation errors.
+Used by both `[print] filter` and `assert_equals_approx_in_slice`. A
+comma-separated list of dim entries:
 
-| Mode                  | Numerical error | Compilation error         | Notes                                                                |
-| --------------------- | --------------- | ------------------------- | -------------------------------------------------------------------- |
-| `correct` _(default)_ | fail            | accept                    | Useful when test grids include invalid configurations on purpose.    |
-| `strict`              | fail            | fail                      | Recommended for debugging — surfaces every problem.                  |
-| `printall[:filter]`   | fail (printed)  | fail (printed)            | Every test is rejected so you can read the full per-element dump.    |
-| `printfail[:filter]`  | fail (printed)  | accept                    | Per-element dump only for tests that compile and produce mismatches. |
-| `failifrun`           | accept          | accept (other tests fail) | Inverts `correct` to surface tests that _do_ run.                    |
-
-### Filter syntax
-
-The filter is optional and tells the printers which indices to highlight. A
-comma-separated list of dimensions, where each entry is one of:
-
-- `.` — wildcard (any index along that dimension)
+- `.` — wildcard (any index along that dim)
 - `N` — a single index
-- `M-K` — an inclusive range
+- `M-K` — inclusive range
 
-Example for a 4-D tensor: `CUBE_TEST_MODE=printfail:.,.,10-20,30` selects all
-elements where dim 2 is in `10..=20` and dim 3 is exactly `30`.
+Example for a 4-D tensor: `.,.,10-20,30` selects all elements where
+dim 2 is in `10..=20` and dim 3 is exactly `30`. Filter rank must equal
+tensor rank.
 
-> The filter rank must match the tensor rank, otherwise the test returns an
-> `Error` instead of `Fail`/`Pass`.
+From Rust:
+
+```rust
+use cubek_test_utils::{DimFilter, assert_equals_approx_in_slice};
+
+// Vec<Range<usize>> works (half-open, like Rust slices).
+assert_equals_approx_in_slice(&actual, &expected, 0.001, vec![0..1, 0..3]);
+
+// Or build the canonical TensorFilter explicitly.
+let filter = vec![
+    DimFilter::Exact(0),
+    DimFilter::Range { start: 0, end: 2 }, // inclusive: 0..=2
+];
+assert_equals_approx_in_slice(&actual, &expected, 0.001, filter);
+```
+
+`parse_tensor_filter("0,0-2")` parses the string DSL into a `TensorFilter`.
 
 ---
 
 ## Failure messages
 
-`assert_equals_approx` collects up to **8 individual mismatches** plus aggregate
+`assert_equals_approx` collects up to **8** mismatches plus aggregate
 stats and reports them in the test panic message:
 
 ```
@@ -76,19 +157,114 @@ Test failed: Got incorrect results: 17/4096 elements mismatched
   (max |Δ|=0.014648, mean |Δ|=0.004112, worst at [3, 12]) — shape=[16, 256]
 First mismatches:
   [0, 5]: got 1.234, expected 1.220, |Δ|=0.014 > ε=0.001
-  [0, 17]: got 0.998, expected 1.001, |Δ|=0.003 > ε=0.001
   ...
   ... and 9 more
 ```
 
-In `printall` / `printfail` modes, the per-element output is written to stdout
-and the panic message keeps only the aggregate header (no duplicated examples).
+When printing is enabled the per-element output goes to stdout; the panic
+message keeps only the aggregate header so it doesn't duplicate the dump.
+
+---
+
+## Test suites
+
+Four suites are available:
+
+- **Light** — tractable subset that runs on CI.
+- **Basic** — basic tests that may hang on CI (slow on CPU).
+- **Extended** — auto-generated combinatorial tests, kept tractable.
+- **Full** — all generable combinations, may not fit.
+
+```bash
+# Replace <runtime> with cpu, cuda, rocm, wgpu, vulkan or metal.
+cargo test-<runtime>             # basic suite (light on cpu)
+cargo test-<runtime>-extended
+cargo test-<runtime>-full
+```
+
+---
+
+## Building test inputs
+
+Two equivalent ways to construct a test tensor:
+
+```rust
+use cubek_test_utils::{TestInput, StrideSpec, DataKind, Distribution};
+
+// Long-form constructor.
+let (handle, host) = TestInput::new(
+    client.clone(),
+    [4, 4],
+    f32::as_type_native_unchecked().storage_type(),
+    StrideSpec::RowMajor,
+    DataKind::Random {
+        seed: 0,
+        distribution: Distribution::Uniform(-1.0, 1.0),
+    },
+)
+.generate_with_f32_host_data();
+
+// Fluent builder — `dtype` defaults to f32, `stride` defaults to RowMajor.
+let (handle, host) = TestInput::builder(client.clone(), [4, 4])
+    .uniform(/* seed */ 0, -1.0, 1.0)
+    .generate_with_f32_host_data();
+```
+
+Builder setters (all optional):
+
+| Setter          | Default                | Effect                      |
+| --------------- | ---------------------- | --------------------------- |
+| `.dtype(d)`     | `f32`                  | Override the input dtype.   |
+| `.stride(spec)` | `StrideSpec::RowMajor` | Override the stride layout. |
+
+Builder finalizers (each returns a `TestInput` ready to generate):
+
+| Finalizer                  | Equivalent `DataKind`                                            |
+| -------------------------- | ---------------------------------------------------------------- |
+| `.arange()`                | `Arange { scale: None }`                                         |
+| `.arange_scaled(s)`        | `Arange { scale: Some(s) }`                                      |
+| `.eye()`                   | `Eye`                                                            |
+| `.zeros()`                 | `Zeros`                                                          |
+| `.uniform(seed, lo, hi)`   | `Random { Uniform(lo, hi) }`                                     |
+| `.bernoulli(seed, p)`      | `Random { Bernoulli(p) }`                                        |
+| `.normal(seed, mean, std)` | `Random { Normal { mean, std } }`                                |
+| `.random(seed, dist)`      | `Random { dist }`                                                |
+| `.linspace(start, end)`    | `Custom { data }` with N evenly-spaced values from `start..=end` |
+| `.custom(data)`            | `Custom { data }`                                                |
+
+After a finalizer, call any of: `.generate()`, `.generate_with_f32_host_data()`,
+`.generate_with_bool_host_data()`, `.generate_test_tensor()`,
+`.f32_host_data()`, `.bool_host_data()`.
+
+---
+
+## Walking host tensors
+
+`HostData` exposes typed accessors and indexed iterators that resolve
+through the tensor's strides, so non-contiguous tensors work without manual
+offset math:
+
+| API                          | Returns                            | On dtype mismatch |
+| ---------------------------- | ---------------------------------- | ----------------- |
+| `host.get_f32(&[i, j])`      | `f32`                              | panics            |
+| `host.get_i32(&[i, j])`      | `i32`                              | panics            |
+| `host.get_bool(&[i, j])`     | `bool`                             | panics            |
+| `host.try_get_f32(&[i, j])`  | `Option<f32>`                      | `None`            |
+| `host.try_get_i32(&[i, j])`  | `Option<i32>`                      | `None`            |
+| `host.try_get_bool(&[i, j])` | `Option<bool>`                     | `None`            |
+| `host.iter_indices()`        | `impl Iterator<Item = Vec<usize>>` | n/a               |
+| `host.iter_indexed_f32()`    | `(Vec<usize>, f32)` (row-major)    | panics            |
+| `host.iter_indexed_i32()`    | `(Vec<usize>, i32)`                | panics            |
+| `host.iter_indexed_bool()`   | `(Vec<usize>, bool)`               | panics            |
 
 ---
 
 ## Pointers
 
-- `TestMode` and `current_test_mode` — `src/test_mode/base.rs`
-- Validation result / decision pipeline — `src/test_mode/result.rs`
+- Config (`CubekConfig`, `PrintSection`, `TestPolicy`) — `src/config.rs`
+- Test-policy decisions — `src/test_mode/`
 - `assert_equals_approx`, `assert_equals_approx_in_slice` — `src/correctness/base.rs`
-- Tensor builders (`TestInput`, `DataKind`, `StrideSpec`, …) — `src/test_tensor/`
+- Unified renderer — `src/correctness/render.rs`
+- `print_tensors`, `print_tensor` — `src/correctness/print_tensor.rs`
+- Tensor builders (`TestInput`, `TestInputBuilder`, `DataKind`, `StrideSpec`) — `src/test_tensor/`
+- Quantization helper — `src/test_tensor/quant.rs`

--- a/crates/cubek-test-utils/README.md
+++ b/crates/cubek-test-utils/README.md
@@ -202,7 +202,7 @@ let (handle, host) = TestInput::new(
 
 // Fluent builder — `dtype` defaults to f32, `stride` defaults to RowMajor.
 let (handle, host) = TestInput::builder(client.clone(), [4, 4])
-    .uniform(/* seed */ 0, -1.0, 1.0)
+    .uniform( 0, -1.0, 1.0)
     .generate_with_f32_host_data();
 ```
 

--- a/crates/cubek-test-utils/README.md
+++ b/crates/cubek-test-utils/README.md
@@ -1,0 +1,94 @@
+# cubek-test-utils
+
+Shared building blocks for kernel tests in CubeK: test-tensor builders, host-side
+reference comparisons, and a `CUBE_TEST_MODE` policy layer that decides what
+constitutes a passing test under a given environment variable.
+
+This README documents the testing workflow used across most CubeK kernels.
+
+---
+
+## Test suites
+
+Four test suites are available:
+
+- **Light test suite** — a tractable subset of representative tests that runs in CI.
+- **Basic test suite** — adds tests considered basic but that may hang on CI (slow on CPU).
+- **Extended test suite** — usually auto-generated combinatorial tests covering many
+  configurations. Good to run when developing kernels. Normally kept tractable.
+- **Full test suite** — all generable test combinations; may be too large to compile or
+  run practically.
+
+Run them with:
+
+```bash
+# Replace <runtime> with cpu, cuda, rocm, wgpu, vulkan or metal
+
+# Basic test suite (light on cpu)
+cargo test-<runtime>
+
+# Extended test suite
+cargo test-<runtime>-extended
+
+# Full test suite
+cargo test-<runtime>-full
+```
+
+---
+
+## Cube test mode
+
+Set the `CUBE_TEST_MODE` environment variable to control how tests respond to
+numerical errors and compilation errors.
+
+| Mode                  | Numerical error | Compilation error         | Notes                                                                |
+| --------------------- | --------------- | ------------------------- | -------------------------------------------------------------------- |
+| `correct` _(default)_ | fail            | accept                    | Useful when test grids include invalid configurations on purpose.    |
+| `strict`              | fail            | fail                      | Recommended for debugging — surfaces every problem.                  |
+| `printall[:filter]`   | fail (printed)  | fail (printed)            | Every test is rejected so you can read the full per-element dump.    |
+| `printfail[:filter]`  | fail (printed)  | accept                    | Per-element dump only for tests that compile and produce mismatches. |
+| `failifrun`           | accept          | accept (other tests fail) | Inverts `correct` to surface tests that _do_ run.                    |
+
+### Filter syntax
+
+The filter is optional and tells the printers which indices to highlight. A
+comma-separated list of dimensions, where each entry is one of:
+
+- `.` — wildcard (any index along that dimension)
+- `N` — a single index
+- `M-K` — an inclusive range
+
+Example for a 4-D tensor: `CUBE_TEST_MODE=printfail:.,.,10-20,30` selects all
+elements where dim 2 is in `10..=20` and dim 3 is exactly `30`.
+
+> The filter rank must match the tensor rank, otherwise the test returns an
+> `Error` instead of `Fail`/`Pass`.
+
+---
+
+## Failure messages
+
+`assert_equals_approx` collects up to **8 individual mismatches** plus aggregate
+stats and reports them in the test panic message:
+
+```
+Test failed: Got incorrect results: 17/4096 elements mismatched
+  (max |Δ|=0.014648, mean |Δ|=0.004112, worst at [3, 12]) — shape=[16, 256]
+First mismatches:
+  [0, 5]: got 1.234, expected 1.220, |Δ|=0.014 > ε=0.001
+  [0, 17]: got 0.998, expected 1.001, |Δ|=0.003 > ε=0.001
+  ...
+  ... and 9 more
+```
+
+In `printall` / `printfail` modes, the per-element output is written to stdout
+and the panic message keeps only the aggregate header (no duplicated examples).
+
+---
+
+## Pointers
+
+- `TestMode` and `current_test_mode` — `src/test_mode/base.rs`
+- Validation result / decision pipeline — `src/test_mode/result.rs`
+- `assert_equals_approx`, `assert_equals_approx_in_slice` — `src/correctness/base.rs`
+- Tensor builders (`TestInput`, `DataKind`, `StrideSpec`, …) — `src/test_tensor/`

--- a/crates/cubek-test-utils/src/config.rs
+++ b/crates/cubek-test-utils/src/config.rs
@@ -1,0 +1,364 @@
+//! `cubek.toml` loader.
+//!
+//! At process start we walk up from the current working directory looking
+//! for a file named `cubek.toml`. The first match wins, the parsed result
+//! is cached in a `OnceLock`, and every other module asks for the parts it
+//! needs through this module.
+//!
+//! The parser is intentionally tiny — `cubek.toml` is a flat schema (one
+//! `[section]` key per group, scalar values only). Anything more elaborate
+//! belongs in a real TOML library; for now we accept exactly what the
+//! example file documents and panic loudly on anything else.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use crate::correctness::{TensorFilter, parse_tensor_filter};
+
+/// Top-level configuration loaded from `cubek.toml`.
+#[derive(Clone, Debug)]
+pub struct CubekConfig {
+    pub test: TestSection,
+    pub print: PrintSection,
+}
+
+#[derive(Clone, Debug)]
+pub struct TestSection {
+    pub policy: TestPolicy,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum TestPolicy {
+    Correct,
+    Strict,
+    FailIfRun,
+}
+
+#[derive(Clone, Debug)]
+pub struct PrintSection {
+    pub enabled: bool,
+    pub view: PrintView,
+    pub force_fail: bool,
+    pub fail_only: bool,
+    pub show_expected: bool,
+    pub filter: TensorFilter,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum PrintView {
+    Table,
+    Lines,
+}
+
+impl Default for CubekConfig {
+    fn default() -> Self {
+        Self {
+            test: TestSection {
+                policy: TestPolicy::Correct,
+            },
+            print: PrintSection {
+                enabled: false,
+                view: PrintView::Table,
+                force_fail: true,
+                fail_only: false,
+                show_expected: false,
+                filter: Vec::new(),
+            },
+        }
+    }
+}
+
+/// Returns the active config. Cached on first call.
+pub fn config() -> &'static CubekConfig {
+    static CACHE: OnceLock<CubekConfig> = OnceLock::new();
+    CACHE.get_or_init(load_config)
+}
+
+fn load_config() -> CubekConfig {
+    let Some(path) = find_cubek_toml() else {
+        return CubekConfig::default();
+    };
+    let text = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    parse_cubek_toml(&text).unwrap_or_else(|e| {
+        panic!("invalid cubek.toml ({}): {e}", path.display())
+    })
+}
+
+fn find_cubek_toml() -> Option<PathBuf> {
+    let mut cur = std::env::current_dir().ok()?;
+    loop {
+        let candidate = cur.join("cubek.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !cur.pop() {
+            return None;
+        }
+    }
+}
+
+// ---------- minimal flat-section TOML parser ----------
+
+type Sections = HashMap<String, HashMap<String, String>>;
+
+fn parse_cubek_toml(text: &str) -> Result<CubekConfig, String> {
+    let sections = parse_sections(text)?;
+
+    let mut cfg = CubekConfig::default();
+
+    if let Some(map) = sections.get("test") {
+        cfg.test.policy = match get_string(map, "policy")?.as_deref() {
+            None | Some("correct") => TestPolicy::Correct,
+            Some("strict") => TestPolicy::Strict,
+            Some("fail-if-run") => TestPolicy::FailIfRun,
+            Some(other) => {
+                return Err(format!(
+                    "[test] policy='{}': expected one of \"correct\", \"strict\", \"fail-if-run\"",
+                    other
+                ));
+            }
+        };
+        reject_unknown_keys(
+            "test",
+            map,
+            &["policy"],
+        )?;
+    }
+
+    if let Some(map) = sections.get("print") {
+        let enabled = get_bool(map, "enabled")?.unwrap_or(false);
+        let view = match get_string(map, "view")?.as_deref() {
+            None | Some("table") => PrintView::Table,
+            Some("lines") => PrintView::Lines,
+            Some(other) => {
+                return Err(format!(
+                    "[print] view='{}': expected \"table\" or \"lines\"",
+                    other
+                ));
+            }
+        };
+        let force_fail = get_bool(map, "force-fail")?.unwrap_or(true);
+        let fail_only = get_bool(map, "fail-only")?.unwrap_or(false);
+        let show_expected = get_bool(map, "show-expected")?.unwrap_or(false);
+        let filter_str = get_string(map, "filter")?.unwrap_or_default();
+        let filter = if filter_str.is_empty() {
+            Vec::new()
+        } else {
+            parse_tensor_filter(&filter_str)
+                .map_err(|e| format!("[print] filter='{}': {}", filter_str, e))?
+        };
+
+        cfg.print = PrintSection {
+            enabled,
+            view,
+            force_fail,
+            fail_only,
+            show_expected,
+            filter,
+        };
+
+        reject_unknown_keys(
+            "print",
+            map,
+            &[
+                "enabled",
+                "view",
+                "force-fail",
+                "fail-only",
+                "show-expected",
+                "filter",
+            ],
+        )?;
+    }
+
+    for sec in sections.keys() {
+        if sec != "test" && sec != "print" {
+            return Err(format!("unknown section [{}]", sec));
+        }
+    }
+
+    Ok(cfg)
+}
+
+fn parse_sections(text: &str) -> Result<Sections, String> {
+    let mut sections: Sections = HashMap::new();
+    let mut current: Option<String> = None;
+
+    for (line_no, raw) in text.lines().enumerate() {
+        let line = strip_comment(raw).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix('[')
+            && let Some(name) = rest.strip_suffix(']')
+        {
+            let name = name.trim();
+            if name.is_empty() || name.contains('.') {
+                return Err(format!(
+                    "line {}: section name '[{}]' must be a single identifier",
+                    line_no + 1,
+                    name
+                ));
+            }
+            sections.entry(name.to_string()).or_default();
+            current = Some(name.to_string());
+            continue;
+        }
+
+        let Some(section) = current.as_ref() else {
+            return Err(format!(
+                "line {}: key '{}' before any [section]",
+                line_no + 1,
+                line
+            ));
+        };
+
+        let Some((k, v)) = line.split_once('=') else {
+            return Err(format!("line {}: expected `key = value`, got '{}'", line_no + 1, line));
+        };
+        let key = k.trim().to_string();
+        let val = v.trim().to_string();
+        sections.get_mut(section).unwrap().insert(key, val);
+    }
+
+    Ok(sections)
+}
+
+fn strip_comment(line: &str) -> &str {
+    // TOML allows '#' anywhere outside a string. We only support unquoted
+    // scalars and strings without '#' inside; that's enough for cubek.toml.
+    let mut in_string = false;
+    let bytes = line.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'"' => in_string = !in_string,
+            b'#' if !in_string => return &line[..i],
+            _ => {}
+        }
+    }
+    line
+}
+
+fn get_string(map: &HashMap<String, String>, key: &str) -> Result<Option<String>, String> {
+    let Some(raw) = map.get(key) else {
+        return Ok(None);
+    };
+    let s = unquote(raw)
+        .ok_or_else(|| format!("key '{}' must be a quoted string, got `{}`", key, raw))?;
+    Ok(Some(s))
+}
+
+fn get_bool(map: &HashMap<String, String>, key: &str) -> Result<Option<bool>, String> {
+    let Some(raw) = map.get(key) else {
+        return Ok(None);
+    };
+    match raw.as_str() {
+        "true" => Ok(Some(true)),
+        "false" => Ok(Some(false)),
+        other => Err(format!(
+            "key '{}' must be `true` or `false`, got `{}`",
+            key, other
+        )),
+    }
+}
+
+fn unquote(s: &str) -> Option<String> {
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        Some(s[1..s.len() - 1].to_string())
+    } else {
+        None
+    }
+}
+
+fn reject_unknown_keys(
+    section: &str,
+    map: &HashMap<String, String>,
+    known: &[&str],
+) -> Result<(), String> {
+    for k in map.keys() {
+        if !known.contains(&k.as_str()) {
+            return Err(format!(
+                "[{}] unknown key '{}'. Known: {}",
+                section,
+                k,
+                known.join(", ")
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ---------- unit tests for the parser ----------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_example() {
+        let text = r#"
+[test]
+policy = "strict"
+
+[print]
+enabled = true
+view = "lines"
+force-fail = false
+fail-only = true
+show-expected = true
+filter = "0,1-2"
+"#;
+        let cfg = parse_cubek_toml(text).unwrap();
+        assert_eq!(cfg.test.policy, TestPolicy::Strict);
+        assert!(cfg.print.enabled);
+        assert_eq!(cfg.print.view, PrintView::Lines);
+        assert!(!cfg.print.force_fail);
+        assert!(cfg.print.fail_only);
+        assert!(cfg.print.show_expected);
+        assert_eq!(cfg.print.filter.len(), 2);
+    }
+
+    #[test]
+    fn empty_file_gives_defaults() {
+        let cfg = parse_cubek_toml("").unwrap();
+        assert_eq!(cfg.test.policy, TestPolicy::Correct);
+        assert!(!cfg.print.enabled);
+        assert_eq!(cfg.print.view, PrintView::Table);
+    }
+
+    #[test]
+    fn rejects_unknown_section() {
+        let err = parse_cubek_toml("[bogus]\nx=1\n").unwrap_err();
+        assert!(err.contains("unknown section"), "{}", err);
+    }
+
+    #[test]
+    fn rejects_unknown_key() {
+        let err = parse_cubek_toml("[print]\nbogus = true\n").unwrap_err();
+        assert!(err.contains("unknown key"), "{}", err);
+    }
+
+    #[test]
+    fn rejects_bad_policy() {
+        let err = parse_cubek_toml("[test]\npolicy = \"loose\"\n").unwrap_err();
+        assert!(err.contains("policy"), "{}", err);
+    }
+
+    #[test]
+    fn rejects_unquoted_string() {
+        let err = parse_cubek_toml("[print]\nview = table\n").unwrap_err();
+        assert!(err.contains("quoted string"), "{}", err);
+    }
+
+    #[test]
+    fn rejects_show_delta_key() {
+        // We removed `show-delta`/`show-epsilon` — they should now be
+        // unknown keys, since lines view always shows them and table view
+        // never does.
+        let err = parse_cubek_toml("[print]\nshow-delta = true\n").unwrap_err();
+        assert!(err.contains("unknown key"), "{}", err);
+    }
+}

--- a/crates/cubek-test-utils/src/config.rs
+++ b/crates/cubek-test-utils/src/config.rs
@@ -81,9 +81,8 @@ fn load_config() -> CubekConfig {
     };
     let text = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
-    parse_cubek_toml(&text).unwrap_or_else(|e| {
-        panic!("invalid cubek.toml ({}): {e}", path.display())
-    })
+    parse_cubek_toml(&text)
+        .unwrap_or_else(|e| panic!("invalid cubek.toml ({}): {e}", path.display()))
 }
 
 fn find_cubek_toml() -> Option<PathBuf> {
@@ -120,11 +119,7 @@ fn parse_cubek_toml(text: &str) -> Result<CubekConfig, String> {
                 ));
             }
         };
-        reject_unknown_keys(
-            "test",
-            map,
-            &["policy"],
-        )?;
+        reject_unknown_keys("test", map, &["policy"])?;
     }
 
     if let Some(map) = sections.get("print") {
@@ -217,7 +212,11 @@ fn parse_sections(text: &str) -> Result<Sections, String> {
         };
 
         let Some((k, v)) = line.split_once('=') else {
-            return Err(format!("line {}: expected `key = value`, got '{}'", line_no + 1, line));
+            return Err(format!(
+                "line {}: expected `key = value`, got '{}'",
+                line_no + 1,
+                line
+            ));
         };
         let key = k.trim().to_string();
         let val = v.trim().to_string();

--- a/crates/cubek-test-utils/src/correctness/base.rs
+++ b/crates/cubek-test-utils/src/correctness/base.rs
@@ -6,6 +6,10 @@ use crate::{
     {HostData, ValidationResult},
 };
 
+/// Maximum number of individual mismatches to include in a `Fail` reason
+/// before we stop recording details and only update the aggregate stats.
+const DEFAULT_MAX_REPORTED_MISMATCHES: usize = 8;
+
 /// Check if two tensors are approximately equal
 pub fn assert_equals_approx(
     // One of the tensor to compare
@@ -55,12 +59,19 @@ fn assert_equals_approx_inner(
     let shape = &lhs.shape;
     let test_mode = current_test_mode();
 
-    let mut visitor: Box<dyn CompareVisitor> = match test_mode.clone() {
-        TestMode::Print { filter, .. } => Box::new(SafePrinter {
-            inner: ColorPrinter::new(filter),
+    let print_visitor = matches!(test_mode, TestMode::Print { .. });
+    let mut summary_visitor = SummaryCollector::new(DEFAULT_MAX_REPORTED_MISMATCHES);
+    let mut printer_visitor: Option<SafePrinter> = match &test_mode {
+        TestMode::Print { filter, .. } => Some(SafePrinter {
+            inner: ColorPrinter::new(filter.clone()),
             shape_len: shape.len(),
         }),
-        _ => Box::new(FailFast),
+        _ => None,
+    };
+
+    let mut visitor = TeeVisitor {
+        summary: &mut summary_visitor,
+        printer: printer_visitor.as_mut().map(|v| v as &mut dyn CompareVisitor),
     };
 
     let test_failed = compare_tensors(
@@ -68,14 +79,14 @@ fn assert_equals_approx_inner(
         rhs,
         shape,
         epsilon,
-        &mut *visitor,
+        &mut visitor,
         &mut Vec::new(),
         slice.as_deref(), // pass slice as Option<&[usize]>
     );
 
     // Enforce filter rank only if the test failed and we would print
     if test_failed {
-        if let TestMode::Print { filter, .. } = test_mode
+        if let TestMode::Print { filter, .. } = &test_mode
             && !filter.is_empty()
             && filter.len() != shape.len()
         {
@@ -86,7 +97,7 @@ fn assert_equals_approx_inner(
             ));
         }
 
-        return ValidationResult::Fail("Got incorrect results".to_string());
+        return ValidationResult::Fail(summary_visitor.report(shape, print_visitor));
     }
 
     ValidationResult::Pass
@@ -134,13 +145,167 @@ impl CompareVisitor for SafePrinter {
     }
 }
 
-pub(crate) struct FailFast;
+/// Collects up to `max_reported` individual mismatches plus aggregate stats
+/// (total compared, total mismatched, max/sum of |Δ|, worst index) to build a
+/// detailed failure message without truncating useful debug info.
+pub(crate) struct SummaryCollector {
+    pub max_reported: usize,
+    pub mismatches: Vec<(Vec<usize>, WrongStatus)>,
+    pub total: usize,
+    pub mismatched: usize,
+    pub max_abs_delta: f32,
+    pub sum_abs_delta: f64,
+    pub worst_index: Option<Vec<usize>>,
+}
 
-impl CompareVisitor for FailFast {
-    fn visit(&mut self, index: &[usize], status: ElemStatus) {
-        if let ElemStatus::Wrong(w) = status {
-            panic!("Mismatch at {:?}: {:?}", index, w);
+impl SummaryCollector {
+    fn new(max_reported: usize) -> Self {
+        Self {
+            max_reported,
+            mismatches: Vec::new(),
+            total: 0,
+            mismatched: 0,
+            max_abs_delta: 0.0,
+            sum_abs_delta: 0.0,
+            worst_index: None,
         }
+    }
+
+    fn record_delta(&mut self, index: &[usize], delta: f32) {
+        if delta.is_finite() {
+            self.sum_abs_delta += delta as f64;
+        }
+        if delta > self.max_abs_delta || self.worst_index.is_none() {
+            self.max_abs_delta = delta;
+            self.worst_index = Some(index.to_vec());
+        }
+    }
+
+    pub(crate) fn report(&self, shape: &[usize], skip_examples: bool) -> String {
+        let mut out = String::new();
+        out.push_str("Got incorrect results: ");
+        out.push_str(&format!(
+            "{}/{} elements mismatched",
+            self.mismatched, self.total
+        ));
+
+        if self.mismatched > 0 {
+            let mean = if self.mismatched > 0 {
+                self.sum_abs_delta / self.mismatched as f64
+            } else {
+                0.0
+            };
+            out.push_str(&format!(
+                " (max |Δ|={:.6}, mean |Δ|={:.6}",
+                self.max_abs_delta, mean
+            ));
+            if let Some(idx) = &self.worst_index {
+                out.push_str(&format!(", worst at {:?}", idx));
+            }
+            out.push(')');
+            out.push_str(&format!(" — shape={:?}", shape));
+        }
+
+        // In Print modes, the per-element output is on stdout already; don't
+        // re-list examples in the panic message.
+        if skip_examples || self.mismatches.is_empty() {
+            return out;
+        }
+
+        out.push_str("\nFirst mismatches:");
+        for (idx, w) in &self.mismatches {
+            out.push_str(&format!("\n  {:?}: {}", idx, format_wrong(w)));
+        }
+        if self.mismatched > self.mismatches.len() {
+            out.push_str(&format!(
+                "\n  ... and {} more",
+                self.mismatched - self.mismatches.len()
+            ));
+        }
+
+        out
+    }
+}
+
+impl CompareVisitor for SummaryCollector {
+    fn visit(&mut self, index: &[usize], status: ElemStatus) {
+        self.total += 1;
+        if let ElemStatus::Wrong(w) = status {
+            self.mismatched += 1;
+            let delta = match &w {
+                WrongStatus::GotWrongValue { delta, .. } => *delta,
+                WrongStatus::ExpectedNan { .. } | WrongStatus::GotNan { .. } => f32::INFINITY,
+            };
+            self.record_delta(index, delta);
+            if self.mismatches.len() < self.max_reported {
+                self.mismatches.push((index.to_vec(), w));
+            }
+        }
+    }
+}
+
+/// Forwards each visit to a summary collector and (optionally) a printer, so
+/// PrintAll/PrintFail keep their per-element stdout while the failure message
+/// gets the aggregate stats too.
+struct TeeVisitor<'a> {
+    summary: &'a mut SummaryCollector,
+    printer: Option<&'a mut dyn CompareVisitor>,
+}
+
+impl CompareVisitor for TeeVisitor<'_> {
+    fn visit(&mut self, index: &[usize], status: ElemStatus) {
+        // Clone status for the second visitor; ElemStatus is small (a few f32s).
+        let status_for_summary = match &status {
+            ElemStatus::Correct {
+                got,
+                delta,
+                epsilon,
+            } => ElemStatus::Correct {
+                got: *got,
+                delta: *delta,
+                epsilon: *epsilon,
+            },
+            ElemStatus::Wrong(w) => ElemStatus::Wrong(clone_wrong(w)),
+        };
+        self.summary.visit(index, status_for_summary);
+        if let Some(p) = self.printer.as_deref_mut() {
+            p.visit(index, status);
+        }
+    }
+}
+
+fn clone_wrong(w: &WrongStatus) -> WrongStatus {
+    match w {
+        WrongStatus::GotWrongValue {
+            got,
+            expected,
+            delta,
+            epsilon,
+        } => WrongStatus::GotWrongValue {
+            got: *got,
+            expected: *expected,
+            delta: *delta,
+            epsilon: *epsilon,
+        },
+        WrongStatus::ExpectedNan { got } => WrongStatus::ExpectedNan { got: *got },
+        WrongStatus::GotNan { expected } => WrongStatus::GotNan {
+            expected: *expected,
+        },
+    }
+}
+
+fn format_wrong(w: &WrongStatus) -> String {
+    match w {
+        WrongStatus::GotWrongValue {
+            got,
+            expected,
+            delta,
+            epsilon,
+        } => format!(
+            "got {got}, expected {expected}, |Δ|={delta} > ε={epsilon}",
+        ),
+        WrongStatus::ExpectedNan { got } => format!("got {got}, expected NaN"),
+        WrongStatus::GotNan { expected } => format!("got NaN, expected {expected}"),
     }
 }
 

--- a/crates/cubek-test-utils/src/correctness/base.rs
+++ b/crates/cubek-test-utils/src/correctness/base.rs
@@ -1,8 +1,10 @@
-use std::ops::Range;
-
 use crate::{
-    correctness::color_printer::ColorPrinter,
-    test_mode::{TestMode, current_test_mode},
+    config::config,
+    correctness::{
+        color_printer::index_matches_filter,
+        render::print_tensors,
+        {DimFilter, TensorFilter},
+    },
     {HostData, ValidationResult},
 };
 
@@ -22,19 +24,28 @@ pub fn assert_equals_approx(
     assert_equals_approx_inner(lhs, rhs, epsilon, None)
 }
 
-/// Check if two tensors are approximately equal
-/// Within the given slice, if some
-pub fn assert_equals_approx_in_slice(
+/// Check if two tensors are approximately equal within the given filter.
+///
+/// `filter` is anything iterable whose items convert into [`DimFilter`], so
+/// both `Vec<std::ops::Range<usize>>` and the canonical [`TensorFilter`]
+/// (matching the `cubek.toml` `[print] filter` syntax) work — one DSL for
+/// selective comparison and selective printing.
+pub fn assert_equals_approx_in_slice<I>(
     // One of the tensor to compare
     lhs: &HostData,
     // One of the tensor to compare
     rhs: &HostData,
     // Maximum absolute difference between two values
     epsilon: f32,
-    // If some, will only check values within the slice shape
-    slice: Vec<Range<usize>>,
-) -> ValidationResult {
-    assert_equals_approx_inner(lhs, rhs, epsilon, Some(slice))
+    // If non-empty, only indices that match the filter are compared
+    filter: I,
+) -> ValidationResult
+where
+    I: IntoIterator,
+    I::Item: Into<DimFilter>,
+{
+    let filter: TensorFilter = filter.into_iter().map(Into::into).collect();
+    assert_equals_approx_inner(lhs, rhs, epsilon, Some(filter))
 }
 
 /// Check if two tensors are approximately equal
@@ -46,9 +57,15 @@ fn assert_equals_approx_inner(
     rhs: &HostData,
     // Maximum absolute difference between two values
     epsilon: f32,
-    // If some, will only check values within the slice shape
-    slice: Option<Vec<Range<usize>>>,
+    // If some, only indices matching the filter are compared
+    filter: Option<TensorFilter>,
 ) -> ValidationResult {
+    // Route the diff through the unified renderer. It is a no-op when
+    // printing is disabled or when shapes differ — same code path as
+    // pretty-printing two unrelated tensors.
+    let print_cfg = &config().print;
+    print_tensors(print_cfg, "diff", &[lhs, rhs], Some(epsilon));
+
     if lhs.shape != rhs.shape {
         return ValidationResult::Fail(format!(
             "Shape mismatch: got {:?}, expected {:?}",
@@ -57,47 +74,36 @@ fn assert_equals_approx_inner(
     }
 
     let shape = &lhs.shape;
-    let test_mode = current_test_mode();
+    let in_print_mode = print_cfg.enabled;
 
-    let print_visitor = matches!(test_mode, TestMode::Print { .. });
     let mut summary_visitor = SummaryCollector::new(DEFAULT_MAX_REPORTED_MISMATCHES);
-    let mut printer_visitor: Option<SafePrinter> = match &test_mode {
-        TestMode::Print { filter, .. } => Some(SafePrinter {
-            inner: ColorPrinter::new(filter.clone()),
-            shape_len: shape.len(),
-        }),
-        _ => None,
-    };
 
-    let mut visitor = TeeVisitor {
-        summary: &mut summary_visitor,
-        printer: printer_visitor.as_mut().map(|v| v as &mut dyn CompareVisitor),
-    };
+    // Up-front rank check on the comparison filter — bail out cleanly so a
+    // mistyped filter doesn't silently exclude every index.
+    if let Some(f) = &filter
+        && !f.is_empty()
+        && f.len() != shape.len()
+    {
+        return ValidationResult::Error(format!(
+            "Comparison filter rank mismatch. Got {}, expected {} (tensor shape {:?})",
+            f.len(),
+            shape.len(),
+            shape,
+        ));
+    }
 
     let test_failed = compare_tensors(
         lhs,
         rhs,
         shape,
         epsilon,
-        &mut visitor,
+        &mut summary_visitor,
         &mut Vec::new(),
-        slice.as_deref(), // pass slice as Option<&[usize]>
+        filter.as_ref(),
     );
 
-    // Enforce filter rank only if the test failed and we would print
     if test_failed {
-        if let TestMode::Print { filter, .. } = &test_mode
-            && !filter.is_empty()
-            && filter.len() != shape.len()
-        {
-            return ValidationResult::Error(format!(
-                "Print mode activated with invalid filter rank. Got {:?}, expected {:?}",
-                filter.len(),
-                shape.len()
-            ));
-        }
-
-        return ValidationResult::Fail(summary_visitor.report(shape, print_visitor));
+        return ValidationResult::Fail(summary_visitor.report(shape, in_print_mode));
     }
 
     ValidationResult::Pass
@@ -105,6 +111,7 @@ fn assert_equals_approx_inner(
 
 #[derive(Debug)]
 pub(crate) enum ElemStatus {
+    #[allow(dead_code)] // fields read via Debug in failure messages
     Correct { got: f32, delta: f32, epsilon: f32 },
     Wrong(WrongStatus),
 }
@@ -127,22 +134,6 @@ pub(crate) enum WrongStatus {
 
 pub(crate) trait CompareVisitor {
     fn visit(&mut self, index: &[usize], status: ElemStatus);
-}
-
-struct SafePrinter {
-    inner: ColorPrinter,
-    shape_len: usize,
-}
-
-impl CompareVisitor for SafePrinter {
-    fn visit(&mut self, index: &[usize], status: ElemStatus) {
-        // Only forward to the inner printer if filter rank is valid
-        if self.inner.filter.is_empty() || self.inner.filter.len() == self.shape_len {
-            self.inner.visit(index, status);
-        } else {
-            // skip printing silently
-        }
-    }
 }
 
 /// Collects up to `max_reported` individual mismatches plus aggregate stats
@@ -244,56 +235,6 @@ impl CompareVisitor for SummaryCollector {
     }
 }
 
-/// Forwards each visit to a summary collector and (optionally) a printer, so
-/// PrintAll/PrintFail keep their per-element stdout while the failure message
-/// gets the aggregate stats too.
-struct TeeVisitor<'a> {
-    summary: &'a mut SummaryCollector,
-    printer: Option<&'a mut dyn CompareVisitor>,
-}
-
-impl CompareVisitor for TeeVisitor<'_> {
-    fn visit(&mut self, index: &[usize], status: ElemStatus) {
-        // Clone status for the second visitor; ElemStatus is small (a few f32s).
-        let status_for_summary = match &status {
-            ElemStatus::Correct {
-                got,
-                delta,
-                epsilon,
-            } => ElemStatus::Correct {
-                got: *got,
-                delta: *delta,
-                epsilon: *epsilon,
-            },
-            ElemStatus::Wrong(w) => ElemStatus::Wrong(clone_wrong(w)),
-        };
-        self.summary.visit(index, status_for_summary);
-        if let Some(p) = self.printer.as_deref_mut() {
-            p.visit(index, status);
-        }
-    }
-}
-
-fn clone_wrong(w: &WrongStatus) -> WrongStatus {
-    match w {
-        WrongStatus::GotWrongValue {
-            got,
-            expected,
-            delta,
-            epsilon,
-        } => WrongStatus::GotWrongValue {
-            got: *got,
-            expected: *expected,
-            delta: *delta,
-            epsilon: *epsilon,
-        },
-        WrongStatus::ExpectedNan { got } => WrongStatus::ExpectedNan { got: *got },
-        WrongStatus::GotNan { expected } => WrongStatus::GotNan {
-            expected: *expected,
-        },
-    }
-}
-
 fn format_wrong(w: &WrongStatus) -> String {
     match w {
         WrongStatus::GotWrongValue {
@@ -374,19 +315,19 @@ fn compare_tensors(
     epsilon: f32,
     visitor: &mut dyn CompareVisitor,
     index: &mut Vec<usize>,
-    slice: Option<&[std::ops::Range<usize>]>,
+    filter: Option<&TensorFilter>,
 ) -> bool {
     let mut failed = false;
 
     let dim = index.len();
     if dim == shape.len() {
-        // Check if current index is within all ranges
-        if let Some(slice) = slice {
-            for (i, range) in index.iter().zip(slice.iter()) {
-                if !range.contains(i) {
-                    return false; // skip element outside slice
-                }
-            }
+        // Skip elements that don't match the filter (an empty filter matches
+        // every index).
+        if let Some(filter) = filter
+            && !filter.is_empty()
+            && !index_matches_filter(index, filter)
+        {
+            return false;
         }
 
         let got = actual.get_f32(index);
@@ -401,10 +342,10 @@ fn compare_tensors(
         return failed;
     }
 
-    // Recurse over full dimension — slice check happens at leaf
+    // Recurse over full dimension — filter check happens at leaf
     for i in 0..shape[dim] {
         index.push(i);
-        if compare_tensors(actual, expected, shape, epsilon, visitor, index, slice) {
+        if compare_tensors(actual, expected, shape, epsilon, visitor, index, filter) {
             failed = true;
         }
         index.pop();

--- a/crates/cubek-test-utils/src/correctness/base.rs
+++ b/crates/cubek-test-utils/src/correctness/base.rs
@@ -112,7 +112,11 @@ fn assert_equals_approx_inner(
 #[derive(Debug)]
 pub(crate) enum ElemStatus {
     #[allow(dead_code)] // fields read via Debug in failure messages
-    Correct { got: f32, delta: f32, epsilon: f32 },
+    Correct {
+        got: f32,
+        delta: f32,
+        epsilon: f32,
+    },
     Wrong(WrongStatus),
 }
 
@@ -242,9 +246,7 @@ fn format_wrong(w: &WrongStatus) -> String {
             expected,
             delta,
             epsilon,
-        } => format!(
-            "got {got}, expected {expected}, |Δ|={delta} > ε={epsilon}",
-        ),
+        } => format!("got {got}, expected {expected}, |Δ|={delta} > ε={epsilon}",),
         WrongStatus::ExpectedNan { got } => format!("got {got}, expected NaN"),
         WrongStatus::GotNan { expected } => format!("got NaN, expected {expected}"),
     }

--- a/crates/cubek-test-utils/src/correctness/color_printer.rs
+++ b/crates/cubek-test-utils/src/correctness/color_printer.rs
@@ -1,105 +1,33 @@
-use crate::correctness::{CompareVisitor, ElemStatus, WrongStatus};
-
-const RED: &str = "\x1b[31m";
-const GREEN: &str = "\x1b[32m";
-const RESET: &str = "\x1b[0m";
-
-pub(crate) struct ColorPrinter {
-    pub filter: TensorFilter,
-    indent: usize,
-}
-
-impl ColorPrinter {
-    pub fn new(filter: TensorFilter) -> Self {
-        Self { filter, indent: 0 }
-    }
-
-    fn should_print(&self, index: &[usize]) -> bool {
-        index_matches_filter(index, &self.filter)
-    }
-}
-
-impl CompareVisitor for ColorPrinter {
-    fn visit(&mut self, index: &[usize], status: ElemStatus) {
-        if !self.should_print(index) {
-            return;
-        }
-
-        let idx = format!(
-            "({})",
-            index
-                .iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<_>>()
-                .join(",")
-        );
-
-        match status {
-            ElemStatus::Correct {
-                got,
-                delta,
-                epsilon,
-            } => {
-                println!(
-                    "{}{}: {}{}, Δ={}<={}=ε{}",
-                    " ".repeat(self.indent),
-                    idx,
-                    GREEN,
-                    got,
-                    delta,
-                    epsilon,
-                    RESET
-                );
-            }
-            ElemStatus::Wrong(wrong) => match wrong {
-                WrongStatus::GotWrongValue {
-                    got,
-                    expected,
-                    delta,
-                    epsilon,
-                } => {
-                    println!(
-                        "{}{}: {}Got {}, expected {}, Δ={}>{}=ε{}",
-                        " ".repeat(self.indent),
-                        idx,
-                        RED,
-                        got,
-                        expected,
-                        delta,
-                        epsilon,
-                        RESET
-                    );
-                }
-                WrongStatus::ExpectedNan { got } => {
-                    println!(
-                        "{}{}: {}Got {}, expected NaN{}",
-                        " ".repeat(self.indent),
-                        idx,
-                        RED,
-                        got,
-                        RESET
-                    );
-                }
-                WrongStatus::GotNan { expected } => {
-                    println!(
-                        "{}{}: {}Got NaN, expected {}{}",
-                        " ".repeat(self.indent),
-                        idx,
-                        RED,
-                        expected,
-                        RESET
-                    );
-                }
-            },
-        }
-    }
-}
+//! Filter types shared by `CUBE_TEST_MODE`, `assert_equals_approx_in_slice`,
+//! `print_tensor`, and `pretty_print_slice`. Per-element rendering moved to
+//! `correctness::render`; this module is now just the filter language.
 
 #[derive(Debug, Clone)]
 pub enum DimFilter {
+    /// Wildcard: match any index along this dimension.
     Any,
+    /// Match a single exact index.
     Exact(usize),
+    /// Inclusive range: matches `start..=end`.
+    /// (`CUBE_TEST_MODE`'s `M-K` filter and the parser produce this variant.)
     Range { start: usize, end: usize },
+}
+
+impl From<std::ops::Range<usize>> for DimFilter {
+    /// Convert a half-open `Range<usize>` (`start..end`) into an inclusive
+    /// `DimFilter::Range`. An empty range is converted into a filter that
+    /// matches nothing.
+    fn from(r: std::ops::Range<usize>) -> Self {
+        if r.start >= r.end {
+            // Empty range — produce a filter that excludes every index.
+            DimFilter::Exact(usize::MAX)
+        } else {
+            DimFilter::Range {
+                start: r.start,
+                end: r.end - 1,
+            }
+        }
+    }
 }
 
 pub type TensorFilter = Vec<DimFilter>;

--- a/crates/cubek-test-utils/src/correctness/mod.rs
+++ b/crates/cubek-test-utils/src/correctness/mod.rs
@@ -1,5 +1,8 @@
 mod base;
 mod color_printer;
+mod print_tensor;
+pub(crate) mod render;
 
 pub use base::*;
-pub use color_printer::{TensorFilter, parse_tensor_filter};
+pub use color_printer::{DimFilter, TensorFilter, parse_tensor_filter};
+pub use print_tensor::{print_tensor, print_tensors};

--- a/crates/cubek-test-utils/src/correctness/print_tensor.rs
+++ b/crates/cubek-test-utils/src/correctness/print_tensor.rs
@@ -1,0 +1,32 @@
+use crate::config::config;
+use crate::correctness::render::print_tensors as render;
+use crate::HostData;
+
+/// Pretty-print one or two tensors through the unified renderer.
+///
+/// Two tensors of the same shape are rendered as a colored diff (cells red
+/// when `|a - b| > epsilon`, green otherwise). One tensor renders without
+/// color. Tensors with different shapes (or rank) are silently skipped.
+///
+/// No-op when `[print] enabled = false` in `cubek.toml`.
+///
+/// # Examples
+///
+/// ```ignore
+/// use cubek_test_utils::print_tensors;
+///
+/// // Single tensor — just pretty-print, no color.
+/// print_tensors("input", &[&host], None);
+///
+/// // Two tensors of the same shape — colored diff. Same path is used by
+/// // `assert_equals_approx` for actual-vs-expected.
+/// print_tensors("a vs b", &[&a, &b], Some(1e-3));
+/// ```
+pub fn print_tensors(label: &str, tensors: &[&HostData], epsilon: Option<f32>) {
+    render(&config().print, label, tensors, epsilon);
+}
+
+/// Backwards-compatible single-tensor helper. Delegates to [`print_tensors`].
+pub fn print_tensor(label: &str, host: &HostData) {
+    print_tensors(label, &[host], None);
+}

--- a/crates/cubek-test-utils/src/correctness/print_tensor.rs
+++ b/crates/cubek-test-utils/src/correctness/print_tensor.rs
@@ -1,6 +1,6 @@
+use crate::HostData;
 use crate::config::config;
 use crate::correctness::render::print_tensors as render;
-use crate::HostData;
 
 /// Pretty-print one or two tensors through the unified renderer.
 ///

--- a/crates/cubek-test-utils/src/correctness/render.rs
+++ b/crates/cubek-test-utils/src/correctness/render.rs
@@ -1,0 +1,451 @@
+//! Unified tensor renderer.
+//!
+//! One entry point: [`print_tensors`]. It takes a slice of one or two
+//! `HostData` references and renders them according to the active
+//! [`PrintSection`]. There is no separate "diff" path — comparing actual to
+//! expected and pretty-printing two same-shape tensors are the same call.
+//!
+//! Rules:
+//! - If `cfg.enabled` is `false`, this is a no-op.
+//! - If two tensors are passed and their ranks or shapes don't match, this
+//!   is a no-op too (we don't know how to align them).
+//! - With one tensor, color is off and Δ/ε are meaningless. With two, each
+//!   cell is colored by the per-element comparison against `epsilon`
+//!   (green = within ε, red = beyond).
+
+use crate::config::{PrintSection, PrintView};
+use crate::{DimFilter, HostData, TensorFilter};
+
+const RED: &str = "\x1b[31m";
+const GREEN: &str = "\x1b[32m";
+const RESET: &str = "\x1b[0m";
+
+/// Render one or two tensors. Caller passes `tensors.len() ∈ {1, 2}`. Two
+/// tensors implies a diff: cells colored by `|a - b| > epsilon`.
+///
+/// Silently skips if:
+/// - `cfg.enabled` is false,
+/// - `tensors.len()` is 0 or > 2,
+/// - two tensors have different ranks or shapes,
+/// - the configured filter's rank doesn't match the tensor rank.
+pub fn print_tensors(
+    cfg: &PrintSection,
+    label: &str,
+    tensors: &[&HostData],
+    epsilon: Option<f32>,
+) {
+    if !cfg.enabled || tensors.is_empty() || tensors.len() > 2 {
+        return;
+    }
+    let primary = tensors[0];
+    let other = tensors.get(1).copied();
+
+    if let Some(b) = other
+        && (b.shape.rank() != primary.shape.rank() || b.shape.as_slice() != primary.shape.as_slice())
+    {
+        return;
+    }
+
+    if !cfg.filter.is_empty() && cfg.filter.len() != primary.shape.rank() {
+        return;
+    }
+
+    let filter = if cfg.filter.is_empty() {
+        None
+    } else {
+        Some(cfg.filter.clone())
+    };
+    // ε isn't in the header — it's per-cell (each cell uses
+    // `max(epsilon, epsilon * |expected|)`), so a single number would lie.
+    println!("=== {label}  shape={:?} ===", primary.shape);
+
+    let eps = epsilon.unwrap_or(0.0);
+    match cfg.view {
+        PrintView::Table => render_table(cfg, primary, other, eps, filter.as_ref()),
+        PrintView::Lines => render_lines(cfg, primary, other, eps, filter.as_ref()),
+    }
+}
+
+// ---------- table view ----------
+
+fn render_table(
+    cfg: &PrintSection,
+    a: &HostData,
+    b: Option<&HostData>,
+    epsilon: f32,
+    filter: Option<&TensorFilter>,
+) {
+    let rank = a.shape.rank();
+    if rank == 0 {
+        return;
+    }
+
+    let cell = |full: &[usize]| -> String {
+        let av = a.get_f32(full);
+        match b {
+            None => format_value(av),
+            Some(rhs) => {
+                let bv = rhs.get_f32(full);
+                let cell_eps = (epsilon * bv).abs().max(epsilon);
+                let is_wrong = compare_pair(av, bv, cell_eps);
+                if cfg.fail_only && !is_wrong {
+                    // Blank out matching cells — the table layout still
+                    // pads them, so the surviving red cells stay aligned.
+                    return String::new();
+                }
+                let color = if is_wrong { RED } else { GREEN };
+                let text = if cfg.show_expected {
+                    format!("{}/{}", format_value(av), format_value(bv))
+                } else {
+                    format_value(av)
+                };
+                format!("{color}{text}{RESET}")
+            }
+        }
+    };
+
+    if rank == 1 {
+        let col_filter = filter.and_then(|f| f.first());
+        let cols = axis_indices(col_filter, a.shape[0]);
+        let rows = vec![0usize];
+        print_table(&rows, &cols, |_, c| cell(&[c]));
+    } else if rank == 2 {
+        let row_filter = filter.and_then(|f| f.first());
+        let col_filter = filter.and_then(|f| f.get(1));
+        let rows = axis_indices(row_filter, a.shape[0]);
+        let cols = axis_indices(col_filter, a.shape[1]);
+        print_table(&rows, &cols, |r, c| cell(&[r, c]));
+    } else {
+        let leading_dims = rank - 2;
+        let row_dim = a.shape[rank - 2];
+        let col_dim = a.shape[rank - 1];
+        let row_indices = axis_indices(filter.and_then(|f| f.get(rank - 2)), row_dim);
+        let col_indices = axis_indices(filter.and_then(|f| f.get(rank - 1)), col_dim);
+
+        let mut leading = vec![0usize; leading_dims];
+        let mut first = true;
+        loop {
+            let print_this = filter
+                .map(|f| leading_indices_match(&leading, f))
+                .unwrap_or(true);
+            if print_this {
+                if !first {
+                    println!();
+                }
+                println!("{}:", format_leading_label(&leading, rank));
+                print_table(&row_indices, &col_indices, |r, c| {
+                    let mut full = leading.clone();
+                    full.push(r);
+                    full.push(c);
+                    cell(&full)
+                });
+                first = false;
+            }
+            if !increment_lex(&mut leading, &a.shape.as_slice()[..leading_dims]) {
+                break;
+            }
+        }
+    }
+}
+
+// ---------- lines view ----------
+
+struct LineRow {
+    idx: String,
+    primary: String,
+    other: Option<String>,
+    /// Δ and ε strings, present iff this is a 2-tensor (diff) row.
+    delta: Option<String>,
+    epsilon: Option<String>,
+    is_wrong: bool,
+}
+
+fn render_lines(
+    cfg: &PrintSection,
+    a: &HostData,
+    b: Option<&HostData>,
+    epsilon: f32,
+    filter: Option<&TensorFilter>,
+) {
+    let mut rows: Vec<LineRow> = Vec::new();
+    for idx in a.iter_indices() {
+        if let Some(f) = filter
+            && !index_matches(&idx, f)
+        {
+            continue;
+        }
+        let av = a.get_f32(&idx);
+        match b {
+            None => {
+                rows.push(LineRow {
+                    idx: format_index(&idx),
+                    primary: format_value(av),
+                    other: None,
+                    delta: None,
+                    epsilon: None,
+                    is_wrong: false,
+                });
+            }
+            Some(rhs) => {
+                let bv = rhs.get_f32(&idx);
+                let cell_eps = (epsilon * bv).abs().max(epsilon);
+                let delta = (av - bv).abs();
+                let is_wrong = compare_pair(av, bv, cell_eps);
+                if cfg.fail_only && !is_wrong {
+                    continue;
+                }
+                rows.push(LineRow {
+                    idx: format_index(&idx),
+                    primary: format_value(av),
+                    other: Some(format_value(bv)),
+                    // Δ and ε are always shown in lines view. Suppressing
+                    // them is what the `table` view is for.
+                    delta: Some(format_value(delta)),
+                    epsilon: Some(format_value(cell_eps)),
+                    is_wrong,
+                });
+            }
+        }
+    }
+
+    if rows.is_empty() {
+        return;
+    }
+
+    // Column widths.
+    let idx_w = rows.iter().map(|r| r.idx.len()).max().unwrap_or(0);
+    let pri_w = rows.iter().map(|r| r.primary.len()).max().unwrap_or(0);
+    let oth_w = rows
+        .iter()
+        .filter_map(|r| r.other.as_ref().map(|s| s.len()))
+        .max()
+        .unwrap_or(0);
+    let dlt_w = rows
+        .iter()
+        .filter_map(|r| r.delta.as_ref().map(|s| s.len()))
+        .max()
+        .unwrap_or(0);
+    let eps_w = rows
+        .iter()
+        .filter_map(|r| r.epsilon.as_ref().map(|s| s.len()))
+        .max()
+        .unwrap_or(0);
+
+    let two = b.is_some();
+    let primary_label = if two { "got" } else { "value" };
+
+    // Header — Δ / ε / status are always present in 2-tensor lines view.
+    let mut header = format!("{:>idx_w$} | {:>pri_w$}", "index", primary_label);
+    if two {
+        header.push_str(&format!(
+            " | {:>oth_w$} | {:>dlt_w$} | {:>eps_w$} | status",
+            "expected", "Δ", "ε",
+        ));
+    }
+    println!("{header}");
+
+    let mut total = idx_w + pri_w + 3;
+    if two {
+        total += oth_w + 3 + dlt_w + 3 + eps_w + 3 + " | status".len();
+    }
+    println!("{}", "-".repeat(total));
+
+    for r in rows {
+        let color = if two {
+            if r.is_wrong { RED } else { GREEN }
+        } else {
+            ""
+        };
+        let reset = if two { RESET } else { "" };
+        let mut line = format!(
+            "{}{:>idx_w$} | {:>pri_w$}",
+            color, r.idx, r.primary,
+        );
+        if let Some(o) = r.other.as_ref() {
+            line.push_str(&format!(" | {:>oth_w$}", o));
+        }
+        if let Some(d) = r.delta.as_ref() {
+            line.push_str(&format!(" | {:>dlt_w$}", d));
+        }
+        if let Some(e) = r.epsilon.as_ref() {
+            line.push_str(&format!(" | {:>eps_w$}", e));
+        }
+        if two {
+            let status = if r.is_wrong { "FAIL" } else { "ok" };
+            line.push_str(&format!(" | {status}"));
+        }
+        line.push_str(reset);
+        println!("{line}");
+    }
+}
+
+// ---------- shared helpers ----------
+
+fn format_value(v: f32) -> String {
+    format!("{:.6}", v)
+}
+
+fn format_index(idx: &[usize]) -> String {
+    format!(
+        "[{}]",
+        idx.iter()
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// Returns `true` if `(a, b)` is a mismatch under `epsilon`. Mirrors
+/// `assert_equals_approx`'s NaN/Inf semantics.
+fn compare_pair(a: f32, b: f32, epsilon: f32) -> bool {
+    if a.is_nan() && b.is_nan() {
+        return false;
+    }
+    if a.is_nan() || b.is_nan() {
+        return true;
+    }
+    if a.is_infinite() && b.is_infinite() {
+        return a.signum() != b.signum();
+    }
+    (a - b).abs() > epsilon
+}
+
+fn axis_indices(f: Option<&DimFilter>, dim_size: usize) -> Vec<usize> {
+    match f {
+        None | Some(DimFilter::Any) => (0..dim_size).collect(),
+        Some(DimFilter::Exact(v)) => {
+            if *v < dim_size {
+                vec![*v]
+            } else {
+                Vec::new()
+            }
+        }
+        Some(DimFilter::Range { start, end }) => {
+            if *start >= dim_size {
+                Vec::new()
+            } else {
+                (*start..=(*end).min(dim_size.saturating_sub(1))).collect()
+            }
+        }
+    }
+}
+
+fn index_matches(index: &[usize], filter: &TensorFilter) -> bool {
+    for (dim, idx) in index.iter().enumerate() {
+        let f = filter.get(dim).unwrap_or(&DimFilter::Any);
+        match f {
+            DimFilter::Any => {}
+            DimFilter::Exact(v) => {
+                if idx != v {
+                    return false;
+                }
+            }
+            DimFilter::Range { start, end } => {
+                if idx < start || idx > end {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+fn leading_indices_match(leading: &[usize], filter: &TensorFilter) -> bool {
+    index_matches(leading, filter)
+}
+
+fn increment_lex(idx: &mut [usize], bounds: &[usize]) -> bool {
+    if idx.is_empty() {
+        return false;
+    }
+    for d in (0..idx.len()).rev() {
+        idx[d] += 1;
+        if idx[d] < bounds[d] {
+            return true;
+        }
+        idx[d] = 0;
+    }
+    false
+}
+
+fn format_leading_label(leading: &[usize], rank: usize) -> String {
+    let mut parts: Vec<String> = leading.iter().map(|i| i.to_string()).collect();
+    for _ in 0..(rank - leading.len()) {
+        parts.push("*".to_string());
+    }
+    format!("[{}]", parts.join(", "))
+}
+
+fn print_table<F>(rows: &[usize], cols: &[usize], mut cell: F)
+where
+    F: FnMut(usize, usize) -> String,
+{
+    if rows.is_empty() || cols.is_empty() {
+        return;
+    }
+    let mut max_width = 0;
+    for &r in rows {
+        for &c in cols {
+            max_width = max_width.max(visible_width(&cell(r, c)));
+        }
+    }
+    let label_width = cols
+        .iter()
+        .map(|c| c.to_string().len())
+        .max()
+        .unwrap_or(0);
+    max_width = max_width.max(label_width).max(2);
+
+    let row_label_width = rows
+        .iter()
+        .map(|r| r.to_string().len())
+        .max()
+        .unwrap_or(0)
+        .max(3);
+
+    let mut s = String::new();
+    s.push_str(&format!("{:>width$} |", "", width = row_label_width));
+    for &c in cols {
+        s.push_str(&format!(" {:>width$}", c, width = max_width));
+    }
+    s.push('\n');
+    s.push_str(&"-".repeat(row_label_width + 1));
+    s.push('+');
+    for _ in cols {
+        s.push_str(&"-".repeat(max_width + 1));
+    }
+    s.push('\n');
+
+    for &r in rows {
+        s.push_str(&format!("{:>width$} |", r, width = row_label_width));
+        for &c in cols {
+            let raw = cell(r, c);
+            let pad = max_width.saturating_sub(visible_width(&raw));
+            s.push(' ');
+            for _ in 0..pad {
+                s.push(' ');
+            }
+            s.push_str(&raw);
+        }
+        s.push('\n');
+    }
+    print!("{s}");
+}
+
+/// `len()` ignoring ANSI escapes, so colored cells still align with plain ones.
+fn visible_width(s: &str) -> usize {
+    let mut n = 0;
+    let mut iter = s.chars();
+    while let Some(ch) = iter.next() {
+        if ch == '\x1b' {
+            for c in iter.by_ref() {
+                if c == 'm' {
+                    break;
+                }
+            }
+        } else {
+            n += 1;
+        }
+    }
+    n
+}

--- a/crates/cubek-test-utils/src/correctness/render.rs
+++ b/crates/cubek-test-utils/src/correctness/render.rs
@@ -28,12 +28,7 @@ const RESET: &str = "\x1b[0m";
 /// - `tensors.len()` is 0 or > 2,
 /// - two tensors have different ranks or shapes,
 /// - the configured filter's rank doesn't match the tensor rank.
-pub fn print_tensors(
-    cfg: &PrintSection,
-    label: &str,
-    tensors: &[&HostData],
-    epsilon: Option<f32>,
-) {
+pub fn print_tensors(cfg: &PrintSection, label: &str, tensors: &[&HostData], epsilon: Option<f32>) {
     if !cfg.enabled || tensors.is_empty() || tensors.len() > 2 {
         return;
     }
@@ -41,7 +36,8 @@ pub fn print_tensors(
     let other = tensors.get(1).copied();
 
     if let Some(b) = other
-        && (b.shape.rank() != primary.shape.rank() || b.shape.as_slice() != primary.shape.as_slice())
+        && (b.shape.rank() != primary.shape.rank()
+            || b.shape.as_slice() != primary.shape.as_slice())
     {
         return;
     }
@@ -257,10 +253,7 @@ fn render_lines(
             ""
         };
         let reset = if two { RESET } else { "" };
-        let mut line = format!(
-            "{}{:>idx_w$} | {:>pri_w$}",
-            color, r.idx, r.primary,
-        );
+        let mut line = format!("{}{:>idx_w$} | {:>pri_w$}", color, r.idx, r.primary,);
         if let Some(o) = r.other.as_ref() {
             line.push_str(&format!(" | {:>oth_w$}", o));
         }
@@ -389,11 +382,7 @@ where
             max_width = max_width.max(visible_width(&cell(r, c)));
         }
     }
-    let label_width = cols
-        .iter()
-        .map(|c| c.to_string().len())
-        .max()
-        .unwrap_or(0);
+    let label_width = cols.iter().map(|c| c.to_string().len()).max().unwrap_or(0);
     max_width = max_width.max(label_width).max(2);
 
     let row_label_width = rows

--- a/crates/cubek-test-utils/src/lib.rs
+++ b/crates/cubek-test-utils/src/lib.rs
@@ -1,7 +1,12 @@
+mod config;
 mod correctness;
 mod test_mode;
 mod test_tensor;
 
-pub use correctness::{assert_equals_approx, assert_equals_approx_in_slice};
+pub use config::{CubekConfig, PrintSection, PrintView, TestPolicy, TestSection, config};
+pub use correctness::{
+    DimFilter, TensorFilter, assert_equals_approx, assert_equals_approx_in_slice,
+    parse_tensor_filter, print_tensor, print_tensors,
+};
 pub use test_mode::*;
 pub use test_tensor::*;

--- a/crates/cubek-test-utils/src/test_mode/base.rs
+++ b/crates/cubek-test-utils/src/test_mode/base.rs
@@ -1,173 +1,67 @@
-//! # Test Mode
+//! Test-mode policy.
 //!
-//! Control how tests handle numerical and compilation errors via the environment variable
-//! `CUBE_TEST_MODE`.
-//!
-//! ## Modes
-//! - `Correct` (default): Numerical errors fail the test, compilation errors are ignored.
-//! - `Strict`: Both numerical and compilation errors fail the test.
-//! - `Print { filter, fail_only }`:
-//!     - `printall:<filter>` — all tests fail and matching elements are printed.
-//!     - `printfail:<filter>` — only numerical errors fail and matching elements are printed.
-//!
-//! ## Filter Expressions
-//! - The filter is **optional**. If omitted, all elements of the tensor are included.
-//! - When specified, it is a comma-separated list of dimensions, supporting:
-//!     - `.` to indicate a wildcard (all indices along that dimension),  
-//!     - `N` for a single index,  
-//!     - `M-K` for a range of indices.
-//! - Example for a 4D tensor: `.,.,10-20,30` selects all elements where the 3rd dimension
-//!   is 10–20 and the 4th dimension is 30, any values for the first two dimensions.
-//! - **Important:** The number of entries in the filter must match the rank of the tensor.
-//!
-//! ## Examples
-//!
-//! ```bash
-//! # Default mode: only numerical errors fail
-//! export CUBE_TEST_MODE=Correct
-//!
-//! # Strict mode: all errors fail
-//! export CUBE_TEST_MODE=Strict
-//!
-//! # Print all elements (no filter specified)
-//! export CUBE_TEST_MODE=PrintAll
-//!
-//! # Print all elements in a subset of dimensions
-//! export CUBE_TEST_MODE=PrintAll:.,10-20
-//!
-//! # Print only failing numerical elements
-//! export CUBE_TEST_MODE=PrintFail:.,10-20
-//! ```
+//! Reads `cubek.toml` (see `crate::config`) once and decides whether each
+//! test outcome should `Accept` or `Reject`. The TOML's `[test] policy`
+//! field controls the pass/fail logic; the `[print]` section drives what
+//! gets dumped to stdout (in `correctness::render`).
 
-use crate::{
-    TestDecision, TestOutcome, ValidationResult,
-    correctness::{TensorFilter, parse_tensor_filter},
-};
+use crate::config::{TestPolicy, config};
+use crate::{TestDecision, TestOutcome, ValidationResult};
 
-const CUBE_TEST_MODE_ENV: &str = "CUBE_TEST_MODE";
+/// Decide whether a test outcome passes or fails under the active policy.
+pub fn decide(outcome: TestOutcome) -> TestDecision {
+    use TestDecision::*;
+    use TestOutcome::*;
+    use ValidationResult::*;
 
-#[derive(Default, Debug, Clone)]
-pub enum TestMode {
-    #[default]
-    /// Numerical errors cause the test to fail.
-    /// Compilation errors are accepted (do not fail the test).
-    Correct,
+    let cfg = config();
+    let print_force_fail = cfg.print.enabled && cfg.print.force_fail;
 
-    /// Both numerical and compilation errors cause the test to fail.
-    Strict,
-
-    /// All tests can be printed according to the given `filter`.
-    /// `fail_only = true`: only tests with numerical errors are marked as failed and printed.
-    /// `fail_only = false`: all tests are marked as failed and printed.
-    Print {
-        filter: TensorFilter,
-        fail_only: bool,
-    },
-
-    /// Fail only if the test successfully runs.
-    /// Compilation failures are ignored.
-    ///
-    /// Helpful to isolate relevant tests
-    ///
-    /// Note: if a panic happens inside the kernel this may give false positives.
-    FailIfRun,
-}
-
-impl TestMode {
-    pub fn decide(&self, outcome: TestOutcome) -> TestDecision {
-        use TestDecision::*;
-        use TestMode::*;
-        use TestOutcome::*;
-        use ValidationResult::*;
-
-        match self {
-            Correct => match outcome {
-                Validated(result) => match result {
-                    Pass => Accept,
-                    Fail(reason) => Reject(reason),
-                    Error(reason) => Reject(reason),
-                    Skipped(_) => Accept,
-                },
-                CompileError(_) => Accept,
-            },
-            Strict => match outcome {
-                Validated(result) => match result {
-                    Pass => Accept,
-                    Fail(reason) => Reject(reason),
-                    Error(reason) => Reject(reason),
-                    Skipped(_) => Accept,
-                },
-                CompileError(reason) => Reject(reason),
-            },
-            Print {
-                filter: _,
-                fail_only,
-            } => match outcome {
-                Validated(result) => match result {
-                    Pass => {
-                        if *fail_only {
-                            Accept
-                        } else {
-                            Reject("printed".into())
-                        }
-                    }
-                    Fail(reason) => Reject(reason),
-                    Error(reason) => Reject(reason),
-                    Skipped(content) => Reject(content),
-                },
-
-                CompileError(reason) => {
-                    if *fail_only {
-                        Accept
+    match cfg.test.policy {
+        TestPolicy::Correct => match outcome {
+            Validated(result) => match result {
+                Pass => {
+                    if print_force_fail {
+                        Reject("print mode: tensors dumped".into())
                     } else {
-                        Reject(reason)
+                        Accept
                     }
                 }
+                Fail(reason) => Reject(reason),
+                Error(reason) => Reject(reason),
+                Skipped(_) => Accept,
             },
-            FailIfRun => match outcome {
-                Validated(result) => match result {
-                    Pass => Reject("Actually passed, but FailIfRun mode activated".to_string()),
-                    Fail(_) => Accept,
-                    Error(_) => Accept,
-                    Skipped(_) => Accept,
-                },
-                CompileError(_) => Accept,
-            },
-        }
-    }
-}
-
-pub fn current_test_mode() -> TestMode {
-    let val = match std::env::var(CUBE_TEST_MODE_ENV) {
-        Ok(v) => v.to_lowercase(),
-        Err(_) => return TestMode::Correct,
-    };
-
-    if let Some(print_mode) = val.strip_prefix("printall") {
-        parse_print_mode(print_mode, false)
-    } else if let Some(print_mode) = val.strip_prefix("printfail") {
-        parse_print_mode(print_mode, true)
-    } else if val == "strict" {
-        TestMode::Strict
-    } else if val == "failifrun" {
-        TestMode::FailIfRun
-    } else {
-        TestMode::Correct
-    }
-}
-
-fn parse_print_mode(suffix: &str, fail_only: bool) -> TestMode {
-    let filter = if let Some(rest) = suffix.strip_prefix(':') {
-        match parse_tensor_filter(rest) {
-            Ok(f) => f,
-            Err(e) => {
-                eprintln!("Invalid print filter '{}': {}", rest, e);
-                vec![]
+            CompileError(reason) => {
+                if print_force_fail {
+                    Reject(reason)
+                } else {
+                    Accept
+                }
             }
-        }
-    } else {
-        vec![]
-    };
-
-    TestMode::Print { filter, fail_only }
+        },
+        TestPolicy::Strict => match outcome {
+            Validated(result) => match result {
+                Pass => {
+                    if print_force_fail {
+                        Reject("print mode: tensors dumped".into())
+                    } else {
+                        Accept
+                    }
+                }
+                Fail(reason) => Reject(reason),
+                Error(reason) => Reject(reason),
+                Skipped(reason) => Reject(reason),
+            },
+            CompileError(reason) => Reject(reason),
+        },
+        TestPolicy::FailIfRun => match outcome {
+            Validated(result) => match result {
+                Pass => Reject("Actually passed, but fail-if-run policy active".into()),
+                Fail(_) => Accept,
+                Error(_) => Accept,
+                Skipped(_) => Accept,
+            },
+            CompileError(_) => Accept,
+        },
+    }
 }

--- a/crates/cubek-test-utils/src/test_mode/result.rs
+++ b/crates/cubek-test-utils/src/test_mode/result.rs
@@ -20,7 +20,7 @@
 //!      - `Reject(String)`: test fails.  
 //!    - Call [`TestDecision::enforce`] to actually fail the test.
 
-use crate::current_test_mode;
+use crate::test_mode::base::decide;
 use std::fmt::Display;
 
 #[derive(Debug)]
@@ -59,17 +59,19 @@ pub enum TestOutcome {
 impl TestOutcome {
     /// Apply the current test mode to this outcome and fail the test if rejected.
     ///
-    /// This is a convenience wrapper around
-    /// `current_test_mode().decide(self).enforce()`.
+    /// Convenience wrapper for `decide(self).enforce()` — applies the
+    /// active test policy (from `cubek.toml`) to this outcome and fails the
+    /// test if the decision is `Reject`.
     ///
     /// # Example
     ///
     /// ```ignore
     /// let outcome = assert_equals_approx(&actual, &expected, 0.001).as_test_outcome();
-    /// outcome.enforce(); // panics if TestMode rejects it
+    /// outcome.enforce(); // panics if the active policy rejects it
     /// ```
+    #[track_caller]
     pub fn enforce(self) {
-        current_test_mode().decide(self).enforce();
+        decide(self).enforce();
     }
 }
 
@@ -86,6 +88,7 @@ pub enum TestDecision {
 impl TestDecision {
     /// Actually asserts the test according to the decision.
     /// Panics if the test is rejected.
+    #[track_caller]
     pub fn enforce(self) {
         match self {
             TestDecision::Accept => {}

--- a/crates/cubek-test-utils/src/test_tensor/base.rs
+++ b/crates/cubek-test-utils/src/test_tensor/base.rs
@@ -383,9 +383,7 @@ impl TestInputBuilder {
             vec![start]
         } else {
             let step = (end - start) / (num_elems - 1) as f32;
-            (0..num_elems)
-                .map(|i| start + step * i as f32)
-                .collect()
+            (0..num_elems).map(|i| start + step * i as f32).collect()
         };
         self.finalize(DataKind::Custom { data })
     }

--- a/crates/cubek-test-utils/src/test_tensor/base.rs
+++ b/crates/cubek-test-utils/src/test_tensor/base.rs
@@ -287,7 +287,7 @@ pub enum Distribution {
 ///
 /// let (handle, host) = TestInput::builder(client, [4, 4])
 ///     .stride(StrideSpec::ColMajor)
-///     .uniform(/* seed */ 0, -1.0, 1.0)
+///     .uniform( 0, -1.0, 1.0)
 ///     .generate_with_f32_host_data();
 /// ```
 pub struct TestInputBuilder {

--- a/crates/cubek-test-utils/src/test_tensor/base.rs
+++ b/crates/cubek-test-utils/src/test_tensor/base.rs
@@ -7,13 +7,14 @@ use cubecl::{
     zspace::{Shape, Strides},
 };
 use cubecl_common::quant::scheme::QuantScheme;
-use cubek_quant::scheme::{QuantLevel, QuantStore};
+use cubek_quant::scheme::QuantStore;
 
 use crate::test_tensor::{
     arange::build_arange,
     custom::build_custom,
     eye::build_eye,
     host_data::{HostData, HostDataType},
+    quant::apply_quantization,
     random::build_random,
     strides::StrideSpec,
     zeros::build_zeros,
@@ -124,6 +125,19 @@ pub enum DataKind {
 }
 
 impl TestInput {
+    /// Start a fluent builder for a test input.
+    ///
+    /// Defaults: `dtype = f32`, `stride = RowMajor`. Call `.dtype(_)` /
+    /// `.stride(_)` to override, then a finalizer such as `.arange()`,
+    /// `.eye()`, `.zeros()`, `.uniform(seed, lo, hi)`, `.bernoulli(seed, p)`,
+    /// or `.custom(data)` to produce a [`TestInput`] ready to generate.
+    pub fn builder(
+        client: ComputeClient<TestRuntime>,
+        shape: impl Into<Shape>,
+    ) -> TestInputBuilder {
+        TestInputBuilder::new(client, shape.into())
+    }
+
     pub fn new(
         client: ComputeClient<TestRuntime>,
         shape: impl Into<Shape>,
@@ -175,86 +189,7 @@ impl TestInput {
         };
 
         if let InputDataType::Quantized(scheme) = input_dtype {
-            let original_shape = tensor.handle.shape().clone();
-
-            // Derive the scale tensor from the quant value's range. For
-            // `QuantLevel::Tensor` a single scale is used; for
-            // `QuantLevel::Block` we compute a per-block scale from the host
-            // data so each block fully uses the quant range without clipping.
-            let (scales_shape, scales_data) = compute_input_scales(&tensor.host, &scheme);
-            let scale_handle = TestInput::new(
-                client.clone(),
-                scales_shape.clone(),
-                InputDataType::Standard(f32::as_type_native_unchecked().storage_type()),
-                StrideSpec::RowMajor,
-                DataKind::Custom { data: scales_data },
-            )
-            .generate();
-
-            // Determine the correct storage type for the quantized output buffer
-            let output_storage_type = match &scheme.store {
-                QuantStore::PackedU32(_) => {
-                    StorageType::Scalar(ElemType::UInt(cubecl::ir::UIntKind::U32))
-                }
-                QuantStore::PackedNative(_) | QuantStore::Native => {
-                    StorageType::Scalar(ElemType::from_quant_value(scheme.value))
-                }
-            };
-
-            let mut quant_shape = original_shape.clone();
-            let num_quants = scheme.num_quants();
-            // Only divide last dim for PackedU32/PackedNative; Native stores 1:1
-            match &scheme.store {
-                QuantStore::PackedU32(_) | QuantStore::PackedNative(_) => {
-                    if num_quants > 1 {
-                        let last_dim = quant_shape.len() - 1;
-                        quant_shape[last_dim] /= num_quants;
-                    }
-                }
-                QuantStore::Native => {}
-            }
-
-            let output_handle = TestInput::new(
-                client.clone(),
-                quant_shape,
-                InputDataType::Standard(output_storage_type),
-                StrideSpec::RowMajor,
-                DataKind::Zeros,
-            )
-            .generate();
-
-            let out_scale_handle = TestInput::new(
-                client.clone(),
-                scales_shape,
-                InputDataType::Standard(f32::as_type_native_unchecked().storage_type()),
-                StrideSpec::RowMajor,
-                DataKind::Zeros,
-            )
-            .generate();
-
-            let input_elem = match tensor.handle.dtype {
-                StorageType::Scalar(elem) => elem,
-                _ => panic!("Unsupported storage type {:?}", tensor.handle.dtype),
-            };
-
-            cubek_quant::quantize::launch_ref(
-                &client,
-                tensor.handle.binding(),
-                output_handle.clone().binding(),
-                scale_handle.binding(),
-                out_scale_handle.clone().binding(),
-                &scheme,
-                input_elem,
-            )
-            .expect("Quantization failed");
-
-            // Keep the packed shape on the handle
-            tensor.handle = output_handle;
-            tensor.quantization = Some(QuantizationInfo {
-                scheme,
-                scale: out_scale_handle,
-                shape: original_shape,
-            });
+            apply_quantization(&client, &mut tensor, scheme);
         }
 
         tensor
@@ -310,82 +245,6 @@ impl TestInput {
     }
 }
 
-/// Compute the scale tensor shape and values for a quantized input.
-///
-/// For `QuantLevel::Tensor` this returns a single-element scale based on the
-/// quant value's range (assumes input in [-1, 1]). For `QuantLevel::Block`
-/// each block gets its own scale derived from `max(|value|)` in that block,
-/// matching the reference pattern used by the cubek-quant symmetric tests.
-fn compute_input_scales(host: &HostData, scheme: &QuantScheme) -> (Shape, Vec<f32>) {
-    let (q_min, q_max) = scheme.value.range();
-    let max_abs_q = q_max.abs().max(q_min.abs());
-
-    match &scheme.level {
-        QuantLevel::Tensor => {
-            let shape: Shape = core::iter::repeat_n(1, host.shape.len()).collect();
-            (shape, vec![1.0 / max_abs_q])
-        }
-        QuantLevel::Block(block_size) => {
-            let rank = host.shape.len();
-            let block_dims: Vec<usize> = block_size
-                .to_dim_vec(rank)
-                .into_iter()
-                .map(|b| b as usize)
-                .collect();
-
-            let scales_shape: Shape = host
-                .shape
-                .iter()
-                .zip(block_dims.iter())
-                .map(|(d, b)| {
-                    assert!(
-                        d.is_multiple_of(*b),
-                        "Block size {b} must divide dimension {d}",
-                    );
-                    d / b
-                })
-                .collect();
-
-            let num_blocks: usize = scales_shape.iter().product();
-            let block_elem_count: usize = block_dims.iter().product();
-
-            let mut scales = Vec::with_capacity(num_blocks);
-            let mut data_idx = vec![0usize; rank];
-            for block_linear in 0..num_blocks {
-                // Decode the flat block index into per-dim block indices.
-                let mut block_idx = vec![0usize; rank];
-                let mut rem = block_linear;
-                for d in (0..rank).rev() {
-                    block_idx[d] = rem % scales_shape[d];
-                    rem /= scales_shape[d];
-                }
-
-                let mut block_max = 0.0_f32;
-                for elem_linear in 0..block_elem_count {
-                    let mut rem = elem_linear;
-                    for d in (0..rank).rev() {
-                        let within = rem % block_dims[d];
-                        data_idx[d] = block_idx[d] * block_dims[d] + within;
-                        rem /= block_dims[d];
-                    }
-                    block_max = block_max.max(host.get_f32(&data_idx).abs());
-                }
-
-                // Guard against an all-zero block producing a zero scale that
-                // would divide-by-zero inside the quantize kernel.
-                let scale = if block_max > 0.0 {
-                    block_max / max_abs_q
-                } else {
-                    1.0 / max_abs_q
-                };
-                scales.push(scale);
-            }
-
-            (scales_shape, scales)
-        }
-    }
-}
-
 pub struct BaseInputSpec {
     pub client: ComputeClient<TestRuntime>,
     pub shape: Shape,
@@ -406,8 +265,128 @@ pub struct RandomInputSpec {
 
 #[derive(Copy, Clone)]
 pub enum Distribution {
-    // lower, upper bounds
+    /// Uniform random over `[lower, upper]`.
     Uniform(f32, f32),
-    // prob
+    /// Bernoulli random with probability `prob` of `1`.
     Bernoulli(f32),
+    /// Normal (Gaussian) random with the given `mean` and `std`.
+    Normal { mean: f32, std: f32 },
+}
+
+/// Fluent builder for [`TestInput`].
+///
+/// Use [`TestInput::builder`] to start one. The builder holds the shape,
+/// dtype, and stride spec. Call a finalizer (`arange`, `eye`, `zeros`,
+/// `uniform`, `bernoulli`, `random`, `custom`) to produce a [`TestInput`]
+/// ready to generate a tensor handle, host data, or test tensor.
+///
+/// # Example
+///
+/// ```ignore
+/// use cubek_test_utils::{TestInput, StrideSpec, Distribution};
+///
+/// let (handle, host) = TestInput::builder(client, [4, 4])
+///     .stride(StrideSpec::ColMajor)
+///     .uniform(/* seed */ 0, -1.0, 1.0)
+///     .generate_with_f32_host_data();
+/// ```
+pub struct TestInputBuilder {
+    client: ComputeClient<TestRuntime>,
+    shape: Shape,
+    dtype: Option<InputDataType>,
+    stride_spec: StrideSpec,
+}
+
+impl TestInputBuilder {
+    fn new(client: ComputeClient<TestRuntime>, shape: Shape) -> Self {
+        Self {
+            client,
+            shape,
+            dtype: None,
+            stride_spec: StrideSpec::RowMajor,
+        }
+    }
+
+    /// Override the dtype. Defaults to f32.
+    pub fn dtype(mut self, dtype: impl Into<InputDataType>) -> Self {
+        self.dtype = Some(dtype.into());
+        self
+    }
+
+    /// Override the stride layout. Defaults to [`StrideSpec::RowMajor`].
+    pub fn stride(mut self, stride_spec: StrideSpec) -> Self {
+        self.stride_spec = stride_spec;
+        self
+    }
+
+    fn finalize(self, data_kind: DataKind) -> TestInput {
+        let dtype = self.dtype.unwrap_or_else(|| {
+            InputDataType::Standard(f32::as_type_native_unchecked().storage_type())
+        });
+        TestInput::new(self.client, self.shape, dtype, self.stride_spec, data_kind)
+    }
+
+    /// `0, 1, 2, …` in row-major order.
+    pub fn arange(self) -> TestInput {
+        self.finalize(DataKind::Arange { scale: None })
+    }
+
+    /// `arange` with each value multiplied by `scale`.
+    pub fn arange_scaled(self, scale: f32) -> TestInput {
+        self.finalize(DataKind::Arange { scale: Some(scale) })
+    }
+
+    /// Identity matrix (1 on the diagonal, 0 elsewhere).
+    pub fn eye(self) -> TestInput {
+        self.finalize(DataKind::Eye)
+    }
+
+    /// All-zeros tensor.
+    pub fn zeros(self) -> TestInput {
+        self.finalize(DataKind::Zeros)
+    }
+
+    /// Random tensor with a custom [`Distribution`].
+    pub fn random(self, seed: u64, distribution: Distribution) -> TestInput {
+        self.finalize(DataKind::Random { seed, distribution })
+    }
+
+    /// Uniform random in `[lo, hi]`.
+    pub fn uniform(self, seed: u64, lo: f32, hi: f32) -> TestInput {
+        self.random(seed, Distribution::Uniform(lo, hi))
+    }
+
+    /// Bernoulli random with probability `p` of 1.
+    pub fn bernoulli(self, seed: u64, p: f32) -> TestInput {
+        self.random(seed, Distribution::Bernoulli(p))
+    }
+
+    /// Normal (Gaussian) random with the given `mean` and `std`.
+    pub fn normal(self, seed: u64, mean: f32, std: f32) -> TestInput {
+        self.random(seed, Distribution::Normal { mean, std })
+    }
+
+    /// Tensor populated from an explicit row-major `Vec<f32>`.
+    pub fn custom(self, data: Vec<f32>) -> TestInput {
+        self.finalize(DataKind::Custom { data })
+    }
+
+    /// Evenly-spaced values from `start` to `end` inclusive, populated in
+    /// row-major order. The number of points equals the tensor's element count.
+    ///
+    /// Equivalent to NumPy's `np.linspace(start, end, num=shape.numel()).reshape(shape)`.
+    pub fn linspace(self, start: f32, end: f32) -> TestInput {
+        let num_elems: usize = self.shape.iter().product();
+        let data = if num_elems == 0 {
+            Vec::new()
+        } else if num_elems == 1 {
+            vec![start]
+        } else {
+            let step = (end - start) / (num_elems - 1) as f32;
+            (0..num_elems)
+                .map(|i| start + step * i as f32)
+                .collect()
+        };
+        self.finalize(DataKind::Custom { data })
+    }
 }

--- a/crates/cubek-test-utils/src/test_tensor/host_data.rs
+++ b/crates/cubek-test-utils/src/test_tensor/host_data.rs
@@ -50,6 +50,27 @@ impl HostDataVec {
             _ => panic!("Can't get as i32"),
         }
     }
+
+    pub fn try_get_f32(&self, i: usize) -> Option<f32> {
+        match self {
+            HostDataVec::F32(items) => items.get(i).copied(),
+            _ => None,
+        }
+    }
+
+    pub fn try_get_i32(&self, i: usize) -> Option<i32> {
+        match self {
+            HostDataVec::I32(items) => items.get(i).copied(),
+            _ => None,
+        }
+    }
+
+    pub fn try_get_bool(&self, i: usize) -> Option<bool> {
+        match self {
+            HostDataVec::Bool(items) => items.get(i).copied(),
+            _ => None,
+        }
+    }
 }
 
 impl HostData {
@@ -128,6 +149,59 @@ impl HostData {
         self.data.get_bool(self.strided_index(index))
     }
 
+    pub fn get_i32(&self, index: &[usize]) -> i32 {
+        self.data.get_i32(self.strided_index(index))
+    }
+
+    /// Like [`get_f32`], but returns `None` if the underlying data isn't `F32`
+    /// (or the index is out of bounds), instead of panicking.
+    pub fn try_get_f32(&self, index: &[usize]) -> Option<f32> {
+        self.data.try_get_f32(self.strided_index(index))
+    }
+
+    pub fn try_get_i32(&self, index: &[usize]) -> Option<i32> {
+        self.data.try_get_i32(self.strided_index(index))
+    }
+
+    pub fn try_get_bool(&self, index: &[usize]) -> Option<bool> {
+        self.data.try_get_bool(self.strided_index(index))
+    }
+
+    /// Iterate every logical index in row-major order, yielding the index vector.
+    ///
+    /// Useful when callers want to walk a non-contiguous tensor without
+    /// re-implementing the rank recursion themselves.
+    pub fn iter_indices(&self) -> impl Iterator<Item = Vec<usize>> + '_ {
+        IndexIter::new(self.shape.as_slice().to_vec())
+    }
+
+    /// Iterate `(index, f32 value)` pairs in row-major order.
+    /// Panics if the underlying data isn't `F32`.
+    pub fn iter_indexed_f32(&self) -> impl Iterator<Item = (Vec<usize>, f32)> + '_ {
+        self.iter_indices().map(move |idx| {
+            let v = self.get_f32(&idx);
+            (idx, v)
+        })
+    }
+
+    /// Iterate `(index, i32 value)` pairs in row-major order.
+    /// Panics if the underlying data isn't `I32`.
+    pub fn iter_indexed_i32(&self) -> impl Iterator<Item = (Vec<usize>, i32)> + '_ {
+        self.iter_indices().map(move |idx| {
+            let v = self.get_i32(&idx);
+            (idx, v)
+        })
+    }
+
+    /// Iterate `(index, bool value)` pairs in row-major order.
+    /// Panics if the underlying data isn't `Bool`.
+    pub fn iter_indexed_bool(&self) -> impl Iterator<Item = (Vec<usize>, bool)> + '_ {
+        self.iter_indices().map(move |idx| {
+            let v = self.get_bool(&idx);
+            (idx, v)
+        })
+    }
+
     fn strided_index(&self, index: &[usize]) -> usize {
         let mut i = 0usize;
         for (d, idx) in index.iter().enumerate() {
@@ -136,26 +210,117 @@ impl HostData {
         i
     }
 
+    /// Render the tensor as one or more 2-D tables.
+    ///
+    /// - rank 1: a single row.
+    /// - rank 2: a table.
+    /// - rank ≥ 3: one labeled table per combination of leading-dim indices
+    ///   (the last two dims are always the row/col axes).
     pub fn pretty_print(&self) -> String {
-        let (rows, cols) = rows_cols(&self.shape);
-
-        pretty_print_table(rows, cols, |row, col| {
-            let idx = self.strided_index_2d(row, col);
-
-            match &self.data {
-                HostDataVec::I32(_) => self.data.get_i32(idx).to_string(),
-                HostDataVec::F32(_) => format!("{:.3}", self.data.get_f32(idx)),
-                HostDataVec::Bool(_) => self.data.get_bool(idx).to_string(),
-            }
-        })
+        self.pretty_print_filtered(None)
     }
 
-    fn strided_index_2d(&self, row: usize, col: usize) -> usize {
-        match self.shape.rank() {
-            1 => self.strided_index(&[col]),
-            2 => self.strided_index(&[row, col]),
-            r => panic!("pretty_print only supports 1D and 2D tensors, got rank {r}"),
+    /// Like [`pretty_print`], but only prints slices whose leading-dim indices
+    /// match the filter. Wildcards (`DimFilter::Any`) iterate every value.
+    ///
+    /// `filter` accepts both `Vec<std::ops::Range<usize>>` and the canonical
+    /// `TensorFilter` (the `CUBE_TEST_MODE` `M-K` syntax).
+    pub fn pretty_print_slice<I>(&self, filter: I) -> String
+    where
+        I: IntoIterator,
+        I::Item: Into<crate::DimFilter>,
+    {
+        let f: crate::TensorFilter = filter.into_iter().map(Into::into).collect();
+        assert_eq!(
+            f.len(),
+            self.shape.rank(),
+            "pretty_print_slice: filter rank ({}) must match tensor rank ({})",
+            f.len(),
+            self.shape.rank(),
+        );
+        self.pretty_print_filtered(Some(f))
+    }
+
+    fn pretty_print_filtered(&self, filter: Option<crate::TensorFilter>) -> String {
+        let rank = self.shape.rank();
+        match rank {
+            0 => String::new(),
+            1 => {
+                // Single-row table; the only filter entry filters the col axis.
+                let col_filter = filter.as_ref().and_then(|f| f.first());
+                let cols = axis_indices(col_filter, self.shape[0]);
+                let rows = vec![0usize];
+                pretty_print_table(&rows, &cols, |_row_label, col_label| {
+                    self.cell_string(self.strided_index(&[col_label]))
+                })
+            }
+            2 => {
+                // Last two filter entries (here filter[0], filter[1]) drive
+                // row and col selection respectively.
+                let row_filter = filter.as_ref().and_then(|f| f.first());
+                let col_filter = filter.as_ref().and_then(|f| f.get(1));
+                let rows = axis_indices(row_filter, self.shape[0]);
+                let cols = axis_indices(col_filter, self.shape[1]);
+                pretty_print_table(&rows, &cols, |row_label, col_label| {
+                    self.cell_string(self.strided_index(&[row_label, col_label]))
+                })
+            }
+            _ => self.print_higher_rank(filter.as_ref()),
         }
+    }
+
+    fn cell_string(&self, idx: usize) -> String {
+        match &self.data {
+            HostDataVec::I32(_) => self.data.get_i32(idx).to_string(),
+            HostDataVec::F32(_) => format!("{:.3}", self.data.get_f32(idx)),
+            HostDataVec::Bool(_) => self.data.get_bool(idx).to_string(),
+        }
+    }
+
+    fn print_higher_rank(&self, filter: Option<&crate::TensorFilter>) -> String {
+        let rank = self.shape.rank();
+        let leading_dims = rank - 2;
+        let row_dim = self.shape[rank - 2];
+        let col_dim = self.shape[rank - 1];
+
+        // Filter entries for the row and col axes (the last two), if any.
+        let row_filter = filter.and_then(|f| f.get(rank - 2));
+        let col_filter = filter.and_then(|f| f.get(rank - 1));
+        let row_indices = axis_indices(row_filter, row_dim);
+        let col_indices = axis_indices(col_filter, col_dim);
+
+        let mut out = String::new();
+        let mut leading = vec![0usize; leading_dims];
+
+        // Iterate every leading-index combination, lexicographically.
+        loop {
+            let print_this = match filter {
+                None => true,
+                Some(f) => leading_indices_match(&leading, f),
+            };
+
+            if print_this {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(&format!("{}:\n", format_leading_label(&leading, rank)));
+
+                let table = pretty_print_table(&row_indices, &col_indices, |row, col| {
+                    let mut full = leading.clone();
+                    full.push(row);
+                    full.push(col);
+                    self.cell_string(self.strided_index(&full))
+                });
+                out.push_str(&table);
+            }
+
+            // Increment the leading-index counter.
+            if !increment_lex(&mut leading, &self.shape.as_slice()[..leading_dims]) {
+                break;
+            }
+        }
+
+        out
     }
 }
 
@@ -168,73 +333,220 @@ pub fn pretty_print_zip(tensors: &[&HostData]) -> String {
         assert_eq!(t.shape.as_slice(), dims, "All tensors must have same shape");
     }
 
-    let (rows, cols) = rows_cols(&tensors[0].shape);
+    let rank = tensors[0].shape.rank();
 
-    pretty_print_table(rows, cols, |row, col| {
+    let cell = |full: &[usize]| -> String {
         let mut parts = Vec::with_capacity(tensors.len());
-
         for t in tensors {
-            let idx = t.strided_index_2d(row, col);
-
-            let val = match &t.data {
-                HostDataVec::I32(_) => t.data.get_i32(idx).to_string(),
-                HostDataVec::F32(_) => format!("{:.3}", t.data.get_f32(idx)),
-                HostDataVec::Bool(_) => t.data.get_bool(idx).to_string(),
-            };
-
-            parts.push(val);
+            let idx = t.strided_index(full);
+            parts.push(t.cell_string(idx));
         }
-
         parts.join("/")
-    })
-}
+    };
 
-fn rows_cols(shape: &Shape) -> (usize, usize) {
-    match shape.rank() {
-        1 => (1, shape.as_slice()[0]),
-        2 => {
-            let d = shape.as_slice();
-            (d[0], d[1])
+    match rank {
+        0 => String::new(),
+        1 => {
+            let cols: Vec<usize> = (0..dims[0]).collect();
+            pretty_print_table(&[0], &cols, |_, col| cell(&[col]))
         }
-        r => panic!("pretty_print only supports 1D and 2D tensors, got rank {r}"),
+        2 => {
+            let rows: Vec<usize> = (0..dims[0]).collect();
+            let cols: Vec<usize> = (0..dims[1]).collect();
+            pretty_print_table(&rows, &cols, |row, col| cell(&[row, col]))
+        }
+        _ => {
+            let leading_dims = rank - 2;
+            let rows: Vec<usize> = (0..dims[rank - 2]).collect();
+            let cols: Vec<usize> = (0..dims[rank - 1]).collect();
+            let mut out = String::new();
+            let mut leading = vec![0usize; leading_dims];
+            loop {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(&format!("{}:\n", format_leading_label(&leading, rank)));
+                let table = pretty_print_table(&rows, &cols, |row, col| {
+                    let mut full = leading.clone();
+                    full.push(row);
+                    full.push(col);
+                    cell(&full)
+                });
+                out.push_str(&table);
+
+                if !increment_lex(&mut leading, &dims[..leading_dims]) {
+                    break;
+                }
+            }
+            out
+        }
     }
 }
 
-fn pretty_print_table<F>(rows: usize, cols: usize, mut cell: F) -> String
+/// Match leading indices against the leading slice of a tensor filter. The
+/// trailing two filter entries (covering the row/col axes) are ignored — we
+/// always print the full row × col table for the slices we keep.
+fn leading_indices_match(leading: &[usize], filter: &crate::TensorFilter) -> bool {
+    use crate::DimFilter::*;
+    for (dim, &idx) in leading.iter().enumerate() {
+        let f = filter.get(dim).unwrap_or(&Any);
+        match f {
+            Any => {}
+            Exact(v) => {
+                if idx != *v {
+                    return false;
+                }
+            }
+            Range { start, end } => {
+                if idx < *start || idx > *end {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Lexicographic increment over `idx[i] in 0..bounds[i]`. Returns `false` when
+/// the counter has wrapped past the last position (i.e. iteration is done).
+fn increment_lex(idx: &mut [usize], bounds: &[usize]) -> bool {
+    if idx.is_empty() {
+        return false;
+    }
+    for d in (0..idx.len()).rev() {
+        idx[d] += 1;
+        if idx[d] < bounds[d] {
+            return true;
+        }
+        idx[d] = 0;
+    }
+    false
+}
+
+/// Row-major index iterator. Yields every position in a tensor of the given
+/// shape, lexicographically (last dim varies fastest). For a rank-0 tensor
+/// (empty shape) the iterator yields a single empty index vector and stops.
+struct IndexIter {
+    shape: Vec<usize>,
+    next: Option<Vec<usize>>,
+}
+
+impl IndexIter {
+    fn new(shape: Vec<usize>) -> Self {
+        // Empty dim → no indices.
+        let next = if shape.iter().any(|&d| d == 0) {
+            None
+        } else {
+            Some(vec![0; shape.len()])
+        };
+        Self { shape, next }
+    }
+}
+
+impl Iterator for IndexIter {
+    type Item = Vec<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.next.clone()?;
+
+        // Advance the counter for the next call. `increment_lex` returns
+        // `false` when we've passed the last position; rank-0 also lands
+        // here on the first call.
+        let mut tentative = current.clone();
+        if !increment_lex(&mut tentative, &self.shape) {
+            self.next = None;
+        } else {
+            self.next = Some(tentative);
+        }
+
+        Some(current)
+    }
+}
+
+fn format_leading_label(leading: &[usize], rank: usize) -> String {
+    let mut parts: Vec<String> = leading.iter().map(|i| i.to_string()).collect();
+    // Rows/cols are the last two dims — render as `*` so the label reads
+    // `[i, j, *, *]`.
+    for _ in 0..(rank - leading.len()) {
+        parts.push("*".to_string());
+    }
+    format!("[{}]", parts.join(", "))
+}
+
+/// Resolve which indices along a single dim should be rendered, given a
+/// per-dim filter entry. `None` means "render everything", which is the
+/// default for unfiltered prints.
+fn axis_indices(f: Option<&crate::DimFilter>, dim_size: usize) -> Vec<usize> {
+    use crate::DimFilter::*;
+    match f {
+        None | Some(Any) => (0..dim_size).collect(),
+        Some(Exact(v)) => {
+            if *v < dim_size {
+                vec![*v]
+            } else {
+                Vec::new()
+            }
+        }
+        Some(Range { start, end }) => {
+            if *start >= dim_size {
+                Vec::new()
+            } else {
+                (*start..=(*end).min(dim_size.saturating_sub(1))).collect()
+            }
+        }
+    }
+}
+
+fn pretty_print_table<F>(rows: &[usize], cols: &[usize], mut cell: F) -> String
 where
     F: FnMut(usize, usize) -> String,
 {
     let mut max_width = 0;
 
-    for r in 0..rows {
-        for c in 0..cols {
+    for &r in rows {
+        for &c in cols {
             max_width = max_width.max(cell(r, c).len());
         }
     }
 
-    max_width = max_width.max(2);
+    // Also account for the column-label width (so a tensor sliced down to
+    // `[10-12]` renders header `10 11 12` without crowding).
+    let label_width = cols
+        .iter()
+        .map(|c| c.to_string().len())
+        .max()
+        .unwrap_or(0);
+    max_width = max_width.max(label_width).max(2);
+
+    let row_label_width = rows
+        .iter()
+        .map(|r| r.to_string().len())
+        .max()
+        .unwrap_or(0)
+        .max(3);
 
     let mut s = String::new();
 
     // header
-    s.push_str(&format!("{:>3} |", ""));
-    for col in 0..cols {
+    s.push_str(&format!("{:>width$} |", "", width = row_label_width));
+    for &col in cols {
         s.push_str(&format!(" {:>width$}", col, width = max_width));
     }
     s.push('\n');
 
     // separator
-    s.push_str("----+");
-    for _ in 0..cols {
+    s.push_str(&"-".repeat(row_label_width + 1));
+    s.push('+');
+    for _ in cols {
         s.push_str(&"-".repeat(max_width + 1));
     }
     s.push('\n');
 
     // rows
-    for row in 0..rows {
-        s.push_str(&format!("{:>3} |", row));
+    for &row in rows {
+        s.push_str(&format!("{:>width$} |", row, width = row_label_width));
 
-        for col in 0..cols {
+        for &col in cols {
             let value = cell(row, col);
             s.push_str(&format!(" {:>width$}", value, width = max_width));
         }

--- a/crates/cubek-test-utils/src/test_tensor/host_data.rs
+++ b/crates/cubek-test-utils/src/test_tensor/host_data.rs
@@ -434,7 +434,7 @@ struct IndexIter {
 impl IndexIter {
     fn new(shape: Vec<usize>) -> Self {
         // Empty dim → no indices.
-        let next = if shape.iter().any(|&d| d == 0) {
+        let next = if shape.contains(&0) {
             None
         } else {
             Some(vec![0; shape.len()])

--- a/crates/cubek-test-utils/src/test_tensor/host_data.rs
+++ b/crates/cubek-test-utils/src/test_tensor/host_data.rs
@@ -511,11 +511,7 @@ where
 
     // Also account for the column-label width (so a tensor sliced down to
     // `[10-12]` renders header `10 11 12` without crowding).
-    let label_width = cols
-        .iter()
-        .map(|c| c.to_string().len())
-        .max()
-        .unwrap_or(0);
+    let label_width = cols.iter().map(|c| c.to_string().len()).max().unwrap_or(0);
     max_width = max_width.max(label_width).max(2);
 
     let row_label_width = rows

--- a/crates/cubek-test-utils/src/test_tensor/mod.rs
+++ b/crates/cubek-test-utils/src/test_tensor/mod.rs
@@ -4,6 +4,7 @@ mod cast;
 mod custom;
 mod eye;
 mod host_data;
+mod quant;
 mod random;
 mod strides;
 mod zeros;

--- a/crates/cubek-test-utils/src/test_tensor/quant.rs
+++ b/crates/cubek-test-utils/src/test_tensor/quant.rs
@@ -32,9 +32,7 @@ pub(crate) fn apply_quantization(
 
     // Determine the correct storage type for the quantized output buffer.
     let output_storage_type = match &scheme.store {
-        QuantStore::PackedU32(_) => {
-            StorageType::Scalar(ElemType::UInt(cubecl::ir::UIntKind::U32))
-        }
+        QuantStore::PackedU32(_) => StorageType::Scalar(ElemType::UInt(cubecl::ir::UIntKind::U32)),
         QuantStore::PackedNative(_) | QuantStore::Native => {
             StorageType::Scalar(ElemType::from_quant_value(scheme.value))
         }

--- a/crates/cubek-test-utils/src/test_tensor/quant.rs
+++ b/crates/cubek-test-utils/src/test_tensor/quant.rs
@@ -1,0 +1,164 @@
+use cubecl::{
+    TestRuntime,
+    client::ComputeClient,
+    ir::{ElemType, StorageType},
+    zspace::Shape,
+};
+use cubecl_common::quant::scheme::QuantScheme;
+use cubek_quant::scheme::{QuantLevel, QuantStore};
+
+use crate::{HostData, QuantizationInfo, TestInput, TestTensor};
+
+/// Quantize an already-built [`TestTensor`] in place: launches the cubek-quant
+/// reference quantizer on `tensor.handle`, swaps the handle for the packed
+/// output, and stores the device-side scale + original shape on
+/// `tensor.quantization`. The host data on `tensor.host` is left as the
+/// original f32 reference so correctness checks can still compare against it.
+pub(crate) fn apply_quantization(
+    client: &ComputeClient<TestRuntime>,
+    tensor: &mut TestTensor,
+    scheme: QuantScheme,
+) {
+    let original_shape = tensor.handle.shape().clone();
+
+    // Derive the scale tensor from the quant value's range. For
+    // `QuantLevel::Tensor` a single scale is used; for `QuantLevel::Block` we
+    // compute a per-block scale from the host data so each block fully uses
+    // the quant range without clipping.
+    let (scales_shape, scales_data) = compute_input_scales(&tensor.host, &scheme);
+    let scale_handle = TestInput::builder(client.clone(), scales_shape.clone())
+        .custom(scales_data)
+        .generate();
+
+    // Determine the correct storage type for the quantized output buffer.
+    let output_storage_type = match &scheme.store {
+        QuantStore::PackedU32(_) => {
+            StorageType::Scalar(ElemType::UInt(cubecl::ir::UIntKind::U32))
+        }
+        QuantStore::PackedNative(_) | QuantStore::Native => {
+            StorageType::Scalar(ElemType::from_quant_value(scheme.value))
+        }
+    };
+
+    let mut quant_shape = original_shape.clone();
+    let num_quants = scheme.num_quants();
+    // Only divide last dim for PackedU32/PackedNative; Native stores 1:1.
+    match &scheme.store {
+        QuantStore::PackedU32(_) | QuantStore::PackedNative(_) => {
+            if num_quants > 1 {
+                let last_dim = quant_shape.len() - 1;
+                quant_shape[last_dim] /= num_quants;
+            }
+        }
+        QuantStore::Native => {}
+    }
+
+    let output_handle = TestInput::builder(client.clone(), quant_shape)
+        .dtype(output_storage_type)
+        .zeros()
+        .generate();
+
+    let out_scale_handle = TestInput::builder(client.clone(), scales_shape)
+        .zeros()
+        .generate();
+
+    let input_elem = match tensor.handle.dtype {
+        StorageType::Scalar(elem) => elem,
+        _ => panic!("Unsupported storage type {:?}", tensor.handle.dtype),
+    };
+
+    cubek_quant::quantize::launch_ref(
+        client,
+        tensor.handle.clone().binding(),
+        output_handle.clone().binding(),
+        scale_handle.binding(),
+        out_scale_handle.clone().binding(),
+        &scheme,
+        input_elem,
+    )
+    .expect("Quantization failed");
+
+    // Keep the packed shape on the handle.
+    tensor.handle = output_handle;
+    tensor.quantization = Some(QuantizationInfo {
+        scheme,
+        scale: out_scale_handle,
+        shape: original_shape,
+    });
+}
+
+/// Compute the scale tensor shape and values for a quantized input.
+///
+/// For `QuantLevel::Tensor` this returns a single-element scale based on the
+/// quant value's range (assumes input in [-1, 1]). For `QuantLevel::Block`
+/// each block gets its own scale derived from `max(|value|)` in that block,
+/// matching the reference pattern used by the cubek-quant symmetric tests.
+fn compute_input_scales(host: &HostData, scheme: &QuantScheme) -> (Shape, Vec<f32>) {
+    let (q_min, q_max) = scheme.value.range();
+    let max_abs_q = q_max.abs().max(q_min.abs());
+
+    match &scheme.level {
+        QuantLevel::Tensor => {
+            let shape: Shape = core::iter::repeat_n(1, host.shape.len()).collect();
+            (shape, vec![1.0 / max_abs_q])
+        }
+        QuantLevel::Block(block_size) => {
+            let rank = host.shape.len();
+            let block_dims: Vec<usize> = block_size
+                .to_dim_vec(rank)
+                .into_iter()
+                .map(|b| b as usize)
+                .collect();
+
+            let scales_shape: Shape = host
+                .shape
+                .iter()
+                .zip(block_dims.iter())
+                .map(|(d, b)| {
+                    assert!(
+                        d.is_multiple_of(*b),
+                        "Block size {b} must divide dimension {d}",
+                    );
+                    d / b
+                })
+                .collect();
+
+            let num_blocks: usize = scales_shape.iter().product();
+            let block_elem_count: usize = block_dims.iter().product();
+
+            let mut scales = Vec::with_capacity(num_blocks);
+            let mut data_idx = vec![0usize; rank];
+            for block_linear in 0..num_blocks {
+                // Decode the flat block index into per-dim block indices.
+                let mut block_idx = vec![0usize; rank];
+                let mut rem = block_linear;
+                for d in (0..rank).rev() {
+                    block_idx[d] = rem % scales_shape[d];
+                    rem /= scales_shape[d];
+                }
+
+                let mut block_max = 0.0_f32;
+                for elem_linear in 0..block_elem_count {
+                    let mut rem = elem_linear;
+                    for d in (0..rank).rev() {
+                        let within = rem % block_dims[d];
+                        data_idx[d] = block_idx[d] * block_dims[d] + within;
+                        rem /= block_dims[d];
+                    }
+                    block_max = block_max.max(host.get_f32(&data_idx).abs());
+                }
+
+                // Guard against an all-zero block producing a zero scale that
+                // would divide-by-zero inside the quantize kernel.
+                let scale = if block_max > 0.0 {
+                    block_max / max_abs_q
+                } else {
+                    1.0 / max_abs_q
+                };
+                scales.push(scale);
+            }
+
+            (scales_shape, scales)
+        }
+    }
+}

--- a/crates/cubek-test-utils/src/test_tensor/random.rs
+++ b/crates/cubek-test-utils/src/test_tensor/random.rs
@@ -37,14 +37,10 @@ fn random_tensor_handle(
             cubek_random::random_bernoulli(client, prob, tensor_handle.clone().binding(), dtype)
                 .unwrap()
         }
-        Distribution::Normal { mean, std } => cubek_random::random_normal(
-            client,
-            mean,
-            std,
-            tensor_handle.clone().binding(),
-            dtype,
-        )
-        .unwrap(),
+        Distribution::Normal { mean, std } => {
+            cubek_random::random_normal(client, mean, std, tensor_handle.clone().binding(), dtype)
+                .unwrap()
+        }
     }
 
     tensor_handle

--- a/crates/cubek-test-utils/src/test_tensor/random.rs
+++ b/crates/cubek-test-utils/src/test_tensor/random.rs
@@ -37,6 +37,14 @@ fn random_tensor_handle(
             cubek_random::random_bernoulli(client, prob, tensor_handle.clone().binding(), dtype)
                 .unwrap()
         }
+        Distribution::Normal { mean, std } => cubek_random::random_normal(
+            client,
+            mean,
+            std,
+            tensor_handle.clone().binding(),
+            dtype,
+        )
+        .unwrap(),
     }
 
     tensor_handle

--- a/crates/cubek-test-utils/src/test_tensor/strides.rs
+++ b/crates/cubek-test-utils/src/test_tensor/strides.rs
@@ -58,7 +58,6 @@ mod tests {
         // ...and it's less than the logical element count.
         assert!(physical_extent(&shape, &strides) < 4 * 3);
     }
-
 }
 
 impl StrideSpec {

--- a/crates/cubek-test-utils/src/test_tensor/strides.rs
+++ b/crates/cubek-test-utils/src/test_tensor/strides.rs
@@ -24,6 +24,43 @@ pub fn physical_extent(shape: &Shape, strides: &Strides) -> usize {
     max_offset + 1
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn physical_extent_contiguous_row_major() {
+        // Row-major 2x3 → strides (3, 1) → 6 elements covered.
+        let shape = Shape::from(vec![2, 3]);
+        let strides = Strides::new(&[3, 1]);
+        assert_eq!(physical_extent(&shape, &strides), 6);
+    }
+
+    #[test]
+    fn physical_extent_jumpy_strides_exceed_logical() {
+        // 256x256 logical view of a wider 256x512 buffer (stride 512 on dim 0).
+        // Last reachable offset is 255*512 + 255*1 = 130815 → +1 = 130816.
+        let shape = Shape::from(vec![256, 256]);
+        let strides = Strides::new(&[512, 1]);
+        assert_eq!(physical_extent(&shape, &strides), 130816);
+        // And it strictly exceeds the logical element count.
+        assert!(physical_extent(&shape, &strides) > 256 * 256);
+    }
+
+    #[test]
+    fn physical_extent_broadcast_strides_undercount_logical() {
+        // Broadcast dim: stride 0 means every index along that dim shares the
+        // same physical offset. A 4x3 tensor broadcasting dim 0 only needs 3
+        // elements of physical storage, not 12.
+        let shape = Shape::from(vec![4, 3]);
+        let strides = Strides::new(&[0, 1]);
+        assert_eq!(physical_extent(&shape, &strides), 3);
+        // ...and it's less than the logical element count.
+        assert!(physical_extent(&shape, &strides) < 4 * 3);
+    }
+
+}
+
 impl StrideSpec {
     pub fn compute_strides(&self, shape: &Shape) -> Strides {
         let n = shape.len();

--- a/crates/cubek-test-utils/tests/utils_suite/mod.rs
+++ b/crates/cubek-test-utils/tests/utils_suite/mod.rs
@@ -5,7 +5,7 @@ use cubecl::{
 };
 use cubek_test_utils::{
     DataKind, HostData, HostDataType, StrideSpec, TestInput, ValidationResult,
-    assert_equals_approx, assert_equals_approx_in_slice,
+    assert_equals_approx, assert_equals_approx_in_slice, print_tensor,
 };
 
 #[test]
@@ -14,25 +14,11 @@ fn eye_handle_row_major() {
 
     let shape = [2, 3];
 
-    let handle = TestInput::new(
-        client.clone(),
-        shape,
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Eye,
-    )
-    .generate();
+    let handle = TestInput::builder(client.clone(), shape).eye().generate();
 
-    let expected = TestInput::new(
-        client.clone(),
-        [2, 3],
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom {
-            data: [1., 0., 0., 0., 1., 0.].to_vec(),
-        },
-    )
-    .f32_host_data();
+    let expected = TestInput::builder(client.clone(), [2, 3])
+        .custom(vec![1., 0., 0., 0., 1., 0.])
+        .f32_host_data();
 
     let actual = HostData::from_tensor_handle(&client, handle, HostDataType::F32);
 
@@ -47,25 +33,14 @@ fn eye_handle_col_major() {
 
     let shape = [2, 3];
 
-    let handle = TestInput::new(
-        client.clone(),
-        shape,
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::ColMajor,
-        DataKind::Eye,
-    )
-    .generate();
+    let handle = TestInput::builder(client.clone(), shape)
+        .stride(StrideSpec::ColMajor)
+        .eye()
+        .generate();
 
-    let expected = TestInput::new(
-        client.clone(),
-        [2, 3],
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom {
-            data: [1., 0., 0., 0., 1., 0.].to_vec(),
-        },
-    )
-    .f32_host_data();
+    let expected = TestInput::builder(client.clone(), [2, 3])
+        .custom(vec![1., 0., 0., 0., 1., 0.])
+        .f32_host_data();
 
     let actual = HostData::from_tensor_handle(&client, handle, HostDataType::F32);
 
@@ -80,25 +55,13 @@ fn arange_handle_row_major() {
 
     let shape = shape![2, 3];
 
-    let handle = TestInput::new(
-        client.clone(),
-        shape,
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Arange { scale: None },
-    )
-    .generate();
+    let handle = TestInput::builder(client.clone(), shape)
+        .arange()
+        .generate();
 
-    let expected = TestInput::new(
-        client.clone(),
-        shape![2, 3],
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom {
-            data: [0., 1., 2., 3., 4., 5.].to_vec(),
-        },
-    )
-    .f32_host_data();
+    let expected = TestInput::builder(client.clone(), shape![2, 3])
+        .custom(vec![0., 1., 2., 3., 4., 5.])
+        .f32_host_data();
 
     let actual = HostData::from_tensor_handle(&client, handle, HostDataType::F32);
 
@@ -113,25 +76,14 @@ fn arange_handle_col_major() {
 
     let shape = shape![2, 3];
 
-    let handle = TestInput::new(
-        client.clone(),
-        shape,
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::ColMajor,
-        DataKind::Arange { scale: None },
-    )
-    .generate();
+    let handle = TestInput::builder(client.clone(), shape)
+        .stride(StrideSpec::ColMajor)
+        .arange()
+        .generate();
 
-    let expected = TestInput::new(
-        client.clone(),
-        shape![2, 3],
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom {
-            data: [0., 1., 2., 3., 4., 5.].to_vec(),
-        },
-    )
-    .f32_host_data();
+    let expected = TestInput::builder(client.clone(), shape![2, 3])
+        .custom(vec![0., 1., 2., 3., 4., 5.])
+        .f32_host_data();
 
     let actual = HostData::from_tensor_handle(&client, handle, HostDataType::F32);
 
@@ -146,27 +98,14 @@ fn custom_handle_row_major_col_major() {
 
     let contiguous_data = [9., 8., 7., 6., 5., 4.].to_vec();
 
-    let (_, row_major) = TestInput::new(
-        client.clone(),
-        shape![2, 3],
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom {
-            data: contiguous_data.clone(),
-        },
-    )
-    .generate_with_f32_host_data();
+    let (_, row_major) = TestInput::builder(client.clone(), shape![2, 3])
+        .custom(contiguous_data.clone())
+        .generate_with_f32_host_data();
 
-    let (_, col_major) = TestInput::new(
-        client.clone(),
-        shape![2, 3],
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::ColMajor,
-        DataKind::Custom {
-            data: contiguous_data,
-        },
-    )
-    .generate_with_f32_host_data();
+    let (_, col_major) = TestInput::builder(client.clone(), shape![2, 3])
+        .stride(StrideSpec::ColMajor)
+        .custom(contiguous_data)
+        .generate_with_f32_host_data();
 
     assert_equals_approx(&col_major, &row_major, 0.001)
         .as_test_outcome()
@@ -180,28 +119,16 @@ fn arange_handle_row_major_slice() {
     let shape = shape![2, 3];
 
     // Create an "actual" tensor where the second row differs
-    let actual_data = [0., 1., 2., 9., 9., 9.].to_vec(); // last 3 elements differ
-    let actual = TestInput::new(
-        client.clone(),
-        shape.clone(),
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom { data: actual_data },
-    )
-    .f32_host_data();
+    let actual_data = vec![0., 1., 2., 9., 9., 9.]; // last 3 elements differ
+    let actual = TestInput::builder(client.clone(), shape.clone())
+        .custom(actual_data)
+        .f32_host_data();
 
     // Expected tensor
-    let expected_data = [0., 1., 2., 3., 4., 5.].to_vec();
-    let expected = TestInput::new(
-        client.clone(),
-        shape,
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom {
-            data: expected_data,
-        },
-    )
-    .f32_host_data();
+    let expected_data = vec![0., 1., 2., 3., 4., 5.];
+    let expected = TestInput::builder(client.clone(), shape)
+        .custom(expected_data)
+        .f32_host_data();
 
     assert_equals_approx_in_slice(&actual, &expected, 0.001, vec![0..1, 0..3])
         .as_test_outcome()
@@ -213,27 +140,13 @@ fn fail_message_contains_aggregate_stats_and_examples() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
 
     // 6 elements, 3 of which are wrong by 1.0 each.
-    let actual = TestInput::new(
-        client.clone(),
-        shape![2, 3],
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom {
-            data: vec![0., 1., 2., 4., 5., 6.],
-        },
-    )
-    .f32_host_data();
+    let actual = TestInput::builder(client.clone(), shape![2, 3])
+        .custom(vec![0., 1., 2., 4., 5., 6.])
+        .f32_host_data();
 
-    let expected = TestInput::new(
-        client.clone(),
-        shape![2, 3],
-        f32::as_type_native_unchecked().storage_type(),
-        StrideSpec::RowMajor,
-        DataKind::Custom {
-            data: vec![0., 1., 2., 3., 4., 5.],
-        },
-    )
-    .f32_host_data();
+    let expected = TestInput::builder(client.clone(), shape![2, 3])
+        .custom(vec![0., 1., 2., 3., 4., 5.])
+        .f32_host_data();
 
     let result = assert_equals_approx(&actual, &expected, 0.001);
     let reason = match result {
@@ -249,14 +162,387 @@ fn fail_message_contains_aggregate_stats_and_examples() {
         reason.contains("max |Δ|="),
         "missing max delta, got: {reason}"
     );
-    assert!(
-        reason.contains("First mismatches:"),
-        "missing examples header, got: {reason}"
-    );
     // Worst index has the largest |delta|. All deltas are 1.0, so the *first*
     // wrong index is recorded as the worst (record_delta only updates on '>').
     assert!(
         reason.contains("worst at [1, 0]"),
         "missing worst index, got: {reason}"
     );
+
+    // In Print modes the per-element output is on stdout — the panic message
+    // intentionally drops the examples block. In non-Print modes the block
+    // must be present.
+    let is_print_mode = std::env::var("CUBE_TEST_MODE")
+        .map(|v| v.to_lowercase().starts_with("print"))
+        .unwrap_or(false);
+    if !is_print_mode {
+        assert!(
+            reason.contains("First mismatches:"),
+            "missing examples header, got: {reason}"
+        );
+    }
+}
+
+#[test]
+fn assert_equals_approx_in_slice_accepts_tensor_filter() {
+    use cubek_test_utils::DimFilter;
+
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // Same setup as `arange_handle_row_major_slice` — the second row of
+    // `actual` differs (9, 9, 9) from the expected arange (3, 4, 5).
+    let actual = TestInput::builder(client.clone(), shape![2, 3])
+        .custom(vec![0., 1., 2., 9., 9., 9.])
+        .f32_host_data();
+
+    let expected = TestInput::builder(client.clone(), shape![2, 3])
+        .custom(vec![0., 1., 2., 3., 4., 5.])
+        .f32_host_data();
+
+    // Equivalent to `vec![0..1, 0..3]` — only the first row is compared, so
+    // the differing second row is ignored and the result is `Pass`.
+    let filter = vec![DimFilter::Exact(0), DimFilter::Range { start: 0, end: 2 }];
+    assert_equals_approx_in_slice(&actual, &expected, 0.001, filter)
+        .as_test_outcome()
+        .enforce();
+}
+
+#[test]
+fn builder_matches_constructor() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // Builder form: defaults to f32 + RowMajor; finalizer picks the data kind.
+    let from_builder = TestInput::builder(client.clone(), shape![2, 3])
+        .arange()
+        .f32_host_data();
+
+    // Equivalent construction with the long-form `TestInput::new`.
+    let from_new = TestInput::new(
+        client.clone(),
+        shape![2, 3],
+        f32::as_type_native_unchecked().storage_type(),
+        StrideSpec::RowMajor,
+        DataKind::Arange { scale: None },
+    )
+    .f32_host_data();
+
+    assert_equals_approx(&from_builder, &from_new, 0.0)
+        .as_test_outcome()
+        .enforce();
+}
+
+#[test]
+fn builder_overrides_stride_and_dtype() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // Builder with explicit stride override should match the constructor.
+    let from_builder = TestInput::builder(client.clone(), shape![2, 3])
+        .stride(StrideSpec::ColMajor)
+        .arange()
+        .f32_host_data();
+
+    let from_new = TestInput::new(
+        client.clone(),
+        shape![2, 3],
+        f32::as_type_native_unchecked().storage_type(),
+        StrideSpec::ColMajor,
+        DataKind::Arange { scale: None },
+    )
+    .f32_host_data();
+
+    assert_equals_approx(&from_builder, &from_new, 0.0)
+        .as_test_outcome()
+        .enforce();
+}
+
+#[test]
+fn builder_linspace_produces_evenly_spaced_values() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // 5 evenly-spaced values from 0.0 to 1.0 → step = 0.25.
+    // Shape [1, 5] because RowMajor requires ≥ 2 dimensions.
+    let actual = TestInput::builder(client.clone(), shape![1, 5])
+        .linspace(0.0, 1.0)
+        .f32_host_data();
+
+    let expected = TestInput::builder(client.clone(), shape![1, 5])
+        .custom(vec![0.0, 0.25, 0.5, 0.75, 1.0])
+        .f32_host_data();
+
+    assert_equals_approx(&actual, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+#[test]
+fn builder_normal_distribution_within_statistical_bounds() {
+    // `cubek_random::seed` is a global, so we don't pin bit-exact reproduction
+    // (other tests racing on the same global would flake). Instead check that
+    // the distribution's *empirical* mean / std stay within sample-size bounds.
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // Shape [1, N] because RowMajor requires ≥ 2 dimensions.
+    let n: usize = 4096;
+    let host = TestInput::builder(client.clone(), shape![1, n])
+        .normal(/* seed */ 11, /* mean */ 0.0, /* std */ 1.0)
+        .f32_host_data();
+
+    let values: Vec<f32> = (0..n).map(|i| host.get_f32(&[0, i])).collect();
+    let mean = values.iter().copied().sum::<f32>() / n as f32;
+    let var = values.iter().map(|v| (v - mean).powi(2)).sum::<f32>() / n as f32;
+    let std = var.sqrt();
+
+    // SE of the mean is std/sqrt(n) ≈ 1/64 ≈ 0.016. Use 0.1 as a safe bound.
+    assert!(mean.abs() < 0.1, "mean drifted: {mean}");
+    assert!((std - 1.0).abs() < 0.1, "std drifted: {std}");
+}
+
+#[test]
+fn host_data_typed_accessors_and_iter() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // arange tensor — values 0..6 in row-major order.
+    let host = TestInput::builder(client.clone(), shape![2, 3])
+        .arange()
+        .f32_host_data();
+
+    // Panicking and falling-back accessors agree on F32 data.
+    assert_eq!(host.get_f32(&[1, 2]), 5.0);
+    assert_eq!(host.try_get_f32(&[1, 2]), Some(5.0));
+    // Wrong dtype → None instead of panic.
+    assert_eq!(host.try_get_i32(&[1, 2]), None);
+    assert_eq!(host.try_get_bool(&[1, 2]), None);
+
+    // Indexed iterator walks every cell row-major.
+    let collected: Vec<(Vec<usize>, f32)> = host.iter_indexed_f32().collect();
+    assert_eq!(collected.len(), 6);
+    assert_eq!(collected[0], (vec![0, 0], 0.0));
+    assert_eq!(collected[3], (vec![1, 0], 3.0));
+    assert_eq!(collected.last().unwrap(), &(vec![1, 2], 5.0));
+}
+
+#[test]
+fn host_data_iter_respects_strides() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // Same logical 2x3 tensor, but stored col-major. The iterator must walk
+    // the *logical* row-major order while resolving each cell through the
+    // strides — so the values must match a row-major arange.
+    let actual = TestInput::builder(client.clone(), shape![2, 3])
+        .stride(StrideSpec::ColMajor)
+        .arange()
+        .f32_host_data();
+
+    let collected: Vec<f32> = actual.iter_indexed_f32().map(|(_, v)| v).collect();
+    assert_eq!(collected, vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
+}
+
+/// Run with `--nocapture` to see print
+#[test]
+fn playground_partial_mismatch() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let eps = 0.001f32;
+
+    let expected = TestInput::builder(client.clone(), shape![4, 4])
+        .custom(vec![
+            0.10, 0.20, 0.30, 0.40, 1.00, 1.10, 1.20, 1.30, 2.00, 2.10, 2.20, 2.30, 3.00, 3.10,
+            3.20, 3.30,
+        ])
+        .f32_host_data();
+
+    let actual = TestInput::builder(client.clone(), shape![4, 4])
+        .custom(vec![
+            0.10,
+            0.20,
+            0.30,
+            0.40,
+            1.0001,
+            1.0999,
+            1.2001,
+            1.2999,
+            2.01,
+            2.10,
+            2.21,
+            2.31,
+            3.50,
+            3.60,
+            3.70,
+            f32::NAN,
+        ])
+        .f32_host_data();
+
+    let result = assert_equals_approx(&actual, &expected, eps);
+    assert!(
+        matches!(result, ValidationResult::Fail(_)),
+        "expected partial mismatch to be flagged as Fail, got {result:?}"
+    );
+}
+
+#[test]
+fn print_tensors_skips_shape_mismatch() {
+    use cubek_test_utils::print_tensors;
+
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    let a = TestInput::builder(client.clone(), shape![2, 3])
+        .arange()
+        .f32_host_data();
+    let b = TestInput::builder(client.clone(), shape![3, 2])
+        .arange()
+        .f32_host_data();
+
+    // Shapes differ (2,3) vs (3,2) — must not panic and must not print.
+    // (We can't observe stdout from here, so this is a smoke test.)
+    print_tensors("mismatched", &[&a, &b], Some(0.001));
+}
+
+#[test]
+fn print_tensors_skips_rank_mismatch() {
+    use cubek_test_utils::print_tensors;
+
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    let r2 = TestInput::builder(client.clone(), shape![2, 3])
+        .arange()
+        .f32_host_data();
+    let r3 = TestInput::builder(client.clone(), shape![2, 2, 3])
+        .arange()
+        .f32_host_data();
+
+    // Different ranks — must not panic and must not print.
+    print_tensors("mismatched_rank", &[&r2, &r3], Some(0.001));
+}
+
+#[test]
+fn print_tensor_is_no_op_in_correct_mode() {
+    // Smoke check: `print_tensor` must never panic regardless of the active
+    // test mode, so it is safe to leave in place once a test is debugged.
+    // (We can't observe stdout in a parallel test runner, so we just exercise
+    // the call path on a few ranks.)
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    let r2 = TestInput::builder(client.clone(), shape![2, 3])
+        .arange()
+        .f32_host_data();
+    print_tensor("rank-2 arange", &r2);
+
+    let r3 = TestInput::builder(client.clone(), shape![2, 2, 3])
+        .arange()
+        .f32_host_data();
+    print_tensor("rank-3 arange", &r3);
+}
+
+#[test]
+fn pretty_print_handles_rank_3() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // 2 × 2 × 3 tensor — should print as two labeled 2×3 tables.
+    let host = TestInput::builder(client.clone(), shape![2, 2, 3])
+        .arange()
+        .f32_host_data();
+
+    let printed = host.pretty_print();
+    assert!(
+        printed.contains("[0, *, *]"),
+        "missing first slice label:\n{printed}"
+    );
+    assert!(
+        printed.contains("[1, *, *]"),
+        "missing second slice label:\n{printed}"
+    );
+    // arange produces 0..12; the first slice spans 0..6, the second 6..12.
+    assert!(
+        printed.contains("0.000"),
+        "expected 0.000 in printed output:\n{printed}"
+    );
+    assert!(
+        printed.contains("11.000"),
+        "expected 11.000 in printed output:\n{printed}"
+    );
+}
+
+#[test]
+fn pretty_print_slice_filters_rows_and_cols() {
+    use cubek_test_utils::DimFilter;
+
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // 2 × 4 arange — values 0..8 in row-major order.
+    let host = TestInput::builder(client.clone(), shape![2, 4])
+        .arange()
+        .f32_host_data();
+
+    // Pin row 1 only, cols 1-2 only — should print just `[1, 1]=5` and
+    // `[1, 2]=6` and skip every other cell.
+    let printed = host.pretty_print_slice(vec![
+        DimFilter::Exact(1),
+        DimFilter::Range { start: 1, end: 2 },
+    ]);
+
+    assert!(printed.contains("5.000"), "expected 5.000 in: {printed}");
+    assert!(printed.contains("6.000"), "expected 6.000 in: {printed}");
+    // Column 0 (value 4) and column 3 (value 7) should be filtered out.
+    assert!(
+        !printed.contains("4.000"),
+        "should not contain 4.000: {printed}"
+    );
+    assert!(
+        !printed.contains("7.000"),
+        "should not contain 7.000: {printed}"
+    );
+    // Row 0 (values 0..3) should be filtered out entirely.
+    assert!(
+        !printed.contains("0.000"),
+        "should not contain 0.000: {printed}"
+    );
+}
+
+#[test]
+fn pretty_print_slice_filters_leading_dims() {
+    use cubek_test_utils::DimFilter;
+
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // 3 × 2 × 2 — exercise filtering on the leading dim.
+    let host = TestInput::builder(client.clone(), shape![3, 2, 2])
+        .arange()
+        .f32_host_data();
+
+    // Pin leading dim to 1; the row/col axes always use `Any`.
+    let filter = vec![DimFilter::Exact(1), DimFilter::Any, DimFilter::Any];
+    let printed = host.pretty_print_slice(filter);
+
+    assert!(
+        printed.contains("[1, *, *]"),
+        "expected slice [1, *, *]:\n{printed}"
+    );
+    assert!(
+        !printed.contains("[0, *, *]"),
+        "should not include slice [0, *, *]:\n{printed}"
+    );
+    assert!(
+        !printed.contains("[2, *, *]"),
+        "should not include slice [2, *, *]:\n{printed}"
+    );
+}
+
+#[test]
+fn builder_uniform_values_in_range() {
+    // Range/property check rather than seed-stability — see the note on the
+    // normal test above.
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    let host = TestInput::builder(client.clone(), shape![4, 4])
+        .uniform(/* seed */ 7, -1.0, 1.0)
+        .f32_host_data();
+
+    for i in 0..4 {
+        for j in 0..4 {
+            let v = host.get_f32(&[i, j]);
+            assert!(
+                (-1.0..=1.0).contains(&v),
+                "uniform value out of range at [{i},{j}]: {v}"
+            );
+        }
+    }
 }

--- a/crates/cubek-test-utils/tests/utils_suite/mod.rs
+++ b/crates/cubek-test-utils/tests/utils_suite/mod.rs
@@ -4,8 +4,8 @@ use cubecl::{
     {Runtime, TestRuntime},
 };
 use cubek_test_utils::{
-    DataKind, HostData, HostDataType, StrideSpec, TestInput, assert_equals_approx,
-    assert_equals_approx_in_slice,
+    DataKind, HostData, HostDataType, StrideSpec, TestInput, ValidationResult,
+    assert_equals_approx, assert_equals_approx_in_slice,
 };
 
 #[test]
@@ -206,4 +206,57 @@ fn arange_handle_row_major_slice() {
     assert_equals_approx_in_slice(&actual, &expected, 0.001, vec![0..1, 0..3])
         .as_test_outcome()
         .enforce();
+}
+
+#[test]
+fn fail_message_contains_aggregate_stats_and_examples() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    // 6 elements, 3 of which are wrong by 1.0 each.
+    let actual = TestInput::new(
+        client.clone(),
+        shape![2, 3],
+        f32::as_type_native_unchecked().storage_type(),
+        StrideSpec::RowMajor,
+        DataKind::Custom {
+            data: vec![0., 1., 2., 4., 5., 6.],
+        },
+    )
+    .f32_host_data();
+
+    let expected = TestInput::new(
+        client.clone(),
+        shape![2, 3],
+        f32::as_type_native_unchecked().storage_type(),
+        StrideSpec::RowMajor,
+        DataKind::Custom {
+            data: vec![0., 1., 2., 3., 4., 5.],
+        },
+    )
+    .f32_host_data();
+
+    let result = assert_equals_approx(&actual, &expected, 0.001);
+    let reason = match result {
+        ValidationResult::Fail(r) => r,
+        other => panic!("expected Fail, got {other:?}"),
+    };
+
+    assert!(
+        reason.contains("3/6 elements mismatched"),
+        "missing mismatch count, got: {reason}"
+    );
+    assert!(
+        reason.contains("max |Δ|="),
+        "missing max delta, got: {reason}"
+    );
+    assert!(
+        reason.contains("First mismatches:"),
+        "missing examples header, got: {reason}"
+    );
+    // Worst index has the largest |delta|. All deltas are 1.0, so the *first*
+    // wrong index is recorded as the worst (record_delta only updates on '>').
+    assert!(
+        reason.contains("worst at [1, 0]"),
+        "missing worst index, got: {reason}"
+    );
 }

--- a/crates/cubek-test-utils/tests/utils_suite/mod.rs
+++ b/crates/cubek-test-utils/tests/utils_suite/mod.rs
@@ -284,7 +284,7 @@ fn builder_normal_distribution_within_statistical_bounds() {
     // Shape [1, N] because RowMajor requires ≥ 2 dimensions.
     let n: usize = 4096;
     let host = TestInput::builder(client.clone(), shape![1, n])
-        .normal(/* seed */ 11, /* mean */ 0.0, /* std */ 1.0)
+        .normal(11, /* mean */ 0.0, /* std */ 1.0)
         .f32_host_data();
 
     let values: Vec<f32> = (0..n).map(|i| host.get_f32(&[0, i])).collect();
@@ -533,7 +533,7 @@ fn builder_uniform_values_in_range() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
 
     let host = TestInput::builder(client.clone(), shape![4, 4])
-        .uniform(/* seed */ 7, -1.0, 1.0)
+        .uniform(7, -1.0, 1.0)
         .f32_host_data();
 
     for i in 0..4 {

--- a/cubek.toml
+++ b/cubek.toml
@@ -1,0 +1,72 @@
+# CubeK test configuration.
+#
+# This file controls how `cubek-test-utils` runs your tests — what it prints
+# when comparing tensors, and which numerical / compilation outcomes count
+# as test failures.
+#
+# Loaded once at process start. The cubek-test-utils crate walks up from the
+# current working directory until it finds a `cubek.toml` and reads it.
+
+# ----------------------------------------------------------------------------
+# [test] — pass/fail policy
+# ----------------------------------------------------------------------------
+#
+# `policy` is one of:
+#   "correct"     (default) numerical errors fail; compilation errors are
+#                 accepted. Useful when test grids include invalid configs.
+#   "strict"      numerical errors AND compilation errors fail.
+#   "fail-if-run" inverts `correct`: tests that successfully run are failed,
+#                 others pass. Surfaces what actually executes.
+
+[test]
+policy = "correct"
+
+# ----------------------------------------------------------------------------
+# [print] — what gets dumped to stdout when comparing or pretty-printing tensors
+# ----------------------------------------------------------------------------
+#
+# `enabled` toggles the entire pipeline. When `false`, every dump call is a
+# no-op and nothing else in this section matters.
+
+[print]
+enabled = false
+
+# `view`:
+#   "table"   2-D table per slice. Cells are colored green when values match
+#             within ε, red when they diverge. Δ and ε are NOT shown — the
+#             table would be too wide; the color tells you what you need.
+#   "lines"   one row per cell: `index | got | expected | Δ | ε | status`.
+#             Δ and ε are ALWAYS shown in this view.
+view = "table"
+
+# `force-fail`:
+#   true    every test that prints is forced to fail, so cargo surfaces the
+#           stdout it would otherwise swallow. Combine with a cargo test
+#           filter to inspect a specific test.
+#   false   prints happen on every comparison, but only numerical errors
+#           fail the test.
+force-fail = true
+
+# `fail-only`: only render cells where Δ > ε.
+#   In `lines` view, matching rows are dropped entirely.
+#   In `table` view, matching cells are blanked out (the table layout is
+#   preserved so the surviving red cells stay aligned with their indices).
+fail-only = false
+
+# `show-expected`:
+#   true    in a 2-tensor render, both values are shown joined by `/`,
+#           e.g. "0.450/0.470" (cell colored green or red as a whole).
+#   false   only the first tensor's value is shown; color still reflects
+#           the per-cell comparison.
+show-expected = false
+
+# `filter`: optional per-axis filter. Same DSL as
+# `assert_equals_approx_in_slice`: comma-separated dim entries where each
+# is `.` (wildcard), `N` (exact), or `M-K` (inclusive range). Filter rank
+# must match tensor rank.
+#
+# Examples:
+#   "1,.,."       rank-3 tensors: only slice [1, *, *]
+#   "0,64-127"    rank-2 tensors: row 0, columns 64..=127
+#   ""            render the whole tensor (default)
+filter = ""


### PR DESCRIPTION
Enhance cubek-test-utils:
- CUBE_TEST_MODE has now its dedicated cubek.toml
- Create TestInput with a builder pattern
- Show more than one line when there is a numerical error. 