### PR TITLE
Add support for f64 #198

### DIFF
--- a/crates/cubek-matmul/src/eval/cpu_reference.rs
+++ b/crates/cubek-matmul/src/eval/cpu_reference.rs
@@ -125,25 +125,17 @@ fn seed_inputs(
     seed_lhs: u64,
     seed_rhs: u64,
 ) -> (Tensor, HostData, Tensor, HostData, Tensor, MatmulProblem) {
-    let lhs_input = TestInput::builder(client.clone(), problem.lhs_shape.clone())
+    let (lhs, lhs_data) = TestInput::builder(client.clone(), problem.lhs_shape.clone())
         .dtype(problem.global_dtypes.lhs)
         .layout(problem.lhs_layout)
-        .uniform(seed_lhs, -1., 1.);
-    let (lhs, lhs_data) = if host_data_type_for(problem.global_dtypes.lhs) == HostDataType::F64 {
-        lhs_input.generate_with_f64_host_data()
-    } else {
-        lhs_input.generate_with_f32_host_data()
-    };
+        .uniform(seed_lhs, -1., 1.)
+        .generate_with_host_data(host_data_type_for(problem.global_dtypes.lhs));
 
-    let rhs_input = TestInput::builder(client.clone(), problem.rhs_shape.clone())
+    let (rhs, rhs_data) = TestInput::builder(client.clone(), problem.rhs_shape.clone())
         .dtype(problem.global_dtypes.rhs)
         .layout(problem.rhs_layout)
-        .uniform(seed_rhs, -1., 1.);
-    let (rhs, rhs_data) = if host_data_type_for(problem.global_dtypes.rhs) == HostDataType::F64 {
-        rhs_input.generate_with_f64_host_data()
-    } else {
-        rhs_input.generate_with_f32_host_data()
-    };
+        .uniform(seed_rhs, -1., 1.)
+        .generate_with_host_data(host_data_type_for(problem.global_dtypes.rhs));
     let out = TestInput::builder(client.clone(), problem.out_shape.clone())
         .dtype(problem.global_dtypes.out)
         .layout(MatrixLayout::RowMajor)

--- a/crates/cubek-matmul/src/eval/cpu_reference.rs
+++ b/crates/cubek-matmul/src/eval/cpu_reference.rs
@@ -5,33 +5,17 @@
 //! - [`cpu_reference_result`] runs the naive triple-loop on the same seeded
 //!   inputs and returns its output as a [`HostData`].
 
-use cubecl::{
-    TestRuntime,
-    ir::{ElemType, FloatKind},
-    prelude::*,
-    std::tensor::TensorHandle,
-};
+use cubecl::{TestRuntime, prelude::*, std::tensor::TensorHandle};
 use cubek_std::{InputBinding, MatrixLayout};
 use cubek_test_utils::{
-    ExecutionOutcome, HostData, HostDataType, HostDataVec, Progress, StridedLayout, TestInput,
-    ValidationResult, assert_equals_approx, launch_and_capture_outcome,
+    ExecutionOutcome, HostData, HostDataVec, Progress, StridedLayout, TestInput, ValidationResult,
+    assert_equals_approx, launch_and_capture_outcome,
 };
 
 use crate::{
     definition::{MatmulElems, MatmulProblem, MatmulSetupError},
     {launch::launch_ref, strategy::Strategy},
 };
-
-/// Host data type to use for a tensor with this storage type: `F64` for f64
-/// tensors (so both the reference computation and the GPU readback retain
-/// full precision), `F32` otherwise.
-fn host_data_type_for(dtype: StorageType) -> HostDataType {
-    if matches!(dtype.elem_type(), ElemType::Float(FloatKind::F64)) {
-        HostDataType::F64
-    } else {
-        HostDataType::F32
-    }
-}
 
 /// Run `strategy` against `problem` with seeded inputs and return its output as
 /// a [`HostData`].
@@ -112,7 +96,7 @@ where
         ExecutionOutcome::Executed => Ok(HostData::from_tensor_handle(
             &client,
             out,
-            host_data_type_for(problem.global_dtypes.out),
+            problem.global_dtypes.out.into(),
         )),
     }
 }
@@ -129,13 +113,13 @@ fn seed_inputs(
         .dtype(problem.global_dtypes.lhs)
         .layout(problem.lhs_layout)
         .uniform(seed_lhs, -1., 1.)
-        .generate_with_host_data(host_data_type_for(problem.global_dtypes.lhs));
+        .generate_with_host_data(problem.global_dtypes.lhs.into());
 
     let (rhs, rhs_data) = TestInput::builder(client.clone(), problem.rhs_shape.clone())
         .dtype(problem.global_dtypes.rhs)
         .layout(problem.rhs_layout)
         .uniform(seed_rhs, -1., 1.)
-        .generate_with_host_data(host_data_type_for(problem.global_dtypes.rhs));
+        .generate_with_host_data(problem.global_dtypes.rhs.into());
     let out = TestInput::builder(client.clone(), problem.out_shape.clone())
         .dtype(problem.global_dtypes.out)
         .layout(MatrixLayout::RowMajor)
@@ -173,8 +157,7 @@ pub fn assert_result_with_epsilon(
     epsilon: f32,
 ) -> ValidationResult {
     let expected = matmul_cpu_reference(lhs, rhs, problem, None);
-    let actual =
-        HostData::from_tensor_handle(client, out, host_data_type_for(problem.global_dtypes.out));
+    let actual = HostData::from_tensor_handle(client, out, problem.global_dtypes.out.into());
     assert_equals_approx(&actual, &expected, epsilon)
 }
 
@@ -273,11 +256,7 @@ pub fn matmul_cpu_reference(
 
     let strides = StridedLayout::RowMajor.compute_strides(&out_shape);
 
-    let data = if host_data_type_for(problem.global_dtypes.out) == HostDataType::F64 {
-        HostDataVec::F64(out)
-    } else {
-        HostDataVec::F32(out.into_iter().map(|x| x as f32).collect())
-    };
+    let data = HostDataVec::from((out, problem.global_dtypes.out));
 
     HostData {
         data,

--- a/crates/cubek-matmul/src/eval/cpu_reference.rs
+++ b/crates/cubek-matmul/src/eval/cpu_reference.rs
@@ -5,7 +5,12 @@
 //! - [`cpu_reference_result`] runs the naive triple-loop on the same seeded
 //!   inputs and returns its output as a [`HostData`].
 
-use cubecl::{TestRuntime, prelude::*, std::tensor::TensorHandle};
+use cubecl::{
+    TestRuntime,
+    ir::{ElemType, FloatKind},
+    prelude::*,
+    std::tensor::TensorHandle,
+};
 use cubek_std::{InputBinding, MatrixLayout};
 use cubek_test_utils::{
     ExecutionOutcome, HostData, HostDataType, HostDataVec, Progress, StridedLayout, TestInput,
@@ -16,6 +21,17 @@ use crate::{
     definition::{MatmulElems, MatmulProblem, MatmulSetupError},
     {launch::launch_ref, strategy::Strategy},
 };
+
+/// Host data type to use for a tensor with this storage type: `F64` for f64
+/// tensors (so both the reference computation and the GPU readback retain
+/// full precision), `F32` otherwise.
+fn host_data_type_for(dtype: StorageType) -> HostDataType {
+    if matches!(dtype.elem_type(), ElemType::Float(FloatKind::F64)) {
+        HostDataType::F64
+    } else {
+        HostDataType::F32
+    }
+}
 
 /// Run `strategy` against `problem` with seeded inputs and return its output as
 /// a [`HostData`].
@@ -96,7 +112,7 @@ where
         ExecutionOutcome::Executed => Ok(HostData::from_tensor_handle(
             &client,
             out,
-            HostDataType::F32,
+            host_data_type_for(problem.global_dtypes.out),
         )),
     }
 }
@@ -109,16 +125,25 @@ fn seed_inputs(
     seed_lhs: u64,
     seed_rhs: u64,
 ) -> (Tensor, HostData, Tensor, HostData, Tensor, MatmulProblem) {
-    let (lhs, lhs_data) = TestInput::builder(client.clone(), problem.lhs_shape.clone())
+    let lhs_input = TestInput::builder(client.clone(), problem.lhs_shape.clone())
         .dtype(problem.global_dtypes.lhs)
         .layout(problem.lhs_layout)
-        .uniform(seed_lhs, -1., 1.)
-        .generate_with_f32_host_data();
-    let (rhs, rhs_data) = TestInput::builder(client.clone(), problem.rhs_shape.clone())
+        .uniform(seed_lhs, -1., 1.);
+    let (lhs, lhs_data) = if host_data_type_for(problem.global_dtypes.lhs) == HostDataType::F64 {
+        lhs_input.generate_with_f64_host_data()
+    } else {
+        lhs_input.generate_with_f32_host_data()
+    };
+
+    let rhs_input = TestInput::builder(client.clone(), problem.rhs_shape.clone())
         .dtype(problem.global_dtypes.rhs)
         .layout(problem.rhs_layout)
-        .uniform(seed_rhs, -1., 1.)
-        .generate_with_f32_host_data();
+        .uniform(seed_rhs, -1., 1.);
+    let (rhs, rhs_data) = if host_data_type_for(problem.global_dtypes.rhs) == HostDataType::F64 {
+        rhs_input.generate_with_f64_host_data()
+    } else {
+        rhs_input.generate_with_f32_host_data()
+    };
     let out = TestInput::builder(client.clone(), problem.out_shape.clone())
         .dtype(problem.global_dtypes.out)
         .layout(MatrixLayout::RowMajor)
@@ -156,7 +181,8 @@ pub fn assert_result_with_epsilon(
     epsilon: f32,
 ) -> ValidationResult {
     let expected = matmul_cpu_reference(lhs, rhs, problem, None);
-    let actual = HostData::from_tensor_handle(client, out, HostDataType::F32);
+    let actual =
+        HostData::from_tensor_handle(client, out, host_data_type_for(problem.global_dtypes.out));
     assert_equals_approx(&actual, &expected, epsilon)
 }
 
@@ -196,7 +222,7 @@ pub fn matmul_cpu_reference(
         p.set_total((num_batches * m * n) as u64);
     }
 
-    let mut out = vec![0.0; num_batches * m * n];
+    let mut out = vec![0.0f64; num_batches * m * n];
 
     let mut batch_index = vec![0usize; rank - 2];
     let mut lhs_index = vec![0usize; rank];
@@ -236,12 +262,12 @@ pub fn matmul_cpu_reference(
                 rhs_index[rank - 1] = j;
                 out_index[rank - 1] = j;
 
-                let mut sum = 0.0;
+                let mut sum = 0.0f64;
                 for kk in 0..k {
                     lhs_index[rank - 1] = kk;
                     rhs_index[rank - 2] = kk;
 
-                    sum += lhs.get_f32(&lhs_index) * rhs.get_f32(&rhs_index);
+                    sum += lhs.get_f64(&lhs_index) * rhs.get_f64(&rhs_index);
                 }
 
                 let out_linear = batch_flat * (m * n) + i * n + j;
@@ -255,8 +281,14 @@ pub fn matmul_cpu_reference(
 
     let strides = StridedLayout::RowMajor.compute_strides(&out_shape);
 
+    let data = if host_data_type_for(problem.global_dtypes.out) == HostDataType::F64 {
+        HostDataVec::F64(out)
+    } else {
+        HostDataVec::F32(out.into_iter().map(|x| x as f32).collect())
+    };
+
     HostData {
-        data: HostDataVec::F32(out),
+        data,
         shape: out_shape,
         strides,
     }

--- a/crates/cubek-matmul/tests/matmul/basic/auto.rs
+++ b/crates/cubek-matmul/tests/matmul/basic/auto.rs
@@ -3,7 +3,7 @@
 
 use cubek_matmul::strategy::Strategy;
 
-use super::common::{client, f16_elems, f32_elems, rect, square};
+use super::common::{client, f16_elems, f32_elems, f64_elems, rect, square};
 use crate::matmul::test_matmul_strategy;
 
 #[test]
@@ -33,4 +33,10 @@ fn auto_skinny_vecmat() {
 #[test]
 fn auto_skinny_matvec() {
     test_matmul_strategy(client(), rect(256, 1, 256, f16_elems()), Strategy::Auto);
+}
+
+#[cfg(feature = "heavy")]
+#[test]
+fn auto_medium_f64() {
+    test_matmul_strategy(client(), square(256, f64_elems()), Strategy::Auto);
 }

--- a/crates/cubek-matmul/tests/matmul/basic/common.rs
+++ b/crates/cubek-matmul/tests/matmul/basic/common.rs
@@ -21,6 +21,11 @@ pub(crate) fn f32_elems() -> MatmulGlobalElems {
     MatmulElems::from_single_dtype(f32::as_type_native_unchecked()).as_global_elems()
 }
 
+pub(crate) fn f64_elems() -> MatmulGlobalElems {
+    use cubecl::frontend::CubePrimitive;
+    MatmulElems::from_single_dtype(f64::as_type_native_unchecked()).as_global_elems()
+}
+
 pub(crate) fn square(dim: usize, elems: MatmulGlobalElems) -> MatmulProblem {
     rect(dim, dim, dim, elems)
 }

--- a/crates/cubek-test-utils/src/correctness/base.rs
+++ b/crates/cubek-test-utils/src/correctness/base.rs
@@ -132,7 +132,7 @@ fn assert_equals_approx_inner(
         lhs,
         rhs,
         shape,
-        epsilon,
+        epsilon as f64,
         &mut summary_visitor,
         &mut Vec::new(),
         filter.as_ref(),
@@ -149,9 +149,9 @@ fn assert_equals_approx_inner(
 pub(crate) enum ElemStatus {
     #[allow(dead_code)] // fields read via Debug in failure messages
     Correct {
-        got: f32,
-        delta: f32,
-        epsilon: f32,
+        got: f64,
+        delta: f64,
+        epsilon: f64,
     },
     Wrong(WrongStatus),
 }
@@ -159,16 +159,16 @@ pub(crate) enum ElemStatus {
 #[derive(Debug)]
 pub(crate) enum WrongStatus {
     GotWrongValue {
-        got: f32,
-        expected: f32,
-        delta: f32,
-        epsilon: f32,
+        got: f64,
+        expected: f64,
+        delta: f64,
+        epsilon: f64,
     },
     ExpectedNan {
-        got: f32,
+        got: f64,
     },
     GotNan {
-        expected: f32,
+        expected: f64,
     },
 }
 
@@ -184,7 +184,7 @@ pub(crate) struct SummaryCollector {
     pub mismatches: Vec<(Vec<usize>, WrongStatus)>,
     pub total: usize,
     pub mismatched: usize,
-    pub max_abs_delta: f32,
+    pub max_abs_delta: f64,
     pub sum_abs_delta: f64,
     pub worst_index: Option<Vec<usize>>,
 }
@@ -202,9 +202,9 @@ impl SummaryCollector {
         }
     }
 
-    fn record_delta(&mut self, index: &[usize], delta: f32) {
+    fn record_delta(&mut self, index: &[usize], delta: f64) {
         if delta.is_finite() {
-            self.sum_abs_delta += delta as f64;
+            self.sum_abs_delta += delta;
         }
         if delta > self.max_abs_delta || self.worst_index.is_none() {
             self.max_abs_delta = delta;
@@ -265,7 +265,7 @@ impl CompareVisitor for SummaryCollector {
             self.mismatched += 1;
             let delta = match &w {
                 WrongStatus::GotWrongValue { delta, .. } => *delta,
-                WrongStatus::ExpectedNan { .. } | WrongStatus::GotNan { .. } => f32::INFINITY,
+                WrongStatus::ExpectedNan { .. } | WrongStatus::GotNan { .. } => f64::INFINITY,
             };
             self.record_delta(index, delta);
             if self.mismatches.len() < self.max_reported {
@@ -289,7 +289,7 @@ fn format_wrong(w: &WrongStatus) -> String {
 }
 
 #[inline]
-fn compare_elem(got: f32, expected: f32, epsilon: f32) -> ElemStatus {
+fn compare_elem(got: f64, expected: f64, epsilon: f64) -> ElemStatus {
     let epsilon = (epsilon * expected).abs().max(epsilon);
 
     // NaN check: pass if both are NaN
@@ -322,7 +322,7 @@ fn compare_elem(got: f32, expected: f32, epsilon: f32) -> ElemStatus {
             return ElemStatus::Wrong(WrongStatus::GotWrongValue {
                 got,
                 expected,
-                delta: f32::INFINITY,
+                delta: f64::INFINITY,
                 epsilon,
             });
         }
@@ -350,7 +350,7 @@ fn compare_tensors(
     actual: &HostData,
     expected: &HostData,
     shape: &[usize],
-    epsilon: f32,
+    epsilon: f64,
     visitor: &mut dyn CompareVisitor,
     index: &mut Vec<usize>,
     filter: Option<&TensorFilter>,
@@ -368,8 +368,8 @@ fn compare_tensors(
             return false;
         }
 
-        let got = actual.get_f32(index);
-        let exp = expected.get_f32(index);
+        let got = actual.get_f64(index);
+        let exp = expected.get_f64(index);
         let status = compare_elem(got, exp, epsilon);
 
         if matches!(status, ElemStatus::Wrong(_)) {

--- a/crates/cubek-test-utils/src/correctness/render.rs
+++ b/crates/cubek-test-utils/src/correctness/render.rs
@@ -55,7 +55,7 @@ pub fn print_tensors(cfg: &PrintSection, label: &str, tensors: &[&HostData], eps
     // `max(epsilon, epsilon * |expected|)`), so a single number would lie.
     println!("=== {label}  shape={:?} ===", primary.shape);
 
-    let eps = epsilon.unwrap_or(0.0);
+    let eps = epsilon.unwrap_or(0.0) as f64;
     match cfg.view {
         PrintView::Table => render_table(cfg, primary, other, eps, filter.as_ref()),
         PrintView::Lines => render_lines(cfg, primary, other, eps, filter.as_ref()),
@@ -68,7 +68,7 @@ fn render_table(
     cfg: &PrintSection,
     a: &HostData,
     b: Option<&HostData>,
-    epsilon: f32,
+    epsilon: f64,
     filter: Option<&TensorFilter>,
 ) {
     let rank = a.shape.rank();
@@ -77,11 +77,11 @@ fn render_table(
     }
 
     let cell = |full: &[usize]| -> String {
-        let av = a.get_f32(full);
+        let av = a.get_f64(full);
         match b {
             None => format_value(av),
             Some(rhs) => {
-                let bv = rhs.get_f32(full);
+                let bv = rhs.get_f64(full);
                 let cell_eps = (epsilon * bv).abs().max(epsilon);
                 let is_wrong = compare_pair(av, bv, cell_eps);
                 if cfg.fail_only && !is_wrong {
@@ -160,7 +160,7 @@ fn render_lines(
     cfg: &PrintSection,
     a: &HostData,
     b: Option<&HostData>,
-    epsilon: f32,
+    epsilon: f64,
     filter: Option<&TensorFilter>,
 ) {
     let mut rows: Vec<LineRow> = Vec::new();
@@ -170,7 +170,7 @@ fn render_lines(
         {
             continue;
         }
-        let av = a.get_f32(&idx);
+        let av = a.get_f64(&idx);
         match b {
             None => {
                 rows.push(LineRow {
@@ -183,7 +183,7 @@ fn render_lines(
                 });
             }
             Some(rhs) => {
-                let bv = rhs.get_f32(&idx);
+                let bv = rhs.get_f64(&idx);
                 let cell_eps = (epsilon * bv).abs().max(epsilon);
                 let delta = (av - bv).abs();
                 let is_wrong = compare_pair(av, bv, cell_eps);
@@ -274,7 +274,7 @@ fn render_lines(
 
 // ---------- shared helpers ----------
 
-fn format_value(v: f32) -> String {
+fn format_value(v: f64) -> String {
     format!("{:.6}", v)
 }
 
@@ -290,7 +290,7 @@ fn format_index(idx: &[usize]) -> String {
 
 /// Returns `true` if `(a, b)` is a mismatch under `epsilon`. Mirrors
 /// `assert_equals_approx`'s NaN/Inf semantics.
-fn compare_pair(a: f32, b: f32, epsilon: f32) -> bool {
+fn compare_pair(a: f64, b: f64, epsilon: f64) -> bool {
     if a.is_nan() && b.is_nan() {
         return false;
     }

--- a/crates/cubek-test-utils/src/test_tensor/base.rs
+++ b/crates/cubek-test-utils/src/test_tensor/base.rs
@@ -171,23 +171,21 @@ impl TestInput {
     }
 
     pub fn generate_with_f32_host_data(self) -> (TensorHandle<TestRuntime>, HostData) {
-        self.generate_host_data(HostDataType::F32)
+        self.generate_with_host_data(HostDataType::F32)
     }
 
-    /// Like [`generate_with_f32_host_data`](Self::generate_with_f32_host_data),
-    /// but reads the host reference copy back at full `f64` precision.
     pub fn generate_with_f64_host_data(self) -> (TensorHandle<TestRuntime>, HostData) {
-        self.generate_host_data(HostDataType::F64)
+        self.generate_with_host_data(HostDataType::F64)
     }
 
     pub fn generate_with_bool_host_data(self) -> (TensorHandle<TestRuntime>, HostData) {
-        self.generate_host_data(HostDataType::Bool)
+        self.generate_with_host_data(HostDataType::Bool)
     }
 
     pub fn generate_test_tensor(self) -> TestTensor {
         let input_dtype = self.input_dtype.clone();
         let client = self.base_spec.client.clone();
-        let (handle, host) = self.generate_with_f32_host_data();
+        let (handle, host) = self.generate_with_host_data(HostDataType::F32);
 
         let mut tensor = TestTensor {
             handle,
@@ -203,11 +201,11 @@ impl TestInput {
     }
 
     pub fn f32_host_data(self) -> HostData {
-        self.generate_host_data(HostDataType::F32).1
+        self.generate_with_host_data(HostDataType::F32).1
     }
 
     pub fn bool_host_data(self) -> HostData {
-        self.generate_host_data(HostDataType::Bool).1
+        self.generate_with_host_data(HostDataType::Bool).1
     }
 
     // Public API returning only TensorHandle
@@ -234,16 +232,14 @@ impl TestInput {
         handle
     }
 
-    fn generate_host_data(
+    pub fn generate_with_host_data(
         self,
         host_data_type: HostDataType,
     ) -> (TensorHandle<TestRuntime>, HostData) {
         let client = self.base_spec.client.clone();
-
         let tensor_handle = self.generate_without_host_data();
         let host_data =
             HostData::from_tensor_handle(&client, tensor_handle.clone(), host_data_type);
-
         (tensor_handle, host_data)
     }
 }

--- a/crates/cubek-test-utils/src/test_tensor/base.rs
+++ b/crates/cubek-test-utils/src/test_tensor/base.rs
@@ -174,6 +174,12 @@ impl TestInput {
         self.generate_host_data(HostDataType::F32)
     }
 
+    /// Like [`generate_with_f32_host_data`](Self::generate_with_f32_host_data),
+    /// but reads the host reference copy back at full `f64` precision.
+    pub fn generate_with_f64_host_data(self) -> (TensorHandle<TestRuntime>, HostData) {
+        self.generate_host_data(HostDataType::F64)
+    }
+
     pub fn generate_with_bool_host_data(self) -> (TensorHandle<TestRuntime>, HostData) {
         self.generate_host_data(HostDataType::Bool)
     }

--- a/crates/cubek-test-utils/src/test_tensor/host_data.rs
+++ b/crates/cubek-test-utils/src/test_tensor/host_data.rs
@@ -1,6 +1,7 @@
 use cubecl::{
     CubeElement, TestRuntime,
     client::ComputeClient,
+    ir::{ElemType, FloatKind, StorageType},
     prelude::CubePrimitive,
     std::tensor::TensorHandle,
     zspace::{Shape, Strides},
@@ -21,6 +22,31 @@ pub enum HostDataType {
     F64,
     I32,
     Bool,
+}
+
+/// Convert a `Vec<f64>` accumulation buffer into a `HostDataVec` at the
+/// precision dictated by `dtype`: kept as `F64` for f64 tensors, downcast to
+/// `F32` for everything else (matching `HostDataType::from`).
+impl From<(Vec<f64>, StorageType)> for HostDataVec {
+    fn from((data, dtype): (Vec<f64>, StorageType)) -> Self {
+        match HostDataType::from(dtype) {
+            HostDataType::F64 => HostDataVec::F64(data),
+            _ => HostDataVec::F32(data.into_iter().map(|x| x as f32).collect()),
+        }
+    }
+}
+
+impl From<StorageType> for HostDataType {
+    /// Map a tensor storage type to the host representation used in tests.
+    /// `f64` tensors get `F64` so comparisons happen at full precision; all
+    /// other numeric types collapse to `F32`.
+    fn from(dtype: StorageType) -> Self {
+        if matches!(dtype.elem_type(), ElemType::Float(FloatKind::F64)) {
+            HostDataType::F64
+        } else {
+            HostDataType::F32
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/cubek-test-utils/src/test_tensor/host_data.rs
+++ b/crates/cubek-test-utils/src/test_tensor/host_data.rs
@@ -18,6 +18,7 @@ pub struct HostData {
 #[derive(Eq, PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub enum HostDataType {
     F32,
+    F64,
     I32,
     Bool,
 }
@@ -25,6 +26,7 @@ pub enum HostDataType {
 #[derive(Clone, Debug)]
 pub enum HostDataVec {
     F32(Vec<f32>),
+    F64(Vec<f64>),
     I32(Vec<i32>),
     Bool(Vec<bool>),
 }
@@ -34,6 +36,17 @@ impl HostDataVec {
         match self {
             HostDataVec::F32(items) => items[i],
             _ => panic!("Can't get as f32"),
+        }
+    }
+
+    /// Get the element as `f64`, losslessly upcasting `F32` data if needed.
+    /// This is the precision-preserving accessor used by the correctness
+    /// comparator so `F64` host data can be compared at full precision.
+    pub fn get_f64(&self, i: usize) -> f64 {
+        match self {
+            HostDataVec::F32(items) => items[i] as f64,
+            HostDataVec::F64(items) => items[i],
+            _ => panic!("Can't get as f64"),
         }
     }
 
@@ -54,6 +67,15 @@ impl HostDataVec {
     pub fn try_get_f32(&self, i: usize) -> Option<f32> {
         match self {
             HostDataVec::F32(items) => items.get(i).copied(),
+            _ => None,
+        }
+    }
+
+    /// Like [`try_get_f32`](Self::try_get_f32), but for [`get_f64`](Self::get_f64).
+    pub fn try_get_f64(&self, i: usize) -> Option<f64> {
+        match self {
+            HostDataVec::F32(items) => items.get(i).map(|&x| x as f64),
+            HostDataVec::F64(items) => items.get(i).copied(),
             _ => None,
         }
     }
@@ -106,6 +128,19 @@ impl HostData {
 
                 HostDataVec::F32(data)
             }
+            HostDataType::F64 => {
+                let handle = copy_casted(
+                    client,
+                    tensor_handle,
+                    f64::as_type_native_unchecked().storage_type(),
+                );
+                let data = f64::from_bytes(
+                    &client.read_one_unchecked_tensor(handle.into_copy_descriptor()),
+                )
+                .to_owned();
+
+                HostDataVec::F64(data)
+            }
             HostDataType::I32 => {
                 let handle = copy_casted(
                     client,
@@ -145,6 +180,12 @@ impl HostData {
         self.data.get_f32(self.strided_index(index))
     }
 
+    /// Like [`get_f32`](Self::get_f32), but returns `f64`, losslessly
+    /// upcasting `F32` data if needed.
+    pub fn get_f64(&self, index: &[usize]) -> f64 {
+        self.data.get_f64(self.strided_index(index))
+    }
+
     pub fn get_bool(&self, index: &[usize]) -> bool {
         self.data.get_bool(self.strided_index(index))
     }
@@ -157,6 +198,11 @@ impl HostData {
     /// (or the index is out of bounds), instead of panicking.
     pub fn try_get_f32(&self, index: &[usize]) -> Option<f32> {
         self.data.try_get_f32(self.strided_index(index))
+    }
+
+    /// Like [`try_get_f32`](Self::try_get_f32), but for [`get_f64`](Self::get_f64).
+    pub fn try_get_f64(&self, index: &[usize]) -> Option<f64> {
+        self.data.try_get_f64(self.strided_index(index))
     }
 
     pub fn try_get_i32(&self, index: &[usize]) -> Option<i32> {
@@ -180,6 +226,15 @@ impl HostData {
     pub fn iter_indexed_f32(&self) -> impl Iterator<Item = (Vec<usize>, f32)> + '_ {
         self.iter_indices().map(move |idx| {
             let v = self.get_f32(&idx);
+            (idx, v)
+        })
+    }
+
+    /// Iterate `(index, f64 value)` pairs in row-major order, losslessly
+    /// upcasting `F32` data if needed.
+    pub fn iter_indexed_f64(&self) -> impl Iterator<Item = (Vec<usize>, f64)> + '_ {
+        self.iter_indices().map(move |idx| {
+            let v = self.get_f64(&idx);
             (idx, v)
         })
     }
@@ -273,6 +328,7 @@ impl HostData {
         match &self.data {
             HostDataVec::I32(_) => self.data.get_i32(idx).to_string(),
             HostDataVec::F32(_) => format!("{:.3}", self.data.get_f32(idx)),
+            HostDataVec::F64(_) => format!("{:.3}", self.data.get_f64(idx)),
             HostDataVec::Bool(_) => self.data.get_bool(idx).to_string(),
         }
     }

--- a/crates/cubek-test-utils/src/test_tensor/io.rs
+++ b/crates/cubek-test-utils/src/test_tensor/io.rs
@@ -12,7 +12,7 @@
 //!   ------  ----   -----
 //!     0     4      magic = "CKHD"
 //!     4     1      version (currently 1)
-//!     5     1      dtype tag (0=F32, 1=I32, 2=Bool)
+//!     5     1      dtype tag (0=F32, 1=I32, 2=Bool, 3=F64)
 //!     6     4      rank
 //!    10     8*rank shape
 //!    +     8*rank  strides
@@ -37,6 +37,7 @@ const VERSION: u8 = 1;
 const TAG_F32: u8 = 0;
 const TAG_I32: u8 = 1;
 const TAG_BOOL: u8 = 2;
+const TAG_F64: u8 = 3;
 
 /// Write `data` to `path` in the binary format documented at the module level.
 ///
@@ -51,6 +52,7 @@ pub fn write_host_data(path: &Path, data: &HostData) -> io::Result<u64> {
 
     let (tag, elem_count) = match &data.data {
         HostDataVec::F32(v) => (TAG_F32, v.len()),
+        HostDataVec::F64(v) => (TAG_F64, v.len()),
         HostDataVec::I32(v) => (TAG_I32, v.len()),
         HostDataVec::Bool(v) => (TAG_BOOL, v.len()),
     };
@@ -79,6 +81,7 @@ pub fn write_host_data(path: &Path, data: &HostData) -> io::Result<u64> {
 
     match &data.data {
         HostDataVec::F32(v) => w.write_all(bytemuck::cast_slice(v))?,
+        HostDataVec::F64(v) => w.write_all(bytemuck::cast_slice(v))?,
         HostDataVec::I32(v) => w.write_all(bytemuck::cast_slice(v))?,
         HostDataVec::Bool(v) => {
             // One byte per bool — keeps reads alignment-free and rare enough
@@ -141,6 +144,15 @@ pub fn read_host_data(path: &Path) -> io::Result<HostData> {
             }
             HostDataVec::F32(v)
         }
+        TAG_F64 => {
+            let mut buf = vec![0u8; elem_count * std::mem::size_of::<f64>()];
+            r.read_exact(&mut buf)?;
+            let mut v = Vec::with_capacity(elem_count);
+            for chunk in buf.chunks_exact(8) {
+                v.push(f64::from_le_bytes(chunk.try_into().unwrap()));
+            }
+            HostDataVec::F64(v)
+        }
         TAG_I32 => {
             let mut buf = vec![0u8; elem_count * std::mem::size_of::<i32>()];
             r.read_exact(&mut buf)?;
@@ -202,6 +214,7 @@ mod tests {
         assert_eq!(data.strides, read_back.strides);
         match (&data.data, &read_back.data) {
             (HostDataVec::F32(a), HostDataVec::F32(b)) => assert_eq!(a, b),
+            (HostDataVec::F64(a), HostDataVec::F64(b)) => assert_eq!(a, b),
             (HostDataVec::I32(a), HostDataVec::I32(b)) => assert_eq!(a, b),
             (HostDataVec::Bool(a), HostDataVec::Bool(b)) => assert_eq!(a, b),
             _ => panic!("dtype mismatch on round-trip"),
@@ -215,6 +228,18 @@ mod tests {
             "f32",
             HostData {
                 data: HostDataVec::F32(vec![1.0, -2.0, std::f32::consts::PI, 0.5, 0.0]),
+                shape: Shape::from(vec![5]),
+                strides: Strides::new(&[1]),
+            },
+        );
+    }
+
+    #[test]
+    fn round_trip_f64() {
+        round_trip(
+            "f64",
+            HostData {
+                data: HostDataVec::F64(vec![1.0, -2.0, std::f64::consts::PI, 0.5, 0.0]),
                 shape: Shape::from(vec![5]),
                 strides: Strides::new(&[1]),
             },


### PR DESCRIPTION
Wit this commit https://github.com/tracel-ai/cubecl/commit/84d719b0bff308cda7db4b4fb1412ff1f069a022
and this one, f64 can be used in cubek cuda.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
