### PR TITLE
require output precision for Any / All

### DIFF
--- a/crates/cubek-reduce/src/components/instructions/mixed.rs
+++ b/crates/cubek-reduce/src/components/instructions/mixed.rs
@@ -59,26 +59,30 @@ impl ReduceOperationConfig {
             | ReduceOperationConfig::Prod
             | ReduceOperationConfig::Mean => {}
             // No benefit to mixed precision accumulation.
-            // `Any` / `All` keep the accumulator narrow (it only ever holds 0/1 flags).
             ReduceOperationConfig::MaxAbs
             | ReduceOperationConfig::Max
             | ReduceOperationConfig::TopK(_)
-            | ReduceOperationConfig::Min
-            | ReduceOperationConfig::Any
-            | ReduceOperationConfig::All => {
+            | ReduceOperationConfig::Min => {
                 return ReduceDtypes {
                     input: input.into(),
                     output: input.into(),
                     accumulation: input.into(),
                 };
             }
+            // The output is not a value of the input but an index (Arg*) or a
+            // logical flag (`Any` / `All`), so the caller must pick its dtype;
+            // the conversion happens for free in the final output write. The
+            // accumulator stays narrow (= input): indices live in a separate
+            // u32 accumulator, and logical flags only ever hold 0/1.
             ReduceOperationConfig::ArgMax
             | ReduceOperationConfig::ArgMin
-            | ReduceOperationConfig::ArgTopK(_) => {
+            | ReduceOperationConfig::ArgTopK(_)
+            | ReduceOperationConfig::Any
+            | ReduceOperationConfig::All => {
                 return ReduceDtypes {
                     input: input.into(),
                     output: output
-                        .expect("ArgMax, ArgMin and ArgTopK must specify output type")
+                        .expect("ArgMax, ArgMin, ArgTopK, Any and All must specify output type")
                         .into(),
                     accumulation: input.into(),
                 };
@@ -611,17 +615,24 @@ mod tests {
     /// The key benefit of `Any` / `All` over the sum-based emulation is that the
     /// dynamic dispatch path keeps `accumulation = input`: the accumulator only
     /// ever holds 0/1 flags, so there is no need to widen (and no overflow) the
-    /// way `Sum` / `Mean` do. Check the narrow accumulator for a narrow float
-    /// (f16, the type that motivated this work) and an integer input.
+    /// way `Sum` / `Mean` do. The output dtype is the caller-provided flag
+    /// storage (e.g. the u8/u32 backing of a bool tensor), like Arg* indices.
+    /// Check both for a narrow float (f16, the type that motivated this work)
+    /// and an integer input.
     #[test]
-    fn any_all_precision_keeps_input_dtype() {
+    fn any_all_precision_keeps_accumulation_narrow() {
         let inputs = [ElemType::Float(FloatKind::F16), ElemType::Int(IntKind::I32)];
+        let output = ElemType::UInt(UIntKind::U8);
         for config in [ReduceOperationConfig::Any, ReduceOperationConfig::All] {
             for input in inputs {
-                let dtypes = config.precision(input, None);
+                let dtypes = config.precision(input, Some(output));
                 let expected: StorageType = input.into();
                 assert_eq!(dtypes.input, expected, "input for {input:?}");
-                assert_eq!(dtypes.output, expected, "output for {input:?}");
+                assert_eq!(
+                    dtypes.output,
+                    output.into(),
+                    "output must follow the requested flag storage for {input:?}"
+                );
                 assert_eq!(
                     dtypes.accumulation, expected,
                     "accumulation must stay narrow for {input:?}"

--- a/crates/cubek-reduce/tests/reduce/it/logical.rs
+++ b/crates/cubek-reduce/tests/reduce/it/logical.rs
@@ -8,7 +8,7 @@
 
 use cubecl::{
     TestRuntime,
-    ir::{ElemType, FloatKind},
+    ir::{ElemType, FloatKind, UIntKind},
     prelude::*,
     zspace::Shape,
 };
@@ -45,14 +45,22 @@ fn reduce_mask(config: ReduceOperationConfig) -> Vec<f32> {
         .custom(data)
         .generate_with_f32_host_data();
 
+    // Drives the real `precision()` path: Any/All require the flag storage as
+    // output (u32 here — the bool backing callers request on runtimes without
+    // 8-bit storage, and the dtype every test runtime supports) while
+    // accumulation stays = input. The kernel writes the flags directly into
+    // the u32 output, so the f32-input -> flag-output conversion is exercised
+    // end to end.
+    let dtypes = config.precision(
+        ElemType::Float(FloatKind::F32),
+        Some(ElemType::UInt(UIntKind::U32)),
+    );
+
     let output_handle = TestInput::builder(client.clone(), Shape::new([3, 1]))
-        .dtype(input_dtype)
+        .dtype(dtypes.output)
         .layout(StridedLayout::Explicit(vec![1, 1]))
         .zeros()
         .generate_without_host_data();
-
-    // Drives the real `precision()` path: Any/All keep accumulation = input.
-    let dtypes = config.precision(ElemType::Float(FloatKind::F32), None);
     let strategy = ReduceStrategy {
         routine: RoutineStrategy::Unit(BlueprintStrategy::Inferred(UnitStrategy)),
         vectorization: VectorizationStrategy {

--- a/crates/cubek-reduce/tests/reduce/it/test_case.rs
+++ b/crates/cubek-reduce/tests/reduce/it/test_case.rs
@@ -122,10 +122,14 @@ impl TestCase {
         // Bernoulli with p ≈ 1.5/axis_len makes ~22% of reduced slices all-zero
         // (any = 0) and the rest contain a non-zero (any = 1), so both merge
         // outcomes are exercised instead of the trivial all-ones case `uniform`
-        // would produce.
+        // would produce. The output is u32 like the bool tensor backing callers
+        // request (u32 is the one flag storage every test runtime supports), so
+        // the in-kernel flag conversion is covered for every input dtype of the
+        // matrix.
+        let u32_dtype = u32::as_type_native_unchecked().storage_type();
         self.run_reduce_test_with(
             |input, axis| reference_any(input, axis, None),
-            self.input_dtype,
+            u32_dtype,
             ReduceOperationConfig::Any,
             0.0,
             Distribution::Bernoulli(self.flag_probability()),
@@ -135,9 +139,10 @@ impl TestCase {
     pub fn test_all(&self) {
         // Mirror of `test_any`: p ≈ 1 - 1.5/axis_len makes ~22% of slices
         // all-ones (all = 1) and the rest contain a zero (all = 0).
+        let u32_dtype = u32::as_type_native_unchecked().storage_type();
         self.run_reduce_test_with(
             |input, axis| reference_all(input, axis, None),
-            self.input_dtype,
+            u32_dtype,
             ReduceOperationConfig::All,
             0.0,
             Distribution::Bernoulli(1.0 - self.flag_probability()),


### PR DESCRIPTION
Follow-up to #302, implementing the suggestion from the review of [tracel-ai/burn#5051](https://github.com/tracel-ai/burn/issues/5051).

Any / All now require the output precision, like the Arg* instructions: the output of a logical reduction is a 0/1 flag rather than a value of the input, so the caller picks its storage (e.g. the u8/u32 backing of a bool tensor) and the conversion happens for free in the kernel's final output write. This removes the "logical encoded as float/int" intermediate and the follow-up cast kernel on the caller side.

No kernel changes: to_output_*<Out: Numeric> already handles Out != input — the same machinery as argmax/argmin.

Tests: the precision() unit test asserts output follows the requested storage while accumulation stays = input (narrow, overflow-free); the deterministic and randomized any/all integration tests now drive the realistic path (float input → u32 flag output). u32 rather than u8 because WGSL has no 8-bit storage; the u8 path gets covered by burn's CUDA CI once [tracel-ai/burn#5051](https://github.com/tracel-ai/burn/issues/5051) picks this rev up.