### PR TITLE
Validate rhs layout for `fused_gemv_unit_perpendicular`

### DIFF
--- a/crates/cubek-matmul/src/components/batch/gemv_unit_perpendicular/setup.rs
+++ b/crates/cubek-matmul/src/components/batch/gemv_unit_perpendicular/setup.rs
@@ -145,6 +145,12 @@ impl BatchMatmulFamily<()> for VecMatUnitPerpendicularFamily {
         _dtypes: &MatmulElems,
         vector_sizes: &MatmulVectorSizes,
     ) -> Result<(), MatmulSetupError> {
+        if !matches!(problem.rhs_layout, MatrixLayout::RowMajor) {
+            return Err(MatmulSetupError::InvalidConfig(Box::new(
+                "Vecmat unit perpendicular only supports row major rhs",
+            )));
+        }
+
         let vector_size = vector_sizes.lhs;
         if !(vector_size == vector_sizes.rhs && vector_size == vector_sizes.out) {
             return Err(MatmulSetupError::InvalidConfig(Box::new(format!(


### PR DESCRIPTION
When testing [fast-whisper-burn](https://github.com/AdrianEddy/fast-whisper-burn) against latest burn, it sometimes failed to produce correct output in f16 mode.

Debugging revealed that `cubek_matmul`'s `VecMatUnitPerpendicular` GEMV kernel was selected by `burn-cubecl-fusion`'s autotune (as `fused_gemv_unit_perpendicular`) for `m=1, n=1500, k=64, F16` - the cross-attention `q @ k.transpose()` matmul in the Whisper decoder. The kernel internally reads rhs as `Vector<V>` along the n axis, which only works for row-major rhs. The standalone launch path (`launch_vecmat_unit_perpendicular.rs`) already enforces this with an explicit RowMajor check, but the fused launch in `optimization.rs:663` skipped that check, so the kernel happily ran on the transposed (col-major) rhs view of `cache.key.transpose()` and produced silently wrong outputs.

**Fix**: Added a `MatrixLayout::RowMajor` check in `validate_blueprint` for `VecMatUnitPerpendicularFamily`. Now when autotune tries this kernel on a non-row-major rhs, it returns `InvalidConfig`, gets marked as failed, and a working alternative (e.g. `fused_simple_vec_mat`) is selected. Verified with 10 consecutive fresh-cache runs - all produce the correct transcription.
