### PR TITLE
Use elemwise cube counts for FFT windows

### DIFF
--- a/crates/cubek-fft/src/fft/irfft.rs
+++ b/crates/cubek-fft/src/fft/irfft.rs
@@ -71,8 +71,7 @@ pub fn irfft_launch<R: Runtime>(
     }
 
     let cube_dim = CubeDim::new_single();
-    let cube_count =
-        cubecl::calculate_cube_count_elemwise(client, count, CubeDim::new_single());
+    let cube_count = cubecl::calculate_cube_count_elemwise(client, count, CubeDim::new_single());
     let vectorization = 1;
     let shape = signal.shape[dim];
 

--- a/crates/cubek-fft/src/fft/irfft.rs
+++ b/crates/cubek-fft/src/fft/irfft.rs
@@ -66,8 +66,13 @@ pub fn irfft_launch<R: Runtime>(
         .map(|(_, e)| *e)
         .product();
 
-    let cube_count = CubeCount::new_1d(count as u32);
+    if count == 0 {
+        return Ok(());
+    }
+
     let cube_dim = CubeDim::new_single();
+    let cube_count =
+        cubecl::calculate_cube_count_elemwise(client, count, CubeDim::new_single());
     let vectorization = 1;
     let shape = signal.shape[dim];
 

--- a/crates/cubek-fft/src/fft/rfft.rs
+++ b/crates/cubek-fft/src/fft/rfft.rs
@@ -79,8 +79,7 @@ pub fn rfft_launch<R: Runtime>(
     }
 
     let cube_dim = CubeDim::new_single();
-    let cube_count =
-        cubecl::calculate_cube_count_elemwise(client, count, CubeDim::new_single());
+    let cube_count = cubecl::calculate_cube_count_elemwise(client, count, CubeDim::new_single());
     let vectorization = 1;
     let shape = signal.shape.as_slice()[dim];
 

--- a/crates/cubek-fft/src/fft/rfft.rs
+++ b/crates/cubek-fft/src/fft/rfft.rs
@@ -74,8 +74,13 @@ pub fn rfft_launch<R: Runtime>(
         .map(|(_, e)| *e)
         .product();
 
-    let cube_count = CubeCount::new_1d(count as u32);
+    if count == 0 {
+        return Ok(());
+    }
+
     let cube_dim = CubeDim::new_single();
+    let cube_count =
+        cubecl::calculate_cube_count_elemwise(client, count, CubeDim::new_single());
     let vectorization = 1;
     let shape = signal.shape.as_slice()[dim];
 

--- a/crates/cubek-fft/tests/suite/irfft.rs
+++ b/crates/cubek-fft/tests/suite/irfft.rs
@@ -110,3 +110,11 @@ fn irfft_3d_batch_singleton_dim() {
     let dim = spectrum_shape.len() - 1;
     test_launch(client, spectrum_shape, dim);
 }
+
+#[test]
+fn irfft_dispatch_more_than_wgpu_x_axis_limit() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let spectrum_shape = [65_536, 2].to_vec();
+    let dim = spectrum_shape.len() - 1;
+    test_launch(client, spectrum_shape, dim);
+}

--- a/crates/cubek-fft/tests/suite/rfft.rs
+++ b/crates/cubek-fft/tests/suite/rfft.rs
@@ -122,3 +122,11 @@ fn rfft_3d_batch_singleton_dim() {
     let dim = signal_shape.len() - 1;
     test_launch(client, signal_shape, dim);
 }
+
+#[test]
+fn rfft_dispatch_more_than_wgpu_x_axis_limit() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let signal_shape = [65_536, 2].to_vec();
+    let dim = signal_shape.len() - 1;
+    test_launch(client, signal_shape, dim);
+}


### PR DESCRIPTION
Spread batched RFFT and IRFFT dispatch across the runtime-supported grid instead of packing all windows onto the X axis.

  `CubeCount::new_1d(count)` can exceed backend dispatch limits for large batched inputs. On wgpu, the X-axis dispatch cap is 65,535, so FFT workloads with more windows than that can fail even when each individual FFT is tiny. This switches the launch count to `calculate_cube_count_elemwise`, preserving the existing
  serial per-window kernels while allowing the runtime to split dispatch across supported grid dimensions.

  Adds regression coverage with 65,536 independent two-point FFT windows for both RFFT and IRFFT. This exceeds wgpu's 65,535 X-axis dispatch cap.

  ## Validation

  Cubek:

  - `cargo check -p cubek-fft`
  - `cargo test -p cubek-fft --no-run`

  Burn validation:

  - Burn validation branch/commit: https://github.com/g1ibby/burn/commit/e639662311a9a1ec9ce18b704d38aa26a7e2e921
  - In Burn, `cubek` was pointed at this PR commit: `34607b5dddb87dc0a06c18d97877e1596c53e433`
  - `cargo check -p burn-cubecl`
  - `cargo test -p burn-cubecl --no-run`