### PR TITLE
More representative naming in quantize/dequantize kernels and remove hardcoded u32

### DIFF
--- a/crates/cubek-quant/src/dequantize.rs
+++ b/crates/cubek-quant/src/dequantize.rs
@@ -4,10 +4,10 @@ use cubecl::{calculate_cube_count_elemwise, ir::ElemType};
 use cubecl::{features::TypeUsage, tensor_vector_size_parallel};
 use cubecl::{prelude::*, std::tensor::layout::linear::LinearViewMut};
 
-use crate::utils::quant_size_bytes;
 use crate::{
     layout::{ScalesView, scales_view},
     scheme::{QuantLevel, QuantMode, QuantScheme, QuantStore, QuantValue},
+    utils::packed_storage_elem,
 };
 use cubecl::std::tensor::{
     View,
@@ -139,12 +139,12 @@ fn unpack_q<F: Float, NF: Size, QS: Int>(
 }
 
 #[cube(launch_unchecked, address_type = "dynamic")]
-fn dequantize_symmetric_packed_kernel<F: Float, NF: Size, FS: Numeric, NQ: Size>(
-    input: LinearView<'_, Vector<u32, NQ>>,
+fn dequantize_symmetric_packed_kernel<F: Float, NF: Size, FS: Numeric, QS: Int, NQ: Size>(
+    input: LinearView<'_, Vector<QS, NQ>>,
     scales: ScalesView<'_, FS>,
     mut output: LinearViewMut<'_, Vector<F, NF>>,
     #[comptime] scheme: QuantScheme,
-    #[define(F, FS)] _dtypes: [StorageType; 2],
+    #[define(F, FS, QS)] _dtypes: [StorageType; 3],
 ) {
     if !input.is_in_bounds(ABSOLUTE_POS) {
         terminate!();
@@ -160,9 +160,8 @@ fn dequantize_symmetric_packed_kernel<F: Float, NF: Size, FS: Numeric, NQ: Size>
     let values = input.read(ABSOLUTE_POS);
     let packed_pos = ABSOLUTE_POS * scheme.num_quants();
 
-    let out = dequantize_symmetric_packed_value::<F, NF, FS, u32, NQ>(
-        values, &scales, packed_pos, scheme,
-    );
+    let out =
+        dequantize_symmetric_packed_value::<F, NF, FS, QS, NQ>(values, &scales, packed_pos, scheme);
 
     #[unroll]
     for i in 0..vector_size_in {
@@ -263,10 +262,10 @@ fn dequantize_packed<R: Runtime>(
     scale_dtype: StorageType,
 ) -> Result<(), LaunchError> {
     let num_elems_input: usize = input.shape.iter().product();
-    let input_size = quant_size_bytes(&scheme);
+    let input_dtype = packed_storage_elem(&scheme);
 
     let mut vector_size_in = tensor_vector_size_parallel(
-        client.io_optimized_vector_sizes(input_size),
+        client.io_optimized_vector_sizes(input_dtype.size()),
         &input.shape,
         &input.strides,
         input.shape.len() - 1,
@@ -283,7 +282,7 @@ fn dequantize_packed<R: Runtime>(
     let cube_dim = CubeDim::new(client, num_elems);
     let cube_count = calculate_cube_count_elemwise(client, num_elems, cube_dim);
     let address_type = input
-        .required_address_type(input_size)
+        .required_address_type(input_dtype.size())
         .max(scale.required_address_type(scale_dtype.size()))
         .max(output.required_address_type(output_dtype.size()));
 
@@ -305,7 +304,7 @@ fn dequantize_packed<R: Runtime>(
                 scales_view(input, scale, 1, &scheme),
                 linear_view(output),
                 scheme,
-                [output_dtype, scale_dtype],
+                [output_dtype, scale_dtype, input_dtype.into()],
             )
         },
         QuantScheme { .. } => panic!("Unsupported quantization scheme {scheme:?}"),

--- a/crates/cubek-quant/src/dequantize.rs
+++ b/crates/cubek-quant/src/dequantize.rs
@@ -1,14 +1,12 @@
 #![allow(missing_docs)] // pub cube modules
 
-use cubecl::{
-    calculate_cube_count_elemwise,
-    ir::{ElemType, FloatKind, IntKind},
-};
+use cubecl::{calculate_cube_count_elemwise, ir::ElemType};
 use cubecl::{features::TypeUsage, tensor_vector_size_parallel};
 use cubecl::{prelude::*, std::tensor::layout::linear::LinearViewMut};
 
 use crate::{
     layout::{ScalesView, scales_view},
+    quant_size_bytes,
     scheme::{QuantLevel, QuantMode, QuantScheme, QuantStore, QuantValue},
 };
 use cubecl::std::tensor::{
@@ -261,13 +259,14 @@ fn dequantize_packed<R: Runtime>(
     scheme: QuantScheme,
     scale: TensorBinding<R>,
     output: TensorBinding<R>,
-    input_dtype: StorageType,
+    output_dtype: StorageType,
     scale_dtype: StorageType,
 ) -> Result<(), LaunchError> {
     let num_elems_input: usize = input.shape.iter().product();
+    let input_size = quant_size_bytes(&scheme);
 
     let mut vector_size_in = tensor_vector_size_parallel(
-        client.io_optimized_vector_sizes(input_dtype.size()),
+        client.io_optimized_vector_sizes(input_size),
         &input.shape,
         &input.strides,
         input.shape.len() - 1,
@@ -284,9 +283,9 @@ fn dequantize_packed<R: Runtime>(
     let cube_dim = CubeDim::new(client, num_elems);
     let cube_count = calculate_cube_count_elemwise(client, num_elems, cube_dim);
     let address_type = input
-        .required_address_type(size_of::<u32>())
+        .required_address_type(input_size)
         .max(scale.required_address_type(scale_dtype.size()))
-        .max(output.required_address_type(input_dtype.size()));
+        .max(output.required_address_type(output_dtype.size()));
 
     match scheme {
         QuantScheme {
@@ -306,7 +305,7 @@ fn dequantize_packed<R: Runtime>(
                 scales_view(input, scale, 1, &scheme),
                 linear_view(output),
                 scheme,
-                [input_dtype, scale_dtype],
+                [output_dtype, scale_dtype],
             )
         },
         QuantScheme { .. } => panic!("Unsupported quantization scheme {scheme:?}"),
@@ -321,10 +320,11 @@ fn dequantize_native<R: Runtime>(
     scheme: QuantScheme,
     scale: TensorBinding<R>,
     output: TensorBinding<R>,
-    input_dtype: StorageType,
+    output_dtype: StorageType,
     scale_dtype: StorageType,
 ) -> Result<(), LaunchError> {
     let num_elems: usize = input.shape.iter().product();
+    let input_dtype = ElemType::from_quant_value(scheme.value);
     let vector_size = tensor_vector_size_parallel(
         client.io_optimized_vector_sizes(input_dtype.size()),
         &input.shape,
@@ -339,22 +339,13 @@ fn dequantize_native<R: Runtime>(
         QuantScheme {
             level: QuantLevel::Tensor | QuantLevel::Block(_),
             mode: QuantMode::Symmetric,
-            value,
             store: QuantStore::Native,
             ..
         } => {
-            let quant_dtype: ElemType = match value {
-                QuantValue::Q8F | QuantValue::Q8S => ElemType::Int(IntKind::I8),
-                QuantValue::E4M3 => ElemType::Float(FloatKind::E4M3),
-                QuantValue::E5M2 => ElemType::Float(FloatKind::E5M2),
-                QuantValue::E2M1 => ElemType::Float(FloatKind::E2M1),
-                other => panic!("Unsupported quantization value {other:?}"),
-            };
-
             let address_type = input
-                .required_address_type(quant_dtype.size())
+                .required_address_type(input_dtype.size())
                 .max(scale.required_address_type(scale_dtype.size()))
-                .max(output.required_address_type(input_dtype.size()));
+                .max(output.required_address_type(output_dtype.size()));
 
             unsafe {
                 dequantize_symmetric_native_kernel::launch_unchecked(
@@ -367,7 +358,7 @@ fn dequantize_native<R: Runtime>(
                     linear_view(input.clone()),
                     scales_view(input, scale, 1, &scheme),
                     linear_view(output),
-                    [input_dtype, scale_dtype, quant_dtype.into()],
+                    [output_dtype, scale_dtype, input_dtype.into()],
                 )
             }
         }

--- a/crates/cubek-quant/src/dequantize.rs
+++ b/crates/cubek-quant/src/dequantize.rs
@@ -4,9 +4,9 @@ use cubecl::{calculate_cube_count_elemwise, ir::ElemType};
 use cubecl::{features::TypeUsage, tensor_vector_size_parallel};
 use cubecl::{prelude::*, std::tensor::layout::linear::LinearViewMut};
 
+use crate::utils::quant_size_bytes;
 use crate::{
     layout::{ScalesView, scales_view},
-    quant_size_bytes,
     scheme::{QuantLevel, QuantMode, QuantScheme, QuantStore, QuantValue},
 };
 use cubecl::std::tensor::{
@@ -171,10 +171,10 @@ fn dequantize_symmetric_packed_kernel<F: Float, NF: Size, FS: Numeric, NQ: Size>
 }
 
 #[cube(launch_unchecked, address_type = "dynamic")]
-fn dequantize_symmetric_native_kernel<F: Float, NF: Size, FS: Numeric, Q: Numeric, NQ: Size>(
-    input: LinearView<'_, Vector<Q, NQ>>,
+fn dequantize_symmetric_native_kernel<F: Float, N: Size, FS: Numeric, Q: Numeric>(
+    input: LinearView<'_, Vector<Q, N>>,
     scale: ScalesView<'_, FS>,
-    mut output: LinearViewMut<'_, Vector<F, NF>>,
+    mut output: LinearViewMut<'_, Vector<F, N>>,
     #[define(F, FS, Q)] _dtypes: [StorageType; 3],
 ) {
     if !input.is_in_bounds(ABSOLUTE_POS) {
@@ -187,7 +187,7 @@ fn dequantize_symmetric_native_kernel<F: Float, NF: Size, FS: Numeric, Q: Numeri
 
     output.write(
         ABSOLUTE_POS,
-        dequantize_symmetric::<F, FS, NF>(Vector::cast_from(input.read(ABSOLUTE_POS)), scale),
+        dequantize_symmetric::<F, FS, N>(Vector::cast_from(input.read(ABSOLUTE_POS)), scale),
     );
 }
 
@@ -195,13 +195,13 @@ fn dequantize_symmetric_native_kernel<F: Float, NF: Size, FS: Numeric, Q: Numeri
 /// Convert the tensor back to a higher precision data type.
 pub fn launch_ref<R: Runtime>(
     client: &ComputeClient<R>,
-    values: TensorBinding<R>,
+    input: TensorBinding<R>,
     output: TensorBinding<R>,
-    params: TensorBinding<R>,
+    scale: TensorBinding<R>,
     scheme: &QuantScheme,
-    input_dtype: StorageType,
+    output_dtype: StorageType,
 ) -> Result<(), LaunchError> {
-    let dtype_scale: StorageType = ElemType::from_quant_param(scheme.param).into();
+    let scale_dtype: StorageType = ElemType::from_quant_param(scheme.param).into();
 
     match scheme {
         QuantScheme {
@@ -209,12 +209,12 @@ pub fn launch_ref<R: Runtime>(
             ..
         } => dequantize_packed(
             client,
-            values,
+            input,
             *scheme,
-            params,
+            scale,
             output,
-            input_dtype,
-            dtype_scale,
+            output_dtype,
+            scale_dtype,
         ),
         QuantScheme {
             value: QuantValue::Q8F | QuantValue::Q8S | QuantValue::E4M3 | QuantValue::E5M2,
@@ -235,12 +235,12 @@ pub fn launch_ref<R: Runtime>(
 
             dequantize_native(
                 client,
-                values,
+                input,
                 *scheme,
-                params,
+                scale,
                 output,
-                input_dtype,
-                dtype_scale,
+                output_dtype,
+                scale_dtype,
             )
         }
         QuantScheme {
@@ -325,12 +325,15 @@ fn dequantize_native<R: Runtime>(
 ) -> Result<(), LaunchError> {
     let num_elems: usize = input.shape.iter().product();
     let input_dtype = ElemType::from_quant_value(scheme.value);
+
+    let candidates = client.io_optimized_vector_sizes(input_dtype.size().max(output_dtype.size()));
     let vector_size = tensor_vector_size_parallel(
-        client.io_optimized_vector_sizes(input_dtype.size()),
+        candidates,
         &input.shape,
         &input.strides,
         input.shape.len() - 1,
     );
+
     let working_units = num_elems / vector_size as usize;
     let cube_dim = CubeDim::new(client, working_units);
     let cube_count = calculate_cube_count_elemwise(client, working_units, cube_dim);
@@ -353,7 +356,6 @@ fn dequantize_native<R: Runtime>(
                     cube_count,
                     cube_dim,
                     address_type,
-                    vector_size,
                     vector_size,
                     linear_view(input.clone()),
                     scales_view(input, scale, 1, &scheme),

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -31,8 +31,14 @@ pub(crate) mod utils {
             );
         }
     }
-}
 
-pub fn quant_size_bytes(scheme: &scheme::QuantScheme) -> usize {
-    scheme.size_bits_stored() / 8
+    pub(crate) fn quant_size_bytes(scheme: &QuantScheme) -> usize {
+        debug_assert!(
+            scheme.size_bits_stored() % 8 == 0,
+            "size_bits_stored must be divisible by 8, got {} -> {}",
+            scheme.size_bits_stored(),
+            scheme.size_bits_stored() / 8
+        );
+        scheme.size_bits_stored() / 8
+    }
 }

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -15,7 +15,8 @@ pub use cubecl_common::quant::scheme;
 
 #[cfg(feature = "kernels")]
 pub(crate) mod utils {
-    use crate::scheme::{QuantLevel, QuantScheme};
+    use crate::scheme::{QuantLevel, QuantScheme, QuantStore};
+    use cubecl::ir::{ElemType, UIntKind};
 
     pub(crate) fn check_block_size_compat(scheme: &QuantScheme, div: usize) {
         // Validate block size compatibility
@@ -32,13 +33,10 @@ pub(crate) mod utils {
         }
     }
 
-    pub(crate) fn quant_size_bytes(scheme: &QuantScheme) -> usize {
-        debug_assert!(
-            scheme.size_bits_stored() % 8 == 0,
-            "size_bits_stored must be divisible by 8, got {} -> {}",
-            scheme.size_bits_stored(),
-            scheme.size_bits_stored() / 8
-        );
-        scheme.size_bits_stored() / 8
+    pub(crate) fn packed_storage_elem(scheme: &QuantScheme) -> ElemType {
+        match scheme.store {
+            QuantStore::PackedU32(_) => ElemType::UInt(UIntKind::U32),
+            store => panic!("Unsupported packed storage {store:?}"),
+        }
     }
 }

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -32,3 +32,7 @@ pub(crate) mod utils {
         }
     }
 }
+
+pub fn quant_size_bytes(scheme: &scheme::QuantScheme) -> usize {
+    scheme.size_bits_stored() / 8
+}

--- a/crates/cubek-quant/src/quantize.rs
+++ b/crates/cubek-quant/src/quantize.rs
@@ -12,7 +12,7 @@ use cubecl::{
 
 use crate::{
     layout::{ScalesLayout, ScalesViewMut, scales_view},
-    utils::{check_block_size_compat, quant_size_bytes},
+    utils::{check_block_size_compat, packed_storage_elem},
 };
 use crate::{
     layout::{ScalesView, scales_layout},
@@ -130,16 +130,16 @@ fn quantize_symmetric_native_kernel<F: Float, N: Size, FS: Numeric, Q: Numeric>(
 }
 
 #[cube(launch_unchecked, address_type = "dynamic")]
-fn quantize_symmetric_packed_kernel<F: Float, N: Size, FS: Numeric>(
+fn quantize_symmetric_packed_kernel<F: Float, N: Size, FS: Numeric, QS: Int>(
     input: LinearView<'_, Vector<F, N>>,
     scale: ScalesView<'_, F>,
     range_min: InputScalar,
     range_max: InputScalar,
-    mut output: LinearViewMut<'_, u32>,
+    mut output: LinearViewMut<'_, QS>,
     out_scale: ScalesViewMut<'_, FS>,
     scales_layout: ScalesLayout,
     #[comptime] scheme: QuantScheme,
-    #[define(F, FS)] _dtypes: [StorageType; 2],
+    #[define(F, FS, QS)] _dtypes: [StorageType; 3],
 ) {
     if !output.is_in_bounds(ABSOLUTE_POS) {
         terminate!();
@@ -152,7 +152,7 @@ fn quantize_symmetric_packed_kernel<F: Float, N: Size, FS: Numeric>(
     if input.vector_size().comptime() == num_quants {
         output.write(
             ABSOLUTE_POS,
-            quantize_packed_value::<F, N, FS, u32>(
+            quantize_packed_value::<F, N, FS, QS>(
                 input.read(ABSOLUTE_POS),
                 scale,
                 range_min.get::<F>(),
@@ -170,7 +170,7 @@ fn quantize_symmetric_packed_kernel<F: Float, N: Size, FS: Numeric>(
         }
         output.write(
             ABSOLUTE_POS,
-            quantize_packed_value::<F, NQ, FS, u32>(
+            quantize_packed_value::<F, NQ, FS, QS>(
                 values,
                 scale,
                 range_min.get::<F>(),
@@ -259,8 +259,9 @@ fn quantize_native<R: Runtime>(
     let num_elems: usize = input.shape.iter().product();
     let output_dtype = ElemType::from_quant_value(scheme.value);
 
+    let candidates = client.io_optimized_vector_sizes(input_dtype.size().max(output_dtype.size()));
     let vector_size = tensor_vector_size_parallel(
-        client.io_optimized_vector_sizes(input_dtype.size()),
+        candidates,
         &input.shape,
         &input.strides,
         input.shape.len() - 1,
@@ -357,13 +358,12 @@ fn quantize_packed<R: Runtime>(
     let cube_dim = CubeDim::new(client, working_units);
     let cube_count = calculate_cube_count_elemwise(client, working_units, cube_dim);
     let (range_min, range_max) = scheme.value.range();
-
-    let output_size = quant_size_bytes(scheme);
+    let output_dtype = packed_storage_elem(scheme);
 
     let address_type = input
         .required_address_type(input_dtype.size())
         .max(scale.required_address_type(scale_dtype.size()))
-        .max(output.required_address_type(output_size));
+        .max(output.required_address_type(output_dtype.size()));
 
     check_block_size_compat(scheme, num_quants); // 32 / 8 = 4
 
@@ -385,7 +385,7 @@ fn quantize_packed<R: Runtime>(
             scales_view(output, out_scale, 1, scheme),
             scales_layout,
             *scheme,
-            [input_dtype.into(), scale_dtype.into()],
+            [input_dtype.into(), scale_dtype.into(), output_dtype.into()],
         )
     };
 

--- a/crates/cubek-quant/src/quantize.rs
+++ b/crates/cubek-quant/src/quantize.rs
@@ -12,6 +12,7 @@ use cubecl::{
 
 use crate::{
     layout::{ScalesLayout, ScalesViewMut, scales_view},
+    quant_size_bytes,
     utils::check_block_size_compat,
 };
 use crate::{
@@ -263,12 +264,12 @@ fn quantize_native<R: Runtime>(
         } => {
             // We could use vector_size = block_size if it's in the supported vector sizes.. but let's keep it simple
             check_block_size_compat(scheme, vector_size as usize);
-            let quant_type = ElemType::from_quant_value(scheme.value);
+            let quant_dtype = ElemType::from_quant_value(scheme.value);
 
             let address_type = input
                 .required_address_type(input_dtype.size())
                 .max(scale.required_address_type(scale_dtype.size()))
-                .max(output.required_address_type(quant_type.size()));
+                .max(output.required_address_type(quant_dtype.size()));
 
             let scales_layout = scales_layout(&output, &scale, 1, scheme);
 
@@ -287,7 +288,7 @@ fn quantize_native<R: Runtime>(
                     linear_view(output.clone()),
                     scales_view(output, out_scale, 1, scheme),
                     scales_layout,
-                    [input_dtype.into(), scale_dtype.into(), quant_type.into()],
+                    [input_dtype.into(), scale_dtype.into(), quant_dtype.into()],
                 )
             }
         }
@@ -305,8 +306,8 @@ fn quantize_packed<R: Runtime>(
     scale: TensorBinding<R>,
     out_scale: TensorBinding<R>,
     output: TensorBinding<R>,
-    dtype_input: ElemType,
-    dtype_param: ElemType,
+    input_dtype: ElemType,
+    scale_dtype: ElemType,
 ) -> Result<(), LaunchError> {
     let num_elems: usize = input.shape.iter().product();
 
@@ -329,7 +330,7 @@ fn quantize_packed<R: Runtime>(
     let num_quants = scheme.num_quants();
     let input = if !can_vectorize && num_elems >= 2048 {
         can_vectorize = true;
-        into_contiguous(client, input, dtype_input.into()).binding()
+        into_contiguous(client, input, input_dtype.into()).binding()
     } else {
         input
     };
@@ -342,10 +343,12 @@ fn quantize_packed<R: Runtime>(
     let cube_count = calculate_cube_count_elemwise(client, working_units, cube_dim);
     let (range_min, range_max) = scheme.value.range();
 
+    let output_size = quant_size_bytes(scheme);
+
     let address_type = input
-        .required_address_type(dtype_input.size())
-        .max(scale.required_address_type(dtype_input.size()))
-        .max(output.required_address_type(size_of::<u32>()));
+        .required_address_type(input_dtype.size())
+        .max(scale.required_address_type(scale_dtype.size()))
+        .max(output.required_address_type(output_size));
 
     check_block_size_compat(scheme, num_quants); // 32 / 8 = 4
 
@@ -361,13 +364,13 @@ fn quantize_packed<R: Runtime>(
             linear_view(input),
             // scale is computed based on input float dtype, but stored based on qparams precision
             scales_view(output.clone(), scale, 1, scheme),
-            InputScalar::new(range_min, dtype_input),
-            InputScalar::new(range_max, dtype_input),
+            InputScalar::new(range_min, input_dtype),
+            InputScalar::new(range_max, input_dtype),
             linear_view(output.clone()),
             scales_view(output, out_scale, 1, scheme),
             scales_layout,
             *scheme,
-            [dtype_input.into(), dtype_param.into()],
+            [input_dtype.into(), scale_dtype.into()],
         )
     };
 

--- a/crates/cubek-quant/src/quantize.rs
+++ b/crates/cubek-quant/src/quantize.rs
@@ -12,8 +12,7 @@ use cubecl::{
 
 use crate::{
     layout::{ScalesLayout, ScalesViewMut, scales_view},
-    quant_size_bytes,
-    utils::check_block_size_compat,
+    utils::{check_block_size_compat, quant_size_bytes},
 };
 use crate::{
     layout::{ScalesView, scales_layout},
@@ -192,14 +191,21 @@ pub fn launch_ref<R: Runtime>(
     scheme: &QuantScheme,
     input_elem: ElemType,
 ) -> Result<(), LaunchError> {
-    let param_elem = ElemType::from_quant_param(scheme.param);
+    let scale_dtype = ElemType::from_quant_param(scheme.param);
 
     match scheme {
         QuantScheme {
             store: QuantStore::PackedU32(_),
             ..
         } => quantize_packed(
-            client, input, scheme, scale, out_scale, output, input_elem, param_elem,
+            client,
+            input,
+            scheme,
+            scale,
+            out_scale,
+            output,
+            input_elem,
+            scale_dtype,
         ),
         QuantScheme {
             value: QuantValue::Q8F | QuantValue::Q8S | QuantValue::E4M3 | QuantValue::E5M2,
@@ -219,7 +225,14 @@ pub fn launch_ref<R: Runtime>(
             }
 
             quantize_native(
-                client, input, scheme, scale, out_scale, output, input_elem, param_elem,
+                client,
+                input,
+                scheme,
+                scale,
+                out_scale,
+                output,
+                input_elem,
+                scale_dtype,
             )
         }
         QuantScheme {
@@ -244,12 +257,15 @@ fn quantize_native<R: Runtime>(
     scale_dtype: ElemType,
 ) -> Result<(), LaunchError> {
     let num_elems: usize = input.shape.iter().product();
+    let output_dtype = ElemType::from_quant_value(scheme.value);
+
     let vector_size = tensor_vector_size_parallel(
         client.io_optimized_vector_sizes(input_dtype.size()),
         &input.shape,
         &input.strides,
         input.shape.len() - 1,
     );
+
     let working_units = num_elems / vector_size as usize;
     let cube_dim = CubeDim::new(client, working_units);
     let cube_count = calculate_cube_count_elemwise(client, working_units, cube_dim);
@@ -264,12 +280,11 @@ fn quantize_native<R: Runtime>(
         } => {
             // We could use vector_size = block_size if it's in the supported vector sizes.. but let's keep it simple
             check_block_size_compat(scheme, vector_size as usize);
-            let quant_dtype = ElemType::from_quant_value(scheme.value);
 
             let address_type = input
                 .required_address_type(input_dtype.size())
                 .max(scale.required_address_type(scale_dtype.size()))
-                .max(output.required_address_type(quant_dtype.size()));
+                .max(output.required_address_type(output_dtype.size()));
 
             let scales_layout = scales_layout(&output, &scale, 1, scheme);
 
@@ -288,7 +303,7 @@ fn quantize_native<R: Runtime>(
                     linear_view(output.clone()),
                     scales_view(output, out_scale, 1, scheme),
                     scales_layout,
-                    [input_dtype.into(), scale_dtype.into(), quant_dtype.into()],
+                    [input_dtype.into(), scale_dtype.into(), output_dtype.into()],
                 )
             }
         }


### PR DESCRIPTION
This PR fixes a few variable names that seemed to be copy pasted into dequantize from quantize and which did not make sense (i.e. input when it's an output).
It also removes all of the harcoded `size_of::<u32>` and input and output types `u32` in packed kernels in favor of the actual size determined by the `QuantScheme` (currently it's equivalent as only `PackedU32` is supported, by it's now easier to support other types too like `PackedU8`). 
Also made the vectoring a bit more restrictive in packed kernels to take the biggest vector elem size between the input and output to not make false assumptions and take the smaller size unintentionally.
Also removed the two size generics for the `dequantize_symmetric_native_kernel` for output and input in favor of only one to be symmetric with the quantize kernel and they should have the size normally.

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.

`cargo run-checks` was run in burn with this branch as dependency and everything still passes, nothing broke.