### PR TITLE
Expose public complex FFT (cfft)

### DIFF
--- a/crates/cubek-fft/src/fft/cfft.rs
+++ b/crates/cubek-fft/src/fft/cfft.rs
@@ -255,6 +255,9 @@ fn cfft_shared_kernel<F: Float>(
         output_im_view.write_checked(k, shared_im[k]);
         k += threads_per_cube;
     }
+    // Barrier so no unit is still reading shared memory when the cube exits
+    // and a runtime that pools shared memory hands it to the next window.
+    sync_cube();
 }
 
 // --- Four-step path ----------------------------------------------------
@@ -442,6 +445,8 @@ fn cfft_four_step_radix1_kernel<F: Float>(
         scratch_im_view.write_checked(flat, w_re * ai + w_im * ar);
         k1 += threads_per_cube;
     }
+    // See cfft_shared_kernel: barrier before shared memory is reused.
+    sync_cube();
 }
 
 /// Second four-step pass: FFT_{N2} along n2 (contiguous), in place.
@@ -499,6 +504,8 @@ fn cfft_four_step_radix2_kernel<F: Float>(
         scratch_im_view.write_checked(row_base + k2, shared_im[k2]);
         k2 += threads_per_cube;
     }
+    // See cfft_shared_kernel: barrier before shared memory is reused.
+    sync_cube();
 }
 
 /// Transpose (N1, N2) -> (N2, N1) in each selected-axis window.

--- a/crates/cubek-fft/src/fft/cfft.rs
+++ b/crates/cubek-fft/src/fft/cfft.rs
@@ -1,4 +1,5 @@
-//! Complex FFT used internally by the large-`n_fft` real-FFT paths.
+//! Batched 1D complex FFT, also used internally by the large-`n_fft`
+//! real-FFT paths.
 //!
 //! Two flavours live here:
 //!
@@ -14,11 +15,10 @@
 //!   converts the (N1, N2) internal layout to natural linear bin order on
 //!   the way out.
 //!
-//! The public API of this module is the single
-//! [`cfft_launch_any_size`] function which picks the right path.
-//!
-//! The caller is responsible for allocating any scratch buffers; see
-//! `rfft_large` for the allocator shape contract.
+//! The high-level [`cfft`] entry point allocates the outputs and runs the
+//! transform; [`cfft_launch_any_size`] takes pre-allocated buffers and picks
+//! the right path. Either way the caller owns any scratch (see `rfft_large`
+//! for the allocator shape contract).
 
 use core::f32::consts::PI;
 
@@ -36,11 +36,13 @@ use crate::{
     layout::BatchSignalLayout,
 };
 
-pub(crate) struct CfftBindings<R: Runtime> {
-    pub(crate) input_re: TensorBinding<R>,
-    pub(crate) input_im: TensorBinding<R>,
-    pub(crate) output_re: TensorBinding<R>,
-    pub(crate) output_im: TensorBinding<R>,
+/// Pre-allocated input/output buffers for [`cfft_launch_any_size`]. All four
+/// tensors must be contiguous and share the same shape.
+pub struct CfftBindings<R: Runtime> {
+    pub input_re: TensorBinding<R>,
+    pub input_im: TensorBinding<R>,
+    pub output_re: TensorBinding<R>,
+    pub output_im: TensorBinding<R>,
 }
 
 #[derive(Clone, Copy)]
@@ -77,12 +79,67 @@ pub(crate) fn factor_four_step(n_fft: usize, max_shared_n_fft: usize) -> (usize,
     (1 << log2_n1, 1 << log2_n2)
 }
 
+/// Complex FFT along `dim`. `input_re`/`input_im` must have identical
+/// contiguous shapes with a power-of-two length along `dim`; the returned
+/// `(re, im)` share that shape.
+///
+/// Both directions are unnormalized, so `Inverse` after `Forward` scales by
+/// `n` (the length along `dim`); divide by `n` yourself if you need it.
+pub fn cfft<R: Runtime>(
+    input_re: TensorHandle<R>,
+    input_im: TensorHandle<R>,
+    dim: usize,
+    dtype: StorageType,
+    fft_mode: FftMode,
+) -> (TensorHandle<R>, TensorHandle<R>) {
+    assert!(
+        input_re.shape() == input_im.shape(),
+        "real and imaginary inputs must have the same shape, got {:?} and {:?}",
+        input_re.shape(),
+        input_im.shape()
+    );
+    assert!(
+        dim < input_re.shape().len(),
+        "dim must be between 0 and {}",
+        input_re.shape().len()
+    );
+    assert!(
+        input_re.shape()[dim].is_power_of_two(),
+        "CFFT requires power-of-2 length"
+    );
+
+    let client = <R as Runtime>::client(&Default::default());
+    let shape = input_re.shape().clone();
+    let num_elems = shape.iter().product::<usize>();
+
+    let output_re =
+        TensorHandle::new_contiguous(shape.clone(), client.empty(num_elems * dtype.size()), dtype);
+    let output_im =
+        TensorHandle::new_contiguous(shape.clone(), client.empty(num_elems * dtype.size()), dtype);
+
+    cfft_launch_any_size::<R>(
+        &client,
+        CfftBindings {
+            input_re: input_re.binding(),
+            input_im: input_im.binding(),
+            output_re: output_re.clone().binding(),
+            output_im: output_im.clone().binding(),
+        },
+        dim,
+        dtype,
+        fft_mode,
+    )
+    .unwrap();
+
+    (output_re, output_im)
+}
+
 /// Entry point: complex FFT of `input` into `output`, along `dim`.
 /// `input` and `output` must be contiguous and have identical shape. The
 /// caller may safely pass the same buffer for input and output (aliasing is
 /// allowed for the small path; the large path does its own scratch
 /// management).
-pub(crate) fn cfft_launch_any_size<R: Runtime>(
+pub fn cfft_launch_any_size<R: Runtime>(
     client: &ComputeClient<R>,
     bindings: CfftBindings<R>,
     dim: usize,

--- a/crates/cubek-fft/src/fft/mod.rs
+++ b/crates/cubek-fft/src/fft/mod.rs
@@ -6,6 +6,7 @@ mod limits;
 mod rfft;
 mod rfft_large;
 
+pub use cfft::*;
 pub use fft_inner::*;
 pub use irfft::*;
 pub use rfft::*;

--- a/crates/cubek-fft/tests/fft/cfft.rs
+++ b/crates/cubek-fft/tests/fft/cfft.rs
@@ -1,0 +1,147 @@
+use cubecl::{
+    frontend::CubePrimitive,
+    prelude::StorageType,
+    std::tensor::TensorHandle,
+    {Runtime, TestRuntime},
+};
+use cubek_fft::{CfftBindings, FftMode, cfft, cfft_launch_any_size};
+use cubek_test_utils::{
+    ExecutionOutcome, HostData, HostDataType, HostDataVec, TestInput, TestOutcome,
+    ValidationResult, assert_equals_approx, launch_and_capture_outcome,
+};
+
+fn empty_tensor(
+    client: &cubecl::client::ComputeClient<TestRuntime>,
+    shape: Vec<usize>,
+    dtype: StorageType,
+) -> TensorHandle<TestRuntime> {
+    let elems = shape.iter().product::<usize>();
+    TensorHandle::<TestRuntime>::new_contiguous(shape, client.empty(elems * dtype.size()), dtype)
+}
+
+/// Scale every element of an f32 `HostData` by `factor`.
+fn scaled(mut host: HostData, factor: f32) -> HostData {
+    match &mut host.data {
+        HostDataVec::F32(values) => values.iter_mut().for_each(|v| *v *= factor),
+        _ => panic!("expected f32 host data"),
+    }
+    host
+}
+
+fn combine_re_im(re: ValidationResult, im: ValidationResult) -> ValidationResult {
+    use ValidationResult::*;
+    match (re, im) {
+        (Fail(e), _) | (_, Fail(e)) => Fail(e),
+        (Error(e), _) | (_, Error(e)) => Error(e),
+        (Skipped(r1), Skipped(r2)) => Skipped(format!("{r1}, {r2}")),
+        (Skipped(r), Pass) | (Pass, Skipped(r)) => Skipped(r),
+        (Pass, Pass) => Pass,
+    }
+}
+
+/// Forward then inverse along `dim` recovers the input scaled by `n` (the
+/// transform is unnormalized in both directions).
+fn cfft_roundtrip_case(signal_shape: Vec<usize>, dim: usize) {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::as_type_native_unchecked().storage_type();
+    let n = signal_shape[dim] as f32;
+
+    let (input_re, input_re_data) = TestInput::builder(client.clone(), signal_shape.clone())
+        .dtype(dtype)
+        .uniform(42, -1., 1.)
+        .generate_with_f32_host_data();
+    let (input_im, input_im_data) = TestInput::builder(client.clone(), signal_shape.clone())
+        .dtype(dtype)
+        .uniform(7, -1., 1.)
+        .generate_with_f32_host_data();
+
+    let spectrum_re = empty_tensor(&client, signal_shape.clone(), dtype);
+    let spectrum_im = empty_tensor(&client, signal_shape.clone(), dtype);
+    let recovered_re = empty_tensor(&client, signal_shape.clone(), dtype);
+    let recovered_im = empty_tensor(&client, signal_shape.clone(), dtype);
+
+    let forward = CfftBindings {
+        input_re: input_re.binding(),
+        input_im: input_im.binding(),
+        output_re: spectrum_re.clone().binding(),
+        output_im: spectrum_im.clone().binding(),
+    };
+    let inverse = CfftBindings {
+        input_re: spectrum_re.binding(),
+        input_im: spectrum_im.binding(),
+        output_re: recovered_re.clone().binding(),
+        output_im: recovered_im.clone().binding(),
+    };
+
+    let outcome = launch_and_capture_outcome(&client, |c| {
+        if let Err(e) =
+            cfft_launch_any_size::<TestRuntime>(c, forward, dim, dtype, FftMode::Forward)
+        {
+            return ExecutionOutcome::CompileError(format!("forward launch failed: {e}"));
+        }
+        cfft_launch_any_size::<TestRuntime>(c, inverse, dim, dtype, FftMode::Inverse).into()
+    });
+
+    match outcome {
+        ExecutionOutcome::Executed => {
+            let actual_re = HostData::from_tensor_handle(&client, recovered_re, HostDataType::F32);
+            let actual_im = HostData::from_tensor_handle(&client, recovered_im, HostDataType::F32);
+            let expected_re = scaled(input_re_data, n);
+            let expected_im = scaled(input_im_data, n);
+            combine_re_im(
+                assert_equals_approx(&actual_re, &expected_re, 1e-2),
+                assert_equals_approx(&actual_im, &expected_im, 1e-2),
+            )
+            .as_test_outcome()
+        }
+        ExecutionOutcome::CompileError(e) => TestOutcome::CompileError(e),
+    }
+    .enforce();
+}
+
+#[test]
+fn cfft_roundtrip_axis_last() {
+    cfft_roundtrip_case([1, 8].to_vec(), 1);
+}
+
+#[test]
+fn cfft_roundtrip_axis_1_strided() {
+    cfft_roundtrip_case([2, 8, 3].to_vec(), 1);
+}
+
+#[test]
+fn cfft_roundtrip_axis_0_strided() {
+    cfft_roundtrip_case([16, 2].to_vec(), 0);
+}
+
+#[test]
+fn cfft_wrapper_roundtrip() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::as_type_native_unchecked().storage_type();
+    let signal_shape = [2, 8].to_vec();
+    let dim = 1;
+    let n = signal_shape[dim] as f32;
+
+    let (input_re, input_re_data) = TestInput::builder(client.clone(), signal_shape.clone())
+        .dtype(dtype)
+        .uniform(42, -1., 1.)
+        .generate_with_f32_host_data();
+    let (input_im, input_im_data) = TestInput::builder(client.clone(), signal_shape.clone())
+        .dtype(dtype)
+        .uniform(7, -1., 1.)
+        .generate_with_f32_host_data();
+
+    let (spectrum_re, spectrum_im) =
+        cfft::<TestRuntime>(input_re, input_im, dim, dtype, FftMode::Forward);
+    let (recovered_re, recovered_im) =
+        cfft::<TestRuntime>(spectrum_re, spectrum_im, dim, dtype, FftMode::Inverse);
+
+    let actual_re = HostData::from_tensor_handle(&client, recovered_re, HostDataType::F32);
+    let actual_im = HostData::from_tensor_handle(&client, recovered_im, HostDataType::F32);
+    combine_re_im(
+        assert_equals_approx(&actual_re, &scaled(input_re_data, n), 1e-2),
+        assert_equals_approx(&actual_im, &scaled(input_im_data, n), 1e-2),
+    )
+    .as_test_outcome()
+    .enforce();
+}

--- a/crates/cubek-fft/tests/fft/cfft.rs
+++ b/crates/cubek-fft/tests/fft/cfft.rs
@@ -114,6 +114,19 @@ fn cfft_roundtrip_axis_0_strided() {
     cfft_roundtrip_case([16, 2].to_vec(), 0);
 }
 
+// Batched cases: several windows transformed in one launch, every element
+// checked. Guards against per-window state (shared memory) bleeding between
+// concurrent cubes, which corrupts all but one window.
+#[test]
+fn cfft_roundtrip_batched() {
+    cfft_roundtrip_case([5, 16].to_vec(), 1);
+}
+
+#[test]
+fn cfft_roundtrip_batched_larger() {
+    cfft_roundtrip_case([4, 64].to_vec(), 1);
+}
+
 #[test]
 fn cfft_wrapper_roundtrip() {
     let client = <TestRuntime as Runtime>::client(&Default::default());

--- a/crates/cubek-fft/tests/fft/mod.rs
+++ b/crates/cubek-fft/tests/fft/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "benchmarks")]
 mod bench_catalog;
+mod cfft;
 mod irfft;
 mod rfft;
 mod round_trip;


### PR DESCRIPTION
The complex FFT already existed and was used internally by the large real-FFT paths, but was private. This makes it public so downstream crates can compose multi-dimensional transforms (for example a 2D real FFT, rfft along one axis and cfft along the other).

This is purely additive. CfftBindings and cfft_launch_any_size become public, a high-level cfft wrapper is added mirroring rfft/irfft, plus round-trip tests.

Both directions are unnormalized, so inverse-after-forward scales by n (documented on cfft).

It also fixes a shared-memory race in the cfft kernels. The shared-memory butterfly read its results back out with no trailing sync_cube, so on a runtime that pools per-cube shared memory across windows (the cubecl-cpu runtime) one batch row could overwrite another mid-read and corrupt every row but one. rfft and irfft already had this barrier. It is now added to the shared and four-step kernels, with batched round-trip tests that fail without it on the CPU runtime.
