### PR TITLE
Support virtual padding in RFFT/IRFFT launches

### DIFF
--- a/crates/cubek-fft/src/fft/irfft.rs
+++ b/crates/cubek-fft/src/fft/irfft.rs
@@ -90,19 +90,7 @@ pub fn irfft_launch_padded<R: Runtime>(
         spectrum_re.shape == spectrum_im.shape,
         "spectrum real and imaginary shapes must match"
     );
-    assert!(
-        spectrum_re.shape.len() == signal.shape.len(),
-        "spectrum and signal rank must match"
-    );
     assert!(dim < signal.shape.len(), "dim must be in bounds");
-    for axis in 0..signal.shape.len() {
-        if axis != dim {
-            assert!(
-                spectrum_re.shape[axis] == signal.shape[axis],
-                "spectrum and signal batch dimensions must match"
-            );
-        }
-    }
 
     let n_fft = signal.shape[dim];
     assert!(n_fft.is_power_of_two(), "IRFFT requires power-of-2 length");

--- a/crates/cubek-fft/src/fft/irfft.rs
+++ b/crates/cubek-fft/src/fft/irfft.rs
@@ -64,9 +64,60 @@ pub fn irfft_launch<R: Runtime>(
     dim: usize,
     dtype: StorageType,
 ) -> Result<(), LaunchError> {
+    let spec_bins = spectrum_re.shape[dim];
+    irfft_launch_padded::<R>(
+        client,
+        spectrum_re,
+        spectrum_im,
+        signal,
+        dim,
+        spec_bins,
+        dtype,
+    )
+}
+
+/// Launches the IRFFT kernel while treating bins at `spec_bins..n_freq` as zero.
+pub fn irfft_launch_padded<R: Runtime>(
+    client: &ComputeClient<R>,
+    spectrum_re: TensorBinding<R>,
+    spectrum_im: TensorBinding<R>,
+    signal: TensorBinding<R>,
+    dim: usize,
+    spec_bins: usize,
+    dtype: StorageType,
+) -> Result<(), LaunchError> {
+    assert!(
+        spectrum_re.shape == spectrum_im.shape,
+        "spectrum real and imaginary shapes must match"
+    );
+    assert!(
+        spectrum_re.shape.len() == signal.shape.len(),
+        "spectrum and signal rank must match"
+    );
+    assert!(dim < signal.shape.len(), "dim must be in bounds");
+    for axis in 0..signal.shape.len() {
+        if axis != dim {
+            assert!(
+                spectrum_re.shape[axis] == signal.shape[axis],
+                "spectrum and signal batch dimensions must match"
+            );
+        }
+    }
+
     let n_fft = signal.shape[dim];
     assert!(n_fft.is_power_of_two(), "IRFFT requires power-of-2 length");
     assert!(n_fft >= 2, "IRFFT requires n_fft >= 2");
+    let n_freq = n_fft / 2 + 1;
+    assert!(
+        spec_bins <= spectrum_re.shape[dim],
+        "spec_bins ({spec_bins}) must be <= spectrum dimension ({})",
+        spectrum_re.shape[dim]
+    );
+    assert!(spec_bins >= 1, "spec_bins must be >= 1");
+    assert!(
+        spec_bins <= n_freq,
+        "spec_bins ({spec_bins}) must be <= n_fft / 2 + 1 ({n_freq})"
+    );
 
     let count: usize = signal
         .shape
@@ -80,7 +131,15 @@ pub fn irfft_launch<R: Runtime>(
     }
 
     if n_fft > SHARED_MEM_CAP {
-        return irfft_large_launch::<R>(client, spectrum_re, spectrum_im, signal, dim, dtype);
+        return irfft_large_launch::<R>(
+            client,
+            spectrum_re,
+            spectrum_im,
+            signal,
+            dim,
+            spec_bins,
+            dtype,
+        );
     }
 
     let log2_n = n_fft.trailing_zeros() as usize;
@@ -97,6 +156,7 @@ pub fn irfft_launch<R: Runtime>(
         spectrum_im.into_tensor_arg(),
         signal.into_tensor_arg(),
         count as u32,
+        spec_bins as u32,
         n_fft,
         log2_n,
         threads_per_cube,
@@ -111,6 +171,7 @@ fn irfft_kernel<F: Float>(
     spectrum_im: &Tensor<F>,
     signal: &mut Tensor<F>,
     num_windows: u32,
+    spec_bins: u32,
     #[comptime] n_fft: usize,
     #[comptime] log2_n: usize,
     #[comptime] threads_per_cube: usize,
@@ -134,12 +195,22 @@ fn irfft_kernel<F: Float>(
     while k < n_fft {
         let dst = bit_reverse(k, log2_n);
         if k < n_freq {
-            shared_re[dst] = spectrum_re_view[k];
-            shared_im[dst] = spectrum_im_view[k];
+            if k < spec_bins as usize {
+                shared_re[dst] = spectrum_re_view[k];
+                shared_im[dst] = spectrum_im_view[k];
+            } else {
+                shared_re[dst] = F::new(0.0);
+                shared_im[dst] = F::new(0.0);
+            }
         } else {
             let src_bin = n_fft - k;
-            shared_re[dst] = spectrum_re_view[src_bin];
-            shared_im[dst] = -spectrum_im_view[src_bin];
+            if src_bin < spec_bins as usize {
+                shared_re[dst] = spectrum_re_view[src_bin];
+                shared_im[dst] = -spectrum_im_view[src_bin];
+            } else {
+                shared_re[dst] = F::new(0.0);
+                shared_im[dst] = F::new(0.0);
+            }
         }
         k += threads_per_cube;
     }

--- a/crates/cubek-fft/src/fft/irfft.rs
+++ b/crates/cubek-fft/src/fft/irfft.rs
@@ -182,24 +182,12 @@ fn irfft_kernel<F: Float>(
     let mut k = UNIT_POS as usize;
     while k < n_fft {
         let dst = bit_reverse(k, log2_n);
-        if k < n_freq {
-            if k < spec_bins as usize {
-                shared_re[dst] = spectrum_re_view[k];
-                shared_im[dst] = spectrum_im_view[k];
-            } else {
-                shared_re[dst] = F::new(0.0);
-                shared_im[dst] = F::new(0.0);
-            }
-        } else {
-            let src_bin = n_fft - k;
-            if src_bin < spec_bins as usize {
-                shared_re[dst] = spectrum_re_view[src_bin];
-                shared_im[dst] = -spectrum_im_view[src_bin];
-            } else {
-                shared_re[dst] = F::new(0.0);
-                shared_im[dst] = F::new(0.0);
-            }
-        }
+        let src_bin = select(k < n_freq, k, n_fft - k);
+        let active = src_bin < spec_bins as usize;
+        let src_bin = select(active, src_bin, 0);
+        let im_sign = select(k < n_freq, F::new(1.0), F::new(-1.0));
+        shared_re[dst] = select(active, spectrum_re_view[src_bin], F::new(0.0));
+        shared_im[dst] = select(active, spectrum_im_view[src_bin] * im_sign, F::new(0.0));
         k += threads_per_cube;
     }
     sync_cube();

--- a/crates/cubek-fft/src/fft/rfft.rs
+++ b/crates/cubek-fft/src/fft/rfft.rs
@@ -71,9 +71,62 @@ pub fn rfft_launch<R: Runtime>(
     dim: usize,
     dtype: StorageType,
 ) -> Result<(), LaunchError> {
-    let n_fft = signal.shape[dim];
+    let signal_len = signal.shape[dim];
+    rfft_launch_padded::<R>(
+        client,
+        signal,
+        spectrum_re,
+        spectrum_im,
+        dim,
+        signal_len,
+        dtype,
+    )
+}
+
+/// Launches the RFFT kernel while treating samples at `signal_len..n_fft` as zero.
+pub fn rfft_launch_padded<R: Runtime>(
+    client: &ComputeClient<R>,
+    signal: TensorBinding<R>,
+    spectrum_re: TensorBinding<R>,
+    spectrum_im: TensorBinding<R>,
+    dim: usize,
+    signal_len: usize,
+    dtype: StorageType,
+) -> Result<(), LaunchError> {
+    assert!(
+        signal.shape.len() == spectrum_re.shape.len(),
+        "signal and spectrum rank must match"
+    );
+    assert!(
+        spectrum_re.shape == spectrum_im.shape,
+        "spectrum real and imaginary shapes must match"
+    );
+    assert!(dim < signal.shape.len(), "dim must be in bounds");
+    for axis in 0..signal.shape.len() {
+        if axis != dim {
+            assert!(
+                signal.shape[axis] == spectrum_re.shape[axis],
+                "signal and spectrum batch dimensions must match"
+            );
+        }
+    }
+
+    assert!(
+        spectrum_re.shape[dim] >= 2,
+        "RFFT spectrum dimension must contain at least DC and Nyquist bins"
+    );
+    let n_fft = (spectrum_re.shape[dim] - 1) * 2;
     assert!(n_fft.is_power_of_two(), "RFFT requires power-of-2 length");
     assert!(n_fft >= 2, "RFFT requires n_fft >= 2");
+    assert!(
+        signal_len <= signal.shape[dim],
+        "signal_len ({signal_len}) must be <= signal dimension ({})",
+        signal.shape[dim]
+    );
+    assert!(
+        signal_len <= n_fft,
+        "signal_len ({signal_len}) must be <= n_fft ({n_fft})"
+    );
 
     let count: usize = signal
         .shape
@@ -87,7 +140,15 @@ pub fn rfft_launch<R: Runtime>(
     }
 
     if n_fft > SHARED_MEM_CAP {
-        return rfft_large_launch::<R>(client, signal, spectrum_re, spectrum_im, dim, dtype);
+        return rfft_large_launch::<R>(
+            client,
+            signal,
+            spectrum_re,
+            spectrum_im,
+            dim,
+            signal_len,
+            dtype,
+        );
     }
 
     let log2_n = n_fft.trailing_zeros() as usize;
@@ -104,6 +165,7 @@ pub fn rfft_launch<R: Runtime>(
         spectrum_re.into_tensor_arg(),
         spectrum_im.into_tensor_arg(),
         count as u32,
+        signal_len as u32,
         n_fft,
         log2_n,
         threads_per_cube,
@@ -118,6 +180,7 @@ fn rfft_kernel<F: Float>(
     spectrum_re: &mut Tensor<F>,
     spectrum_im: &mut Tensor<F>,
     num_windows: u32,
+    signal_len: u32,
     #[comptime] n_fft: usize,
     #[comptime] log2_n: usize,
     #[comptime] threads_per_cube: usize,
@@ -140,7 +203,11 @@ fn rfft_kernel<F: Float>(
     let mut i = UNIT_POS as usize;
     while i < n_fft {
         let j = bit_reverse(i, log2_n);
-        shared_re[j] = signal_view[i];
+        if i < signal_len as usize {
+            shared_re[j] = signal_view[i];
+        } else {
+            shared_re[j] = F::new(0.0);
+        }
         shared_im[j] = F::new(0.0);
         i += threads_per_cube;
     }

--- a/crates/cubek-fft/src/fft/rfft.rs
+++ b/crates/cubek-fft/src/fft/rfft.rs
@@ -191,11 +191,9 @@ fn rfft_kernel<F: Float>(
     let mut i = UNIT_POS as usize;
     while i < n_fft {
         let j = bit_reverse(i, log2_n);
-        if i < signal_len as usize {
-            shared_re[j] = signal_view[i];
-        } else {
-            shared_re[j] = F::new(0.0);
-        }
+        let active = i < signal_len as usize;
+        let src = select(active, i, 0);
+        shared_re[j] = select(active, signal_view[src], F::new(0.0));
         shared_im[j] = F::new(0.0);
         i += threads_per_cube;
     }

--- a/crates/cubek-fft/src/fft/rfft.rs
+++ b/crates/cubek-fft/src/fft/rfft.rs
@@ -94,22 +94,10 @@ pub fn rfft_launch_padded<R: Runtime>(
     dtype: StorageType,
 ) -> Result<(), LaunchError> {
     assert!(
-        signal.shape.len() == spectrum_re.shape.len(),
-        "signal and spectrum rank must match"
-    );
-    assert!(
         spectrum_re.shape == spectrum_im.shape,
         "spectrum real and imaginary shapes must match"
     );
     assert!(dim < signal.shape.len(), "dim must be in bounds");
-    for axis in 0..signal.shape.len() {
-        if axis != dim {
-            assert!(
-                signal.shape[axis] == spectrum_re.shape[axis],
-                "signal and spectrum batch dimensions must match"
-            );
-        }
-    }
 
     assert!(
         spectrum_re.shape[dim] >= 2,

--- a/crates/cubek-fft/src/fft/rfft_large.rs
+++ b/crates/cubek-fft/src/fft/rfft_large.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 
 /// Forward large-`n_fft` RFFT. Shapes:
-/// * `signal`: (..., n_fft) real.
+/// * `signal`: (..., <= n_fft) real.
 /// * `spectrum_re`, `spectrum_im`: (..., n_fft/2 + 1) complex.
 pub(crate) fn rfft_large_launch<R: Runtime>(
     client: &ComputeClient<R>,
@@ -59,7 +59,7 @@ pub(crate) fn rfft_large_launch<R: Runtime>(
     signal_len: usize,
     dtype: StorageType,
 ) -> Result<(), LaunchError> {
-    let n_fft = signal.shape[dim];
+    let n_fft = (spectrum_re.shape[dim] - 1) * 2;
     let m = n_fft / 2;
     let count: usize = signal
         .shape
@@ -277,16 +277,12 @@ fn rfft_pack_kernel<F: Float>(
     let mut packed_im_view = packed_im.view_mut(BatchSignalLayout::new(packed_im, window, dim));
     let even = 2 * k;
     let odd = even + 1;
-    if even < signal_len as usize {
-        packed_re_view[k] = signal_view[even];
-    } else {
-        packed_re_view[k] = F::new(0.0);
-    }
-    if odd < signal_len as usize {
-        packed_im_view[k] = signal_view[odd];
-    } else {
-        packed_im_view[k] = F::new(0.0);
-    }
+    let even_active = even < signal_len as usize;
+    let odd_active = odd < signal_len as usize;
+    let even = select(even_active, even, 0);
+    let odd = select(odd_active, odd, 0);
+    packed_re_view[k] = select(even_active, signal_view[even], F::new(0.0));
+    packed_im_view[k] = select(odd_active, signal_view[odd], F::new(0.0));
 }
 
 /// Recover `X[0..N/2+1]` from `Y[0..M]` for the packed-real forward path.
@@ -395,40 +391,22 @@ fn irfft_pre_kernel<F: Float>(
     let mut packed_im_view = packed_im.view_mut(BatchSignalLayout::new(packed_im, window, dim));
 
     if k == 0 {
-        let x0_re = if spec_bins > 0 {
-            spectrum_re_view[0]
-        } else {
-            F::new(0.0)
-        };
-        let xm_re = if m < spec_bins as usize {
-            spectrum_re_view[m]
-        } else {
-            F::new(0.0)
-        };
+        let has_nyquist = m < spec_bins as usize;
+        let x0_re = spectrum_re_view[0];
+        let xm = select(has_nyquist, m, 0);
+        let xm_re = select(has_nyquist, spectrum_re_view[xm], F::new(0.0));
         packed_re_view[k] = F::new(0.5) * (x0_re + xm_re);
         packed_im_view[k] = F::new(0.5) * (x0_re - xm_re);
     } else {
-        let x_re = if k < spec_bins as usize {
-            spectrum_re_view[k]
-        } else {
-            F::new(0.0)
-        };
-        let x_im = if k < spec_bins as usize {
-            spectrum_im_view[k]
-        } else {
-            F::new(0.0)
-        };
+        let active = k < spec_bins as usize;
+        let src = select(active, k, 0);
+        let x_re = select(active, spectrum_re_view[src], F::new(0.0));
+        let x_im = select(active, spectrum_im_view[src], F::new(0.0));
         let mirror = m - k;
-        let xm_re = if mirror < spec_bins as usize {
-            spectrum_re_view[mirror]
-        } else {
-            F::new(0.0)
-        };
-        let xm_im_raw = if mirror < spec_bins as usize {
-            spectrum_im_view[mirror]
-        } else {
-            F::new(0.0)
-        };
+        let mirror_active = mirror < spec_bins as usize;
+        let mirror = select(mirror_active, mirror, 0);
+        let xm_re = select(mirror_active, spectrum_re_view[mirror], F::new(0.0));
+        let xm_im_raw = select(mirror_active, spectrum_im_view[mirror], F::new(0.0));
         let xm_im = -xm_im_raw; // conj(X[M-k])
 
         // Inverse twiddle W_N^{-k} = cos(2π k / N) + i sin(2π k / N).

--- a/crates/cubek-fft/src/fft/rfft_large.rs
+++ b/crates/cubek-fft/src/fft/rfft_large.rs
@@ -59,7 +59,7 @@ pub(crate) fn rfft_large_launch<R: Runtime>(
     signal_len: usize,
     dtype: StorageType,
 ) -> Result<(), LaunchError> {
-    let n_fft = (spectrum_re.shape[dim] - 1) * 2;
+    let n_fft = signal.shape[dim];
     let m = n_fft / 2;
     let count: usize = signal
         .shape

--- a/crates/cubek-fft/src/fft/rfft_large.rs
+++ b/crates/cubek-fft/src/fft/rfft_large.rs
@@ -56,9 +56,10 @@ pub(crate) fn rfft_large_launch<R: Runtime>(
     spectrum_re: TensorBinding<R>,
     spectrum_im: TensorBinding<R>,
     dim: usize,
+    signal_len: usize,
     dtype: StorageType,
 ) -> Result<(), LaunchError> {
-    let n_fft = signal.shape[dim];
+    let n_fft = (spectrum_re.shape[dim] - 1) * 2;
     let m = n_fft / 2;
     let count: usize = signal
         .shape
@@ -100,6 +101,7 @@ pub(crate) fn rfft_large_launch<R: Runtime>(
             packed_re.clone().binding().into_tensor_arg(),
             packed_im.clone().binding().into_tensor_arg(),
             (count * m) as u32,
+            signal_len as u32,
             m,
             dim,
         );
@@ -152,6 +154,7 @@ pub(crate) fn irfft_large_launch<R: Runtime>(
     spectrum_im: TensorBinding<R>,
     signal: TensorBinding<R>,
     dim: usize,
+    spec_bins: usize,
     dtype: StorageType,
 ) -> Result<(), LaunchError> {
     let n_fft = signal.shape[dim];
@@ -206,6 +209,7 @@ pub(crate) fn irfft_large_launch<R: Runtime>(
             packed_in_re.clone().binding().into_tensor_arg(),
             packed_in_im.clone().binding().into_tensor_arg(),
             (count * m) as u32,
+            spec_bins as u32,
             n_fft,
             m,
             dim,
@@ -258,6 +262,7 @@ fn rfft_pack_kernel<F: Float>(
     packed_re: &mut Tensor<F>,
     packed_im: &mut Tensor<F>,
     total: u32,
+    signal_len: u32,
     #[comptime] m: usize,
     #[comptime] dim: usize,
 ) {
@@ -270,8 +275,18 @@ fn rfft_pack_kernel<F: Float>(
     let signal_view = signal.view(BatchSignalLayout::new(signal, window, dim));
     let mut packed_re_view = packed_re.view_mut(BatchSignalLayout::new(packed_re, window, dim));
     let mut packed_im_view = packed_im.view_mut(BatchSignalLayout::new(packed_im, window, dim));
-    packed_re_view[k] = signal_view[2 * k];
-    packed_im_view[k] = signal_view[2 * k + 1];
+    let even = 2 * k;
+    let odd = even + 1;
+    if even < signal_len as usize {
+        packed_re_view[k] = signal_view[even];
+    } else {
+        packed_re_view[k] = F::new(0.0);
+    }
+    if odd < signal_len as usize {
+        packed_im_view[k] = signal_view[odd];
+    } else {
+        packed_im_view[k] = F::new(0.0);
+    }
 }
 
 /// Recover `X[0..N/2+1]` from `Y[0..M]` for the packed-real forward path.
@@ -363,6 +378,7 @@ fn irfft_pre_kernel<F: Float>(
     packed_re: &mut Tensor<F>,
     packed_im: &mut Tensor<F>,
     total: u32,
+    spec_bins: u32,
     #[comptime] n_fft: usize,
     #[comptime] m: usize,
     #[comptime] dim: usize,
@@ -379,15 +395,40 @@ fn irfft_pre_kernel<F: Float>(
     let mut packed_im_view = packed_im.view_mut(BatchSignalLayout::new(packed_im, window, dim));
 
     if k == 0 {
-        let x0_re = spectrum_re_view[0];
-        let xm_re = spectrum_re_view[m];
+        let x0_re = if spec_bins > 0 {
+            spectrum_re_view[0]
+        } else {
+            F::new(0.0)
+        };
+        let xm_re = if m < spec_bins as usize {
+            spectrum_re_view[m]
+        } else {
+            F::new(0.0)
+        };
         packed_re_view[k] = F::new(0.5) * (x0_re + xm_re);
         packed_im_view[k] = F::new(0.5) * (x0_re - xm_re);
     } else {
-        let x_re = spectrum_re_view[k];
-        let x_im = spectrum_im_view[k];
-        let xm_re = spectrum_re_view[m - k];
-        let xm_im_raw = spectrum_im_view[m - k];
+        let x_re = if k < spec_bins as usize {
+            spectrum_re_view[k]
+        } else {
+            F::new(0.0)
+        };
+        let x_im = if k < spec_bins as usize {
+            spectrum_im_view[k]
+        } else {
+            F::new(0.0)
+        };
+        let mirror = m - k;
+        let xm_re = if mirror < spec_bins as usize {
+            spectrum_re_view[mirror]
+        } else {
+            F::new(0.0)
+        };
+        let xm_im_raw = if mirror < spec_bins as usize {
+            spectrum_im_view[mirror]
+        } else {
+            F::new(0.0)
+        };
         let xm_im = -xm_im_raw; // conj(X[M-k])
 
         // Inverse twiddle W_N^{-k} = cos(2π k / N) + i sin(2π k / N).

--- a/crates/cubek-fft/tests/suite/irfft.rs
+++ b/crates/cubek-fft/tests/suite/irfft.rs
@@ -230,7 +230,6 @@ fn assert_f32_close(actual: &[f32], expected: &[f32]) {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn irfft_light_axis_last() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let spectrum_shape = [1, 5].to_vec();
@@ -239,7 +238,6 @@ fn irfft_light_axis_last() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn irfft_light_axis_1_strided() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let spectrum_shape = [2, 5, 1].to_vec();
@@ -248,7 +246,6 @@ fn irfft_light_axis_1_strided() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn irfft_light_axis_1_strided_trailing_batch() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let spectrum_shape = [3, 5, 2].to_vec();
@@ -257,7 +254,6 @@ fn irfft_light_axis_1_strided_trailing_batch() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn irfft_light_axis_0_strided() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let spectrum_shape = [5, 2].to_vec();
@@ -266,7 +262,6 @@ fn irfft_light_axis_0_strided() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn irfft_light_axis_last_n16() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let spectrum_shape = [1, 9].to_vec();
@@ -275,14 +270,12 @@ fn irfft_light_axis_last_n16() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn irfft_virtual_padding_axis_1_matches_materialized_zero_padding() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     test_launch_padded(client, vec![2, 3, 3], 1, 8);
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn irfft_virtual_padding_dc_only_matches_materialized_zero_padding() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     test_launch_padded(client, vec![2, 1, 3], 1, 8);

--- a/crates/cubek-fft/tests/suite/irfft.rs
+++ b/crates/cubek-fft/tests/suite/irfft.rs
@@ -1,13 +1,15 @@
+use cubecl::CubeElement;
 use cubecl::{
     client::ComputeClient,
     frontend::CubePrimitive,
+    prelude::StorageType,
     std::tensor::TensorHandle,
     {Runtime, TestRuntime},
 };
-use cubek_fft::irfft_launch;
+use cubek_fft::{irfft_launch, irfft_launch_padded};
 use cubek_test_utils::{
-    self, ExecutionOutcome, HostData, HostDataType, TestInput, TestOutcome, ValidationResult,
-    assert_equals_approx,
+    self, ExecutionOutcome, HostData, HostDataType, HostDataVec, TestInput, TestOutcome,
+    ValidationResult, assert_equals_approx,
 };
 
 use cubek_fft::cpu_reference::irfft_ref;
@@ -57,6 +59,84 @@ fn test_launch(client: ComputeClient<TestRuntime>, spectrum_shape: Vec<usize>, d
     .enforce();
 }
 
+fn test_launch_padded(
+    client: ComputeClient<TestRuntime>,
+    spectrum_shape: Vec<usize>,
+    dim: usize,
+    n_fft: usize,
+) {
+    let dtype = f32::as_type_native_unchecked().storage_type();
+    let spec_bins = spectrum_shape[dim];
+    let n_freq = n_fft / 2 + 1;
+
+    let mut full_spectrum_shape = spectrum_shape.clone();
+    full_spectrum_shape[dim] = n_freq;
+    let mut signal_shape = spectrum_shape.clone();
+    signal_shape[dim] = n_fft;
+
+    let virtual_re = tensor_from_data(
+        &client,
+        spectrum_shape.clone(),
+        &data_for_shape(&spectrum_shape),
+        dtype,
+    );
+    let virtual_im = tensor_from_data(
+        &client,
+        spectrum_shape.clone(),
+        &data_for_shape(&spectrum_shape),
+        dtype,
+    );
+    let padded_re = tensor_from_data(
+        &client,
+        full_spectrum_shape.clone(),
+        &padded_data(&spectrum_shape, dim, n_freq),
+        dtype,
+    );
+    let padded_im = tensor_from_data(
+        &client,
+        full_spectrum_shape,
+        &padded_data(&spectrum_shape, dim, n_freq),
+        dtype,
+    );
+
+    let virtual_signal = empty_tensor(&client, signal_shape.clone(), dtype);
+    let padded_signal = empty_tensor(&client, signal_shape, dtype);
+
+    irfft_launch_padded::<TestRuntime>(
+        &client,
+        virtual_re.binding(),
+        virtual_im.binding(),
+        virtual_signal.clone().binding(),
+        dim,
+        spec_bins,
+        dtype,
+    )
+    .unwrap();
+
+    irfft_launch::<TestRuntime>(
+        &client,
+        padded_re.binding(),
+        padded_im.binding(),
+        padded_signal.clone().binding(),
+        dim,
+        dtype,
+    )
+    .unwrap();
+
+    let actual = to_f32(HostData::from_tensor_handle(
+        &client,
+        virtual_signal,
+        HostDataType::F32,
+    ));
+    let expected = to_f32(HostData::from_tensor_handle(
+        &client,
+        padded_signal,
+        HostDataType::F32,
+    ));
+
+    assert_f32_close(&actual, &expected);
+}
+
 fn assert_irfft_result(
     client: &ComputeClient<TestRuntime>,
     spectrum_re: HostData,
@@ -69,6 +149,84 @@ fn assert_irfft_result(
     let actual_signal = HostData::from_tensor_handle(client, signal, HostDataType::F32);
 
     assert_equals_approx(&actual_signal, &expected_signal, epsilon)
+}
+
+fn to_f32(host: HostData) -> Vec<f32> {
+    match host.data {
+        HostDataVec::F32(v) => v,
+        _ => panic!("expected f32 host data"),
+    }
+}
+
+fn coords_from_index(mut index: usize, shape: &[usize]) -> Vec<usize> {
+    let mut coords = vec![0; shape.len()];
+    for axis in (0..shape.len()).rev() {
+        coords[axis] = index % shape[axis];
+        index /= shape[axis];
+    }
+    coords
+}
+
+fn sample_value(coords: &[usize]) -> f32 {
+    coords
+        .iter()
+        .enumerate()
+        .map(|(axis, coord)| (axis as f32 + 1.0) * (*coord as f32 + 0.25))
+        .sum::<f32>()
+        .sin()
+}
+
+fn data_for_shape(shape: &[usize]) -> Vec<f32> {
+    (0..shape.iter().product::<usize>())
+        .map(|index| sample_value(&coords_from_index(index, shape)))
+        .collect()
+}
+
+fn padded_data(shape: &[usize], dim: usize, target_len: usize) -> Vec<f32> {
+    let mut padded_shape = shape.to_vec();
+    padded_shape[dim] = target_len;
+
+    (0..padded_shape.iter().product::<usize>())
+        .map(|index| {
+            let coords = coords_from_index(index, &padded_shape);
+            if coords[dim] < shape[dim] {
+                sample_value(&coords)
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+fn tensor_from_data(
+    client: &ComputeClient<TestRuntime>,
+    shape: Vec<usize>,
+    data: &[f32],
+    dtype: StorageType,
+) -> TensorHandle<TestRuntime> {
+    TensorHandle::<TestRuntime>::new_contiguous(
+        shape,
+        client.create_from_slice(f32::as_bytes(data)),
+        dtype,
+    )
+}
+
+fn empty_tensor(
+    client: &ComputeClient<TestRuntime>,
+    shape: Vec<usize>,
+    dtype: StorageType,
+) -> TensorHandle<TestRuntime> {
+    let elems = shape.iter().product::<usize>();
+    TensorHandle::<TestRuntime>::new_contiguous(shape, client.empty(elems * dtype.size()), dtype)
+}
+
+fn assert_f32_close(actual: &[f32], expected: &[f32]) {
+    for (index, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (actual - expected).abs() < 1e-4,
+            "mismatch at index {index}: actual={actual}, expected={expected}"
+        );
+    }
 }
 
 #[test]
@@ -114,6 +272,20 @@ fn irfft_light_axis_last_n16() {
     let spectrum_shape = [1, 9].to_vec();
     let dim = spectrum_shape.len() - 1;
     test_launch(client, spectrum_shape, dim);
+}
+
+#[test]
+#[cfg(not(feature = "heavy"))]
+fn irfft_virtual_padding_axis_1_matches_materialized_zero_padding() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    test_launch_padded(client, vec![2, 3, 3], 1, 8);
+}
+
+#[test]
+#[cfg(not(feature = "heavy"))]
+fn irfft_virtual_padding_dc_only_matches_materialized_zero_padding() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    test_launch_padded(client, vec![2, 1, 3], 1, 8);
 }
 
 #[test]
@@ -186,6 +358,13 @@ fn irfft_batched_large_axis_last() {
     let spectrum_shape = [3, 4097].to_vec();
     let dim = spectrum_shape.len() - 1;
     test_launch(client, spectrum_shape, dim);
+}
+
+#[test]
+#[cfg(feature = "heavy")]
+fn irfft_large_virtual_padding_matches_materialized_zero_padding() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    test_launch_padded(client, vec![1, 3000], 1, 8192);
 }
 
 #[test]

--- a/crates/cubek-fft/tests/suite/rfft.rs
+++ b/crates/cubek-fft/tests/suite/rfft.rs
@@ -251,7 +251,6 @@ fn assert_f32_close(actual: &[f32], expected: &[f32]) {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn rfft_light_axis_last() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let signal_shape = [1, 8].to_vec();
@@ -260,7 +259,6 @@ fn rfft_light_axis_last() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn rfft_light_axis_1_strided() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let signal_shape = [2, 8, 1].to_vec();
@@ -269,7 +267,6 @@ fn rfft_light_axis_1_strided() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn rfft_light_axis_1_strided_trailing_batch() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let signal_shape = [3, 8, 2].to_vec();
@@ -278,7 +275,6 @@ fn rfft_light_axis_1_strided_trailing_batch() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn rfft_light_axis_0_strided() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let signal_shape = [8, 2].to_vec();
@@ -287,7 +283,6 @@ fn rfft_light_axis_0_strided() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn rfft_light_axis_last_n16() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let signal_shape = [1, 16].to_vec();
@@ -296,14 +291,12 @@ fn rfft_light_axis_last_n16() {
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn rfft_virtual_padding_axis_1_matches_materialized_zero_padding() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     test_launch_padded(client, vec![2, 5, 3], 1, 5, 8);
 }
 
 #[test]
-#[cfg(not(feature = "heavy"))]
 fn rfft_virtual_padding_ignores_tail_after_signal_len() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     test_launch_padded(client, vec![2, 7, 3], 1, 5, 8);

--- a/crates/cubek-fft/tests/suite/rfft.rs
+++ b/crates/cubek-fft/tests/suite/rfft.rs
@@ -1,13 +1,12 @@
-#[cfg(feature = "heavy")]
 use cubecl::CubeElement;
 use cubecl::{
     client::ComputeClient,
     frontend::CubePrimitive,
+    prelude::StorageType,
     std::tensor::TensorHandle,
     {Runtime, TestRuntime},
 };
-use cubek_fft::rfft_launch;
-#[cfg(feature = "heavy")]
+use cubek_fft::{rfft_launch, rfft_launch_padded};
 use cubek_test_utils::HostDataVec;
 use cubek_test_utils::{
     self, ExecutionOutcome, HostData, HostDataType, TestInput, TestOutcome, ValidationResult,
@@ -60,6 +59,85 @@ fn test_launch(client: ComputeClient<TestRuntime>, signal_shape: Vec<usize>, dim
     .enforce();
 }
 
+fn test_launch_padded(
+    client: ComputeClient<TestRuntime>,
+    signal_shape: Vec<usize>,
+    dim: usize,
+    signal_len: usize,
+    n_fft: usize,
+) {
+    let dtype = f32::as_type_native_unchecked().storage_type();
+    let n_freq = n_fft / 2 + 1;
+
+    let mut spectrum_shape = signal_shape.clone();
+    spectrum_shape[dim] = n_freq;
+    let mut padded_shape = signal_shape.clone();
+    padded_shape[dim] = n_fft;
+
+    let virtual_signal = tensor_from_data(
+        &client,
+        signal_shape.clone(),
+        &data_for_shape_with_len(&signal_shape, dim, signal_len),
+        dtype,
+    );
+    let padded_signal = tensor_from_data(
+        &client,
+        padded_shape,
+        &padded_data(&signal_shape, dim, signal_len, n_fft),
+        dtype,
+    );
+
+    let virtual_re = empty_tensor(&client, spectrum_shape.clone(), dtype);
+    let virtual_im = empty_tensor(&client, spectrum_shape.clone(), dtype);
+    let padded_re = empty_tensor(&client, spectrum_shape.clone(), dtype);
+    let padded_im = empty_tensor(&client, spectrum_shape, dtype);
+
+    rfft_launch_padded::<TestRuntime>(
+        &client,
+        virtual_signal.binding(),
+        virtual_re.clone().binding(),
+        virtual_im.clone().binding(),
+        dim,
+        signal_len,
+        dtype,
+    )
+    .unwrap();
+
+    rfft_launch::<TestRuntime>(
+        &client,
+        padded_signal.binding(),
+        padded_re.clone().binding(),
+        padded_im.clone().binding(),
+        dim,
+        dtype,
+    )
+    .unwrap();
+
+    let actual_re = to_f32(HostData::from_tensor_handle(
+        &client,
+        virtual_re,
+        HostDataType::F32,
+    ));
+    let actual_im = to_f32(HostData::from_tensor_handle(
+        &client,
+        virtual_im,
+        HostDataType::F32,
+    ));
+    let expected_re = to_f32(HostData::from_tensor_handle(
+        &client,
+        padded_re,
+        HostDataType::F32,
+    ));
+    let expected_im = to_f32(HostData::from_tensor_handle(
+        &client,
+        padded_im,
+        HostDataType::F32,
+    ));
+
+    assert_f32_close(&actual_re, &expected_re);
+    assert_f32_close(&actual_im, &expected_im);
+}
+
 pub fn assert_rfft_result(
     client: &ComputeClient<TestRuntime>,
     signal: HostData,
@@ -87,11 +165,88 @@ pub fn assert_rfft_result(
     }
 }
 
-#[cfg(feature = "heavy")]
 fn to_f32(host: HostData) -> Vec<f32> {
     match host.data {
         HostDataVec::F32(v) => v,
         _ => panic!("expected f32 host data"),
+    }
+}
+
+fn coords_from_index(mut index: usize, shape: &[usize]) -> Vec<usize> {
+    let mut coords = vec![0; shape.len()];
+    for axis in (0..shape.len()).rev() {
+        coords[axis] = index % shape[axis];
+        index /= shape[axis];
+    }
+    coords
+}
+
+fn sample_value(coords: &[usize]) -> f32 {
+    coords
+        .iter()
+        .enumerate()
+        .map(|(axis, coord)| (axis as f32 + 1.0) * (*coord as f32 + 0.25))
+        .sum::<f32>()
+        .sin()
+}
+
+fn data_for_shape_with_len(shape: &[usize], dim: usize, signal_len: usize) -> Vec<f32> {
+    (0..shape.iter().product::<usize>())
+        .map(|index| {
+            let coords = coords_from_index(index, shape);
+            if coords[dim] < signal_len {
+                sample_value(&coords)
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+fn padded_data(shape: &[usize], dim: usize, signal_len: usize, target_len: usize) -> Vec<f32> {
+    let mut padded_shape = shape.to_vec();
+    padded_shape[dim] = target_len;
+
+    (0..padded_shape.iter().product::<usize>())
+        .map(|index| {
+            let coords = coords_from_index(index, &padded_shape);
+            if coords[dim] < signal_len {
+                sample_value(&coords)
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
+fn tensor_from_data(
+    client: &ComputeClient<TestRuntime>,
+    shape: Vec<usize>,
+    data: &[f32],
+    dtype: StorageType,
+) -> TensorHandle<TestRuntime> {
+    TensorHandle::<TestRuntime>::new_contiguous(
+        shape,
+        client.create_from_slice(f32::as_bytes(data)),
+        dtype,
+    )
+}
+
+fn empty_tensor(
+    client: &ComputeClient<TestRuntime>,
+    shape: Vec<usize>,
+    dtype: StorageType,
+) -> TensorHandle<TestRuntime> {
+    let elems = shape.iter().product::<usize>();
+    TensorHandle::<TestRuntime>::new_contiguous(shape, client.empty(elems * dtype.size()), dtype)
+}
+
+fn assert_f32_close(actual: &[f32], expected: &[f32]) {
+    for (index, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (actual - expected).abs() < 1e-4,
+            "mismatch at index {index}: actual={actual}, expected={expected}"
+        );
     }
 }
 
@@ -138,6 +293,20 @@ fn rfft_light_axis_last_n16() {
     let signal_shape = [1, 16].to_vec();
     let dim = signal_shape.len() - 1;
     test_launch(client, signal_shape, dim);
+}
+
+#[test]
+#[cfg(not(feature = "heavy"))]
+fn rfft_virtual_padding_axis_1_matches_materialized_zero_padding() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    test_launch_padded(client, vec![2, 5, 3], 1, 5, 8);
+}
+
+#[test]
+#[cfg(not(feature = "heavy"))]
+fn rfft_virtual_padding_ignores_tail_after_signal_len() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    test_launch_padded(client, vec![2, 7, 3], 1, 5, 8);
 }
 
 #[test]
@@ -210,6 +379,13 @@ fn rfft_batched_large_axis_last() {
     let signal_shape = [3, 8192].to_vec();
     let dim = signal_shape.len() - 1;
     test_launch(client, signal_shape, dim);
+}
+
+#[test]
+#[cfg(feature = "heavy")]
+fn rfft_large_virtual_padding_matches_materialized_zero_padding() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    test_launch_padded(client, vec![1, 5000], 1, 5000, 8192);
 }
 
 #[test]


### PR DESCRIPTION
Adds virtual-padding launch variants for real FFT kernels:

  - `rfft_launch_padded(..., signal_len, dtype)`
  - `irfft_launch_padded(..., spec_bins, dtype)`

  These allow callers to pass physically shorter input tensors and have the kernels treat missing samples/bins as zero internally, avoiding an
  explicit zero-padding allocation and copy.

  Closes https://github.com/tracel-ai/cubek/issues/194.

  With these padded launch variants, Burn can remove those [pad_to_length](https://github.com/tracel-ai/burn/blob/17952cd90ee6f5c7a516729f8a46d9d6c20ff71d/crates/burn-cubecl/src/kernel/fft/base.rs#L12) allocations for the CubeCL path.

  ## API shape

  This PR intentionally adds new public APIs instead of changing the existing launch signatures:

  - existing `rfft_launch(...)` still works
  - existing `irfft_launch(...)` still works
  - new `rfft_launch_padded(...)` accepts `signal_len`
  - new `irfft_launch_padded(...)` accepts `spec_bins`

  The existing APIs delegate to the new padded implementations using the full physical input lengths. This keeps current callers source-compatible
  while exposing the extra information needed for virtual padding.

  ## Tests

  Adds coverage for:

  - RFFT virtual padding matching materialized zero-padding
  - RFFT with `signal_len < signal.shape[dim]`, ensuring the physical tail is ignored
  - IRFFT virtual padding matching materialized zero-padding
  - IRFFT with `spec_bins == 1`, covering the DC-only spectrum edge case
  - large packed-real virtual padding cases behind `heavy`

## Validate your PR with burn.

Burn validation branch/commit: https://github.com/g1ibby/burn/commit/3894abc62b3fd1b9e697af4ac6cc27b08753169a
