### PR TITLE
feat(reduce): add logical any/all reductions

### DIFF
--- a/crates/cubek-reduce/src/components/instructions/all.rs
+++ b/crates/cubek-reduce/src/components/instructions/all.rs
@@ -1,0 +1,126 @@
+use super::{ReduceFamily, ReduceInstruction};
+use crate::components::{
+    instructions::{
+        Accumulator, AccumulatorFormat, Item, ReduceRequirements, ReduceStep, Value,
+        normalize_to_flag,
+    },
+    precision::ReducePrecision,
+};
+use cubecl::prelude::*;
+
+/// Logical-AND reduction: returns `1` if every element along the reduced axis is
+/// non-zero, and `0` otherwise.
+///
+/// Each element is normalized to a `0/1` flag, then combined with `min`. On
+/// `{0, 1}`, AND is exactly `min`, so the vectorized `plane_min` machinery is
+/// reused unchanged.
+#[derive(Debug, CubeType, Clone)]
+pub struct All;
+
+impl ReduceFamily for All {
+    type Instruction<P: ReducePrecision> = Self;
+    type Config = ();
+}
+
+#[cube]
+impl<P: ReducePrecision> ReduceInstruction<P> for All {
+    type SharedAccumulator = Shared<[Vector<P::EA, P::SI>]>;
+    type Config = ();
+
+    fn requirements(_this: &Self) -> ReduceRequirements {
+        ReduceRequirements { coordinates: false }
+    }
+
+    fn accumulator_format(_this: &Self) -> comptime_type!(AccumulatorFormat) {
+        AccumulatorFormat::Single
+    }
+
+    fn from_config(_config: Self::Config) -> Self {
+        All {}
+    }
+
+    fn null_input(_this: &Self) -> Vector<P::EI, P::SI> {
+        // 1 normalizes to flag 1, the identity for AND.
+        Vector::empty().fill(P::EI::from_int(1))
+    }
+
+    fn null_accumulator(_this: &Self) -> Accumulator<P> {
+        Accumulator::<P> {
+            elements: Value::new_single(Vector::empty().fill(P::EA::from_int(1))),
+            args: Value::new_None(),
+        }
+    }
+
+    fn reduce(
+        _this: &Self,
+        accumulator: &mut Accumulator<P>,
+        item: Item<P>,
+        #[comptime] reduce_step: ReduceStep,
+    ) {
+        let accumulator_item = accumulator.elements.item();
+        let flag = normalize_to_flag::<P::EI, P::SI>(item.elements);
+        let elements = match reduce_step {
+            ReduceStep::Plane => {
+                let candidate_item = Vector::cast_from(plane_min(flag));
+                select_many(
+                    accumulator_item.less_than(&candidate_item),
+                    accumulator_item,
+                    candidate_item,
+                )
+            }
+            ReduceStep::Identity => {
+                let flag = Vector::cast_from(flag);
+                select_many(accumulator_item.less_than(&flag), accumulator_item, flag)
+            }
+        };
+
+        accumulator.elements.assign(&Value::new_single(elements));
+    }
+
+    fn plane_reduce_inplace(_this: &Self, accumulator: &mut Accumulator<P>) {
+        // The accumulator already holds 0/1 flags, so min-of-flags is AND.
+        let acc_item = accumulator.elements.item();
+        let candidate_item = Vector::cast_from(plane_min(acc_item));
+        let all = select_many(
+            acc_item.less_than(&candidate_item),
+            acc_item,
+            candidate_item,
+        );
+        accumulator.elements.assign(&Value::new_single(all));
+    }
+
+    fn fuse_accumulators(_this: &Self, accumulator: &mut Accumulator<P>, other: &Accumulator<P>) {
+        let accumulator_item = accumulator.elements.item();
+        let other_item = other.elements.item();
+
+        accumulator.elements.assign(&Value::new_single(select_many(
+            accumulator_item.less_than(&other_item),
+            accumulator_item,
+            other_item,
+        )));
+    }
+
+    fn to_output_parallel<Out: Numeric>(
+        _this: &Self,
+        accumulator: Accumulator<P>,
+        _shape_axis_reduce: usize,
+    ) -> Value<Out> {
+        // Fold the vectorized flags from the AND identity (1).
+        let mut all = P::EA::from_int(1);
+        let accumulator = accumulator.elements.item();
+        #[unroll]
+        for k in 0..accumulator.size() {
+            let candidate = accumulator.extract(k);
+            all = select(candidate < all, candidate, all);
+        }
+        Value::new_single(Out::cast_from(all))
+    }
+
+    fn to_output_perpendicular<Out: Numeric>(
+        _this: &Self,
+        accumulator: Accumulator<P>,
+        _shape_axis_reduce: usize,
+    ) -> Value<Vector<Out, P::SI>> {
+        Value::new_single(Vector::cast_from(accumulator.elements.item()))
+    }
+}

--- a/crates/cubek-reduce/src/components/instructions/any.rs
+++ b/crates/cubek-reduce/src/components/instructions/any.rs
@@ -1,0 +1,126 @@
+use super::{ReduceFamily, ReduceInstruction};
+use crate::components::{
+    instructions::{
+        Accumulator, AccumulatorFormat, Item, ReduceRequirements, ReduceStep, Value,
+        normalize_to_flag,
+    },
+    precision::ReducePrecision,
+};
+use cubecl::prelude::*;
+
+/// Logical-OR reduction: returns `1` if any element along the reduced axis is
+/// non-zero, and `0` otherwise.
+///
+/// Each element is normalized to a `0/1` flag, then combined with `max`. On
+/// `{0, 1}`, OR is exactly `max`, so the vectorized `plane_max` machinery is
+/// reused unchanged.
+#[derive(Debug, CubeType, Clone)]
+pub struct Any;
+
+impl ReduceFamily for Any {
+    type Instruction<P: ReducePrecision> = Self;
+    type Config = ();
+}
+
+#[cube]
+impl<P: ReducePrecision> ReduceInstruction<P> for Any {
+    type SharedAccumulator = Shared<[Vector<P::EA, P::SI>]>;
+    type Config = ();
+
+    fn requirements(_this: &Self) -> ReduceRequirements {
+        ReduceRequirements { coordinates: false }
+    }
+
+    fn accumulator_format(_this: &Self) -> comptime_type!(AccumulatorFormat) {
+        AccumulatorFormat::Single
+    }
+
+    fn from_config(_config: Self::Config) -> Self {
+        Any {}
+    }
+
+    fn null_input(_this: &Self) -> Vector<P::EI, P::SI> {
+        // 0 normalizes to flag 0, the identity for OR.
+        Vector::empty().fill(P::EI::from_int(0))
+    }
+
+    fn null_accumulator(_this: &Self) -> Accumulator<P> {
+        Accumulator::<P> {
+            elements: Value::new_single(Vector::empty().fill(P::EA::from_int(0))),
+            args: Value::new_None(),
+        }
+    }
+
+    fn reduce(
+        _this: &Self,
+        accumulator: &mut Accumulator<P>,
+        item: Item<P>,
+        #[comptime] reduce_step: ReduceStep,
+    ) {
+        let accumulator_item = accumulator.elements.item();
+        let flag = normalize_to_flag::<P::EI, P::SI>(item.elements);
+        let elements = match reduce_step {
+            ReduceStep::Plane => {
+                let candidate_item = Vector::cast_from(plane_max(flag));
+                select_many(
+                    accumulator_item.greater_than(&candidate_item),
+                    accumulator_item,
+                    candidate_item,
+                )
+            }
+            ReduceStep::Identity => {
+                let flag = Vector::cast_from(flag);
+                select_many(accumulator_item.greater_than(&flag), accumulator_item, flag)
+            }
+        };
+
+        accumulator.elements.assign(&Value::new_single(elements));
+    }
+
+    fn plane_reduce_inplace(_this: &Self, accumulator: &mut Accumulator<P>) {
+        // The accumulator already holds 0/1 flags, so max-of-flags is OR.
+        let acc_item = accumulator.elements.item();
+        let candidate_item = Vector::cast_from(plane_max(acc_item));
+        let any = select_many(
+            acc_item.greater_than(&candidate_item),
+            acc_item,
+            candidate_item,
+        );
+        accumulator.elements.assign(&Value::new_single(any));
+    }
+
+    fn fuse_accumulators(_this: &Self, accumulator: &mut Accumulator<P>, other: &Accumulator<P>) {
+        let accumulator_item = accumulator.elements.item();
+        let other_item = other.elements.item();
+
+        accumulator.elements.assign(&Value::new_single(select_many(
+            accumulator_item.greater_than(&other_item),
+            accumulator_item,
+            other_item,
+        )));
+    }
+
+    fn to_output_parallel<Out: Numeric>(
+        _this: &Self,
+        accumulator: Accumulator<P>,
+        _shape_axis_reduce: usize,
+    ) -> Value<Out> {
+        // Fold the vectorized flags from the OR identity (0).
+        let mut any = P::EA::from_int(0);
+        let accumulator = accumulator.elements.item();
+        #[unroll]
+        for k in 0..accumulator.size() {
+            let candidate = accumulator.extract(k);
+            any = select(candidate > any, candidate, any);
+        }
+        Value::new_single(Out::cast_from(any))
+    }
+
+    fn to_output_perpendicular<Out: Numeric>(
+        _this: &Self,
+        accumulator: Accumulator<P>,
+        _shape_axis_reduce: usize,
+    ) -> Value<Vector<Out, P::SI>> {
+        Value::new_single(Vector::cast_from(accumulator.elements.item()))
+    }
+}

--- a/crates/cubek-reduce/src/components/instructions/mixed.rs
+++ b/crates/cubek-reduce/src/components/instructions/mixed.rs
@@ -1,6 +1,6 @@
 use super::{
-    ArgMax, ArgMin, ArgTopK, Max, MaxAbs, Mean, Min, Prod, ReduceFamily, ReduceInstruction,
-    ReduceRequirements, SharedAccumulator, Sum,
+    All, Any, ArgMax, ArgMin, ArgTopK, Max, MaxAbs, Mean, Min, Prod, ReduceFamily,
+    ReduceInstruction, ReduceRequirements, SharedAccumulator, Sum,
 };
 use crate::components::instructions::{
     Accumulator, AccumulatorFormat, Item, SharedAccumulatorKind, TopK,
@@ -30,6 +30,8 @@ pub enum ReduceOperation {
     Min(Min),
     ArgTopK(ArgTopK),
     TopK(TopK),
+    Any(Any),
+    All(All),
 }
 
 #[derive_cube_comptime]
@@ -45,6 +47,8 @@ pub enum ReduceOperationConfig {
     Min,
     ArgTopK(usize),
     TopK(usize),
+    Any,
+    All,
 }
 
 impl ReduceOperationConfig {
@@ -55,10 +59,13 @@ impl ReduceOperationConfig {
             | ReduceOperationConfig::Prod
             | ReduceOperationConfig::Mean => {}
             // No benefit to mixed precision accumulation.
+            // `Any` / `All` keep the accumulator narrow (it only ever holds 0/1 flags).
             ReduceOperationConfig::MaxAbs
             | ReduceOperationConfig::Max
             | ReduceOperationConfig::TopK(_)
-            | ReduceOperationConfig::Min => {
+            | ReduceOperationConfig::Min
+            | ReduceOperationConfig::Any
+            | ReduceOperationConfig::All => {
                 return ReduceDtypes {
                     input: input.into(),
                     output: input.into(),
@@ -223,6 +230,8 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
             ReduceOperation::TopK(topk) => <TopK as ReduceInstruction<P>>::requirements(topk),
             ReduceOperation::Max(max) => <Max as ReduceInstruction<P>>::requirements(max),
             ReduceOperation::Min(min) => <Min as ReduceInstruction<P>>::requirements(min),
+            ReduceOperation::Any(any) => <Any as ReduceInstruction<P>>::requirements(any),
+            ReduceOperation::All(all) => <All as ReduceInstruction<P>>::requirements(all),
         }
     }
 
@@ -246,6 +255,8 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
             ReduceOperation::Max(max) => <Max as ReduceInstruction<P>>::accumulator_format(max),
             ReduceOperation::Min(min) => <Min as ReduceInstruction<P>>::accumulator_format(min),
             ReduceOperation::TopK(topk) => <TopK as ReduceInstruction<P>>::accumulator_format(topk),
+            ReduceOperation::Any(any) => <Any as ReduceInstruction<P>>::accumulator_format(any),
+            ReduceOperation::All(all) => <All as ReduceInstruction<P>>::accumulator_format(all),
         }
     }
 
@@ -261,6 +272,8 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
             ReduceOperationConfig::Max => ReduceOperation::new_Max(Max {}),
             ReduceOperationConfig::Min => ReduceOperation::new_Min(Min {}),
             ReduceOperationConfig::TopK(k) => ReduceOperation::new_TopK(TopK { k }),
+            ReduceOperationConfig::Any => ReduceOperation::new_Any(Any {}),
+            ReduceOperationConfig::All => ReduceOperation::new_All(All {}),
         }
     }
 
@@ -276,6 +289,8 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
             ReduceOperation::Max(max) => <Max as ReduceInstruction<P>>::null_input(max),
             ReduceOperation::Min(min) => <Min as ReduceInstruction<P>>::null_input(min),
             ReduceOperation::TopK(topk) => <TopK as ReduceInstruction<P>>::null_input(topk),
+            ReduceOperation::Any(any) => <Any as ReduceInstruction<P>>::null_input(any),
+            ReduceOperation::All(all) => <All as ReduceInstruction<P>>::null_input(all),
         }
     }
 
@@ -299,6 +314,8 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
             ReduceOperation::Max(max) => <Max as ReduceInstruction<P>>::null_accumulator(max),
             ReduceOperation::Min(min) => <Min as ReduceInstruction<P>>::null_accumulator(min),
             ReduceOperation::TopK(topk) => <TopK as ReduceInstruction<P>>::null_accumulator(topk),
+            ReduceOperation::Any(any) => <Any as ReduceInstruction<P>>::null_accumulator(any),
+            ReduceOperation::All(all) => <All as ReduceInstruction<P>>::null_accumulator(all),
         }
     }
 
@@ -339,6 +356,12 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
             ReduceOperation::TopK(topk) => {
                 <TopK as ReduceInstruction<P>>::reduce(topk, accumulator, item, reduce_step)
             }
+            ReduceOperation::Any(any) => {
+                <Any as ReduceInstruction<P>>::reduce(any, accumulator, item, reduce_step)
+            }
+            ReduceOperation::All(all) => {
+                <All as ReduceInstruction<P>>::reduce(all, accumulator, item, reduce_step)
+            }
         }
     }
 
@@ -374,6 +397,12 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
             ReduceOperation::TopK(topk) => {
                 <TopK as ReduceInstruction<P>>::plane_reduce_inplace(topk, accumulator)
             }
+            ReduceOperation::Any(any) => {
+                <Any as ReduceInstruction<P>>::plane_reduce_inplace(any, accumulator)
+            }
+            ReduceOperation::All(all) => {
+                <All as ReduceInstruction<P>>::plane_reduce_inplace(all, accumulator)
+            }
         }
     }
 
@@ -408,6 +437,12 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
             }
             ReduceOperation::TopK(topk) => {
                 <TopK as ReduceInstruction<P>>::fuse_accumulators(topk, accumulator, other)
+            }
+            ReduceOperation::Any(any) => {
+                <Any as ReduceInstruction<P>>::fuse_accumulators(any, accumulator, other)
+            }
+            ReduceOperation::All(all) => {
+                <All as ReduceInstruction<P>>::fuse_accumulators(all, accumulator, other)
             }
         }
     }
@@ -482,6 +517,16 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
                     shape_axis_reduce,
                 )
             }
+            ReduceOperation::Any(any) => <Any as ReduceInstruction<P>>::to_output_parallel::<Out>(
+                any,
+                accumulator,
+                shape_axis_reduce,
+            ),
+            ReduceOperation::All(all) => <All as ReduceInstruction<P>>::to_output_parallel::<Out>(
+                all,
+                accumulator,
+                shape_axis_reduce,
+            ),
         }
     }
 
@@ -548,6 +593,39 @@ impl<P: ReducePrecision> ReduceInstruction<P> for ReduceOperation {
                     accumulator,
                     shape_axis_reduce,
                 )
+            }
+            ReduceOperation::Any(any) => <Any as ReduceInstruction<P>>::to_output_perpendicular::<
+                Out,
+            >(any, accumulator, shape_axis_reduce),
+            ReduceOperation::All(all) => <All as ReduceInstruction<P>>::to_output_perpendicular::<
+                Out,
+            >(all, accumulator, shape_axis_reduce),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The key benefit of `Any` / `All` over the sum-based emulation is that the
+    /// dynamic dispatch path keeps `accumulation = input`: the accumulator only
+    /// ever holds 0/1 flags, so there is no need to widen (and no overflow) the
+    /// way `Sum` / `Mean` do. Check the narrow accumulator for a narrow float
+    /// (f16, the type that motivated this work) and an integer input.
+    #[test]
+    fn any_all_precision_keeps_input_dtype() {
+        let inputs = [ElemType::Float(FloatKind::F16), ElemType::Int(IntKind::I32)];
+        for config in [ReduceOperationConfig::Any, ReduceOperationConfig::All] {
+            for input in inputs {
+                let dtypes = config.precision(input, None);
+                let expected: StorageType = input.into();
+                assert_eq!(dtypes.input, expected, "input for {input:?}");
+                assert_eq!(dtypes.output, expected, "output for {input:?}");
+                assert_eq!(
+                    dtypes.accumulation, expected,
+                    "accumulation must stay narrow for {input:?}"
+                );
             }
         }
     }

--- a/crates/cubek-reduce/src/components/instructions/mod.rs
+++ b/crates/cubek-reduce/src/components/instructions/mod.rs
@@ -1,3 +1,5 @@
+mod all;
+mod any;
 mod argmax;
 mod argmin;
 mod argtopk;
@@ -12,6 +14,8 @@ mod sum;
 mod topk;
 mod utils;
 
+pub use all::*;
+pub use any::*;
 pub use argmax::*;
 pub use argmin::*;
 pub use argtopk::*;

--- a/crates/cubek-reduce/src/components/instructions/utils.rs
+++ b/crates/cubek-reduce/src/components/instructions/utils.rs
@@ -1,5 +1,16 @@
 use cubecl::prelude::*;
 
+// Normalize each element to a 0/1 flag: non-zero -> 1, zero -> 0.
+// On {0, 1}, OR is exactly `max` and AND is exactly `min`, which lets the logical
+// reductions (`Any` / `All`) reuse the vectorized `plane_max` / `plane_min` machinery
+// while keeping a narrow accumulator (no overflow, unlike a sum-based emulation).
+#[cube]
+pub(crate) fn normalize_to_flag<E: Numeric, N: Size>(item: Vector<E, N>) -> Vector<E, N> {
+    let zero = Vector::empty().fill(E::from_int(0));
+    let one = Vector::empty().fill(E::from_int(1));
+    select_many(item.not_equal(&zero), one, zero)
+}
+
 // Using plane operations, return the lowest coordinate for each vector element
 // for which the item equal the target.
 #[cube]

--- a/crates/cubek-reduce/src/eval/cpu_reference/all.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/all.rs
@@ -1,0 +1,28 @@
+use cubek_test_utils::{HostData, Progress};
+
+use super::{build_f32_output, for_each_output_coord, output_shape};
+
+/// Logical-AND reference: 1.0 if every element along `axis` is non-zero, else 0.0.
+pub fn reference_all(input: &HostData, axis: usize, progress: Option<&Progress>) -> HostData {
+    let axis_len = input.shape[axis];
+    let out_shape_vec = output_shape(&input.shape, axis);
+    let mut data = vec![1.0f32; out_shape_vec.iter().product()];
+
+    for_each_output_coord(&out_shape_vec, |linear, out_coord| {
+        let mut coord = out_coord.to_vec();
+        let mut all = true;
+        for i in 0..axis_len {
+            coord[axis] = i;
+            if input.get_f32(&coord) == 0.0 {
+                all = false;
+                break;
+            }
+        }
+        data[linear] = if all { 1.0 } else { 0.0 };
+        if let Some(p) = progress {
+            p.bump();
+        }
+    });
+
+    build_f32_output(input, axis, data)
+}

--- a/crates/cubek-reduce/src/eval/cpu_reference/any.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/any.rs
@@ -1,0 +1,28 @@
+use cubek_test_utils::{HostData, Progress};
+
+use super::{build_f32_output, for_each_output_coord, output_shape};
+
+/// Logical-OR reference: 1.0 if any element along `axis` is non-zero, else 0.0.
+pub fn reference_any(input: &HostData, axis: usize, progress: Option<&Progress>) -> HostData {
+    let axis_len = input.shape[axis];
+    let out_shape_vec = output_shape(&input.shape, axis);
+    let mut data = vec![0.0f32; out_shape_vec.iter().product()];
+
+    for_each_output_coord(&out_shape_vec, |linear, out_coord| {
+        let mut coord = out_coord.to_vec();
+        let mut any = false;
+        for i in 0..axis_len {
+            coord[axis] = i;
+            if input.get_f32(&coord) != 0.0 {
+                any = true;
+                break;
+            }
+        }
+        data[linear] = if any { 1.0 } else { 0.0 };
+        if let Some(p) = progress {
+            p.bump();
+        }
+    });
+
+    build_f32_output(input, axis, data)
+}

--- a/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
@@ -4,6 +4,8 @@
 //! bits from `(seed, shape, axis, config)` so the two `HostData`s they return
 //! are directly comparable for the same `axis`/`config`.
 
+mod all;
+mod any;
 mod argmax;
 mod argmin;
 mod argtopk;
@@ -15,6 +17,8 @@ mod prod;
 mod sum;
 mod topk;
 
+pub use all::reference_all;
+pub use any::reference_any;
 pub use argmax::reference_argmax;
 pub use argmin::reference_argmin;
 pub use argtopk::reference_argtopk;
@@ -140,6 +144,8 @@ fn reference_for_config(
         ReduceOperationConfig::ArgMin => reference_argmin(input, axis, progress),
         ReduceOperationConfig::ArgTopK(k) => reference_argtopk(input, axis, k, progress),
         ReduceOperationConfig::TopK(k) => reference_topk(input, axis, k, progress),
+        ReduceOperationConfig::Any => reference_any(input, axis, progress),
+        ReduceOperationConfig::All => reference_all(input, axis, progress),
     }
 }
 

--- a/crates/cubek-reduce/tests/reduce/it/logical.rs
+++ b/crates/cubek-reduce/tests/reduce/it/logical.rs
@@ -1,0 +1,100 @@
+//! Deterministic coverage for the `Any` / `All` logical reductions.
+//!
+//! The randomized `test_any` / `test_all` cases (in `reduce_dim.rs`) compare the
+//! GPU output against a CPU reference over many shapes/strategies, but a buggy
+//! kernel could in principle agree with a buggy reference. These hand-written
+//! cases pin the exact 0/1 outputs for a known mask, so both ops are guaranteed
+//! to produce *both* a `0` and a `1` output.
+
+use cubecl::{
+    TestRuntime,
+    ir::{ElemType, FloatKind},
+    prelude::*,
+    zspace::Shape,
+};
+use cubek_reduce::{
+    ReduceStrategy,
+    components::instructions::ReduceOperationConfig,
+    launch::{RoutineStrategy, VectorizationStrategy},
+    reduce,
+    routines::{BlueprintStrategy, unit::UnitStrategy},
+};
+use cubek_test_utils::{
+    ExecutionOutcome, HostData, HostDataType, HostDataVec, StridedLayout, TestInput,
+    launch_and_capture_outcome,
+};
+
+/// Reduce a `[3, 4]` mask along `axis = 1` with `config` and return the 3 output
+/// values. The rows are designed to hit every interesting slice:
+/// `[0,0,0,0]` (empty), `[1,1,1,1]` (full), `[0,1,0,0]` (mixed).
+fn reduce_mask(config: ReduceOperationConfig) -> Vec<f32> {
+    let client = TestRuntime::client(&Default::default());
+
+    let shape = Shape::new([3, 4]);
+    #[rustfmt::skip]
+    let data = vec![
+        0.0, 0.0, 0.0, 0.0, // any = 0, all = 0
+        1.0, 1.0, 1.0, 1.0, // any = 1, all = 1
+        0.0, 1.0, 0.0, 0.0, // any = 1, all = 0
+    ];
+
+    let input_dtype = f32::as_type_native_unchecked().storage_type();
+    let (input_handle, _) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .layout(StridedLayout::Explicit(vec![4, 1]))
+        .custom(data)
+        .generate_with_f32_host_data();
+
+    let output_handle = TestInput::builder(client.clone(), Shape::new([3, 1]))
+        .dtype(input_dtype)
+        .layout(StridedLayout::Explicit(vec![1, 1]))
+        .zeros()
+        .generate_without_host_data();
+
+    // Drives the real `precision()` path: Any/All keep accumulation = input.
+    let dtypes = config.precision(ElemType::Float(FloatKind::F32), None);
+    let strategy = ReduceStrategy {
+        routine: RoutineStrategy::Unit(BlueprintStrategy::Inferred(UnitStrategy)),
+        vectorization: VectorizationStrategy {
+            parallel_output_vectorization: false,
+        },
+    };
+
+    let input_binding = input_handle.binding();
+    let output_binding = output_handle.clone().binding();
+    let outcome = launch_and_capture_outcome(&client, |c| {
+        reduce::<TestRuntime>(
+            c,
+            input_binding,
+            output_binding,
+            1,
+            strategy,
+            config,
+            dtypes,
+        )
+        .into()
+    });
+
+    match outcome {
+        ExecutionOutcome::Executed => {
+            let host = HostData::from_tensor_handle(&client, output_handle, HostDataType::F32);
+            match host.data {
+                HostDataVec::F32(values) => values,
+                other => panic!("expected f32 output, got {other:?}"),
+            }
+        }
+        ExecutionOutcome::CompileError(e) => panic!("compile error: {e}"),
+    }
+}
+
+#[test]
+fn test_any_deterministic() {
+    let out = reduce_mask(ReduceOperationConfig::Any);
+    assert_eq!(out, vec![0.0, 1.0, 1.0]);
+}
+
+#[test]
+fn test_all_deterministic() {
+    let out = reduce_mask(ReduceOperationConfig::All);
+    assert_eq!(out, vec![0.0, 1.0, 0.0]);
+}

--- a/crates/cubek-reduce/tests/reduce/it/mod.rs
+++ b/crates/cubek-reduce/tests/reduce/it/mod.rs
@@ -1,5 +1,7 @@
 pub mod test_case;
 
+mod logical;
+
 macro_rules! testgen_reduce {
     (
         dtype: $dtype:ty,

--- a/crates/cubek-reduce/tests/reduce/it/reduce_dim.rs
+++ b/crates/cubek-reduce/tests/reduce/it/reduce_dim.rs
@@ -83,6 +83,16 @@ pub fn test_max_abs() {
     test_case().test_max_abs();
 }
 
+#[test]
+pub fn test_any() {
+    test_case().test_any();
+}
+
+#[test]
+pub fn test_all() {
+    test_case().test_all();
+}
+
 fn test_case() -> TestCase {
     TestCase::new::<TestDType>(test_shape(), test_strides(), test_axis(), test_strategy())
 }

--- a/crates/cubek-reduce/tests/reduce/it/test_case.rs
+++ b/crates/cubek-reduce/tests/reduce/it/test_case.rs
@@ -10,14 +10,14 @@ use cubek_reduce::{
     reduce,
 };
 use cubek_test_utils::{
-    ExecutionOutcome, HostData, HostDataType, HostDataVec, StridedLayout, TestInput, TestOutcome,
-    assert_equals_approx, launch_and_capture_outcome,
+    Distribution, ExecutionOutcome, HostData, HostDataType, HostDataVec, StridedLayout, TestInput,
+    TestOutcome, assert_equals_approx, launch_and_capture_outcome,
 };
 
 use cubek_reduce::eval::cpu_reference::{
-    contiguous_strides, reference_argmax, reference_argmin, reference_argtopk, reference_max,
-    reference_max_abs, reference_mean, reference_min, reference_prod, reference_sum,
-    reference_topk,
+    contiguous_strides, reference_all, reference_any, reference_argmax, reference_argmin,
+    reference_argtopk, reference_max, reference_max_abs, reference_mean, reference_min,
+    reference_prod, reference_sum, reference_topk,
 };
 
 pub struct TestCase {
@@ -118,6 +118,39 @@ impl TestCase {
         );
     }
 
+    pub fn test_any(&self) {
+        // Bernoulli with p ≈ 1.5/axis_len makes ~22% of reduced slices all-zero
+        // (any = 0) and the rest contain a non-zero (any = 1), so both merge
+        // outcomes are exercised instead of the trivial all-ones case `uniform`
+        // would produce.
+        self.run_reduce_test_with(
+            |input, axis| reference_any(input, axis, None),
+            self.input_dtype,
+            ReduceOperationConfig::Any,
+            0.0,
+            Distribution::Bernoulli(self.flag_probability()),
+        );
+    }
+
+    pub fn test_all(&self) {
+        // Mirror of `test_any`: p ≈ 1 - 1.5/axis_len makes ~22% of slices
+        // all-ones (all = 1) and the rest contain a zero (all = 0).
+        self.run_reduce_test_with(
+            |input, axis| reference_all(input, axis, None),
+            self.input_dtype,
+            ReduceOperationConfig::All,
+            0.0,
+            Distribution::Bernoulli(1.0 - self.flag_probability()),
+        );
+    }
+
+    /// Per-element probability of `1` that yields a genuine mix of 0/1 reduction
+    /// outputs for the current reduce axis length.
+    fn flag_probability(&self) -> f32 {
+        let axis_len = self.shape[self.axis.unwrap()].max(1) as f32;
+        (1.5 / axis_len).clamp(0.0, 1.0)
+    }
+
     pub fn test_argmax(&self) {
         let u32_dtype = u32::as_type_native_unchecked().storage_type();
         self.run_reduce_test(
@@ -164,6 +197,23 @@ impl TestCase {
         config: ReduceOperationConfig,
         epsilon: f32,
     ) {
+        self.run_reduce_test_with(
+            reference,
+            output_dtype,
+            config,
+            epsilon,
+            Distribution::Uniform(-1., 1.),
+        );
+    }
+
+    fn run_reduce_test_with(
+        &self,
+        reference: impl FnOnce(&HostData, usize) -> HostData,
+        output_dtype: StorageType,
+        config: ReduceOperationConfig,
+        epsilon: f32,
+        distribution: Distribution,
+    ) {
         let client = TestRuntime::client(&Default::default());
         let axis = self.axis.unwrap();
 
@@ -172,7 +222,7 @@ impl TestCase {
             .layout(StridedLayout::Explicit(
                 self.stride.iter().copied().collect(),
             ))
-            .uniform(1234, -1., 1.)
+            .random(1234, distribution)
             .generate_with_f32_host_data();
 
         let expected = cast_host_through_dtype(reference(&input_host, axis), output_dtype);


### PR DESCRIPTION
This PR adds logical `any` and `all` reductions to `cubek-reduce` which mentioned in [https://github.com/tracel-ai/burn/issues/5046](url)

## Changes include:
  - add `Any` and `All` reduction instructions
  - add CPU reference implementations for logical reductions
  - wire logical reductions into mixed reduction instruction dispatch
  - add integration tests for `any` / `all` over reduce dims and full reductions

## Validation

Focused validation for this change passed:

  ```bash
  cargo fmt -p cubek-reduce -- --check
  cargo clippy -p cubek-reduce --all-targets -- -D warnings
  cargo test -p cubek-reduce
  cargo test -p cubek-reduce test_any
  cargo test -p cubek-reduce test_all
  cargo test -p cubek-reduce logical::
  git diff --check
```

  I also ran the full repository gate:

```  
cargo xtask validate
```

  It currently does not complete locally, but the failures appear unrelated to this PR:


## Burn validation

A downstream Burn validation branch/PR will be prepared separately after this cubek PR is opened, using this PR branch as the cubek dependency.