### PR TITLE
fix(matmul): prevent zero stage size in plane selector

### DIFF
--- a/crates/cubek-matmul/src/definition/blueprint.rs
+++ b/crates/cubek-matmul/src/definition/blueprint.rs
@@ -155,13 +155,25 @@ impl TilingBlueprint {
         let plane_dim = device_settings.plane_dim;
         let cube_dim = cubedim_resource.to_cube_dim(plane_dim)?;
 
+        // The number of elements per global partition must be non-zero on every axis,
+        // otherwise the `div_ceil` below panics with "attempt to divide by zero". A
+        // zero here means the tiling scheme is degenerate (e.g. `stage_size == 0`);
+        // reject it so autotune skips the candidate instead of crashing.
+        let part_m = self.tiling_scheme.elements_per_global_partition_along_m();
+        let part_n = self.tiling_scheme.elements_per_global_partition_along_n();
+        let part_b = self.tiling_scheme.global_partition_size.batches;
+        if part_m == 0 || part_n == 0 || part_b == 0 {
+            return Err(MatmulSetupError::InvalidConfig(Box::new(format!(
+                "Degenerate tiling scheme: elements per global partition is zero \
+                 (m={part_m}, n={part_n}, batches={part_b}) for {:?}",
+                self.tiling_scheme
+            ))));
+        }
+
         let target_cube_count = Count3d {
-            x: (problem.m as u32)
-                .div_ceil(self.tiling_scheme.elements_per_global_partition_along_m()),
-            y: (problem.n as u32)
-                .div_ceil(self.tiling_scheme.elements_per_global_partition_along_n()),
-            z: (problem.num_batches() as u32)
-                .div_ceil(self.tiling_scheme.global_partition_size.batches),
+            x: (problem.m as u32).div_ceil(part_m),
+            y: (problem.n as u32).div_ceil(part_n),
+            z: (problem.num_batches() as u32).div_ceil(part_b),
         };
         let cube_count_plan = CubeCountPlan::from_blueprint(
             &self.hypercube_blueprint,

--- a/crates/cubek-matmul/src/routines/selector/plane.rs
+++ b/crates/cubek-matmul/src/routines/selector/plane.rs
@@ -258,6 +258,13 @@ fn select_size(
         }
     } as usize;
 
+    // The number of rows handled per plane cannot exceed the number of available
+    // planes: otherwise `plane_count / rows` underflows to 0, producing a degenerate
+    // tiling scheme with `stage_size.m == 0` that divides by zero in
+    // `TilingBlueprint::cube_launch_info`. Clamp so there is always at least one stage
+    // along `m` (e.g. a large `problem_m` requesting 2 rows when only 1 plane fits).
+    let rows = rows.min(plane_count).max(1);
+
     (rows, plane_count / rows, plane_count)
 }
 
@@ -371,4 +378,40 @@ fn selection_tiny<R: Runtime>(
         .partition_buffering(PartitionBuffering::Single)
         .hypercube_blueprint(hypercube)
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test: when fewer planes are available than the requested
+    /// rows-per-plane (e.g. a large `problem_m` asks for 2 rows but only 1 plane
+    /// fits), `select_size` must not return `stage_size_m == 0`. The zero used to
+    /// propagate into a degenerate `TilingScheme` (`stage_size.m == 0`) and panic
+    /// with "attempt to divide by zero" in `TilingBlueprint::cube_launch_info`.
+    /// Reproduces the rf-detr crash on the `m=1024, n=4, k=256` matmul.
+    #[test]
+    fn select_size_never_yields_zero_stage_size_m() {
+        let plane_count = 1;
+        let instruction_m = 8;
+        let problem_m = 1024;
+
+        for strategy in [
+            MultiRowStrategy::Always(2),
+            MultiRowStrategy::Adaptive {
+                minimum_stage_count: 8,
+            },
+        ] {
+            let (rows_per_plane, stage_size_m, _partition_shape_n) =
+                select_size(strategy, plane_count, instruction_m, problem_m);
+
+            assert!(
+                stage_size_m >= 1,
+                "stage_size_m must be >= 1 (got {stage_size_m}) for {strategy:?} with plane_count={plane_count}"
+            );
+            assert!(rows_per_plane >= 1);
+            // With a single plane we can only fit a single row per plane.
+            assert!(rows_per_plane <= plane_count);
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`select_size` (plane selector) computes the number of stages along `m` as `plane_count / rows` with integer division:

```rust
(rows, plane_count / rows, plane_count)
```

When the multi-row strategy requests more rows per plane than there are planes available — `MultiRowStrategy::Always(2)`, or `Adaptive` on a large `m` — and only a single plane fits (`plane_count == 1`), this underflows to `0`.

That yields a degenerate `TilingScheme` with `stage_size.m == 0`, so `elements_per_global_partition_along_m()` returns `0`, and `TilingBlueprint::cube_launch_info` panics with **`attempt to divide by zero`** at:

```rust
x: (problem.m as u32).div_ceil(self.tiling_scheme.elements_per_global_partition_along_m()),
```

### Reproduction

Hit during autotune of an `m=1024, n=4, k=256` matmul (an RF-DETR object-detection head running on burn/Metal). For that problem `row_count` resolves to `1`, while the strategy asks for `2` rows, giving `stage_size_m = 1 / 2 = 0`. The captured scheme was:

```
TilingScheme {
    tile_size: TileSize { m: 8, n: 8, k: 8 },
    partition_size: PartitionSize { m: 2, n: 1, k: 4 },
    stage_size: StageSize { m: 0, n: 1, k: 1 },   // <- m == 0
    global_partition_size: GlobalPartitionSize { m: 1, n: 1, batches: 1 },
}
```

## Fix

- **Root cause:** clamp `rows` to `plane_count` (and at least `1`) in `select_size`, so there is always at least one stage along `m`. With a single plane it correctly falls back to single-row.
- **Defense in depth:** `cube_launch_info` already returns `Result<_, MatmulSetupError>`; reject a degenerate tiling scheme with `MatmulSetupError::InvalidConfig` instead of dividing by zero, so autotune skips the candidate gracefully rather than panicking the process.
- **Regression test:** `select_size_never_yields_zero_stage_size_m` covers the `plane_count=1`, `rows=2`, `m=1024` case for both `Always(2)` and `Adaptive`. It fails before the fix (panics on the assert) and passes after.

## Verification

- `cargo test -p cubek-matmul --lib` passes.
- The full RF-DETR model now runs a cold autotune to completion on Metal with no panic and correct output, and the defensive guard never even fires (the root fix prevents the degenerate scheme from being generated).

---

🤖 Diagnosis and patch generated with [Claude Code](https://claude.com/claude-code).