### PR TITLE
Fix inferred `Cube` reduce blueprint overrunning shared memory for `ArgTopK` / `TopK`

### DIFF
--- a/crates/cubek-reduce/src/components/instructions/mixed.rs
+++ b/crates/cubek-reduce/src/components/instructions/mixed.rs
@@ -52,6 +52,36 @@ pub enum ReduceOperationConfig {
 }
 
 impl ReduceOperationConfig {
+    /// Shared-memory bytes one accumulator slot uses (total usage is this times the
+    /// slot count). `acc_elem_size` is the accumulation element size (`P::EA`),
+    /// `vector_size` the input vectorization. Mirrors each instruction's
+    /// `SharedAccumulator` layout: one value slice, plus a `u32` index slice for
+    /// `Arg*`, scaled by `k` for top-k.
+    pub fn shared_memory_bytes_per_accumulator(
+        &self,
+        acc_elem_size: usize,
+        vector_size: usize,
+    ) -> usize {
+        // Index slices are `Vector<u32, SI>` for every instruction that has them
+        // (`ArgAccumulator` and `ArgTopKSharedAccumulator`), so the index element is
+        // always u32. Revisit this if indices ever widen (e.g. u64 coordinates).
+        let index_elem_size = core::mem::size_of::<u32>();
+        let (value_slices, index_slices) = match self {
+            ReduceOperationConfig::Sum
+            | ReduceOperationConfig::Prod
+            | ReduceOperationConfig::Mean
+            | ReduceOperationConfig::MaxAbs
+            | ReduceOperationConfig::Max
+            | ReduceOperationConfig::Min
+            | ReduceOperationConfig::Any
+            | ReduceOperationConfig::All => (1, 0),
+            ReduceOperationConfig::ArgMax | ReduceOperationConfig::ArgMin => (1, 1),
+            ReduceOperationConfig::ArgTopK(k) => (*k, *k),
+            ReduceOperationConfig::TopK(k) => (*k, 0),
+        };
+        (value_slices * acc_elem_size + index_slices * index_elem_size) * vector_size
+    }
+
     /// Computes the best case precision for the given config.
     pub fn precision(&self, input: ElemType, output: Option<ElemType>) -> ReduceDtypes {
         match self {
@@ -619,6 +649,31 @@ mod tests {
     /// storage (e.g. the u8/u32 backing of a bool tensor), like Arg* indices.
     /// Check both for a narrow float (f16, the type that motivated this work)
     /// and an integer input.
+    /// Pin the footprint for one op of each layout. f32 is 4 bytes, so `ArgTopK(k)`
+    /// is `8 * k` bytes.
+    #[test]
+    fn shared_memory_footprint_matches_accumulator_layout() {
+        use ReduceOperationConfig::*;
+        let cases = [
+            (Sum, 4),
+            (ArgMax, 8),
+            (TopK(7), 7 * 4),
+            (ArgTopK(13), 13 * 8),
+        ];
+        for (config, expected) in cases {
+            assert_eq!(
+                config.shared_memory_bytes_per_accumulator(4, 1),
+                expected,
+                "footprint for {config:?}"
+            );
+        }
+        // Vectorization scales every slice uniformly.
+        assert_eq!(
+            ArgTopK(13).shared_memory_bytes_per_accumulator(4, 4),
+            13 * 8 * 4
+        );
+    }
+
     #[test]
     fn any_all_precision_keeps_accumulation_narrow() {
         let inputs = [ElemType::Float(FloatKind::F16), ElemType::Int(IntKind::I32)];

--- a/crates/cubek-reduce/src/error.rs
+++ b/crates/cubek-reduce/src/error.rs
@@ -40,6 +40,13 @@ pub enum ReduceError {
     #[error("Atomic add not supported by the client for {0}")]
     MissingAtomicAdd(StorageType),
 
+    /// The selected blueprint stages more accumulators in shared memory than the
+    /// device allows.
+    #[error(
+        "Reduce blueprint requires {requested} bytes of shared memory, but only {available} bytes are available on the device."
+    )]
+    SharedMemoryOverflow { requested: usize, available: usize },
+
     /// An error happened during launch.
     #[error("An error happened during launch\nCaused by:\n  {0}")]
     Launch(LaunchError),

--- a/crates/cubek-reduce/src/launch/base.rs
+++ b/crates/cubek-reduce/src/launch/base.rs
@@ -50,6 +50,7 @@ pub(crate) fn launch_reduce<Run: Runtime>(
         reduce_count,
         axis: reduce_axis,
         dtypes,
+        instruction: inst,
         address_type,
     };
     let vectorization_mode = match input.strides[reduce_axis] {

--- a/crates/cubek-reduce/src/routines/base.rs
+++ b/crates/cubek-reduce/src/routines/base.rs
@@ -1,4 +1,7 @@
-use crate::{ReduceDtypes, ReduceError, VectorizationMode, routines::ReduceBlueprint};
+use crate::{
+    ReduceDtypes, ReduceError, VectorizationMode, components::instructions::ReduceOperationConfig,
+    routines::ReduceBlueprint,
+};
 use cubecl::prelude::*;
 
 #[derive(Debug)]
@@ -24,6 +27,10 @@ pub struct ReduceProblem {
     pub reduce_count: usize,
     pub axis: usize,
     pub dtypes: ReduceDtypes,
+    /// The reduce operation being launched. The blueprint selector bounds the cube
+    /// width by this instruction's per-accumulator shared-memory footprint (which
+    /// scales with `k` for `ArgTopK` / `TopK`).
+    pub instruction: ReduceOperationConfig,
     /// The address type, defined by the max of each handle's `required_address_type`
     pub address_type: AddressType,
 }

--- a/crates/cubek-reduce/src/routines/cube.rs
+++ b/crates/cubek-reduce/src/routines/cube.rs
@@ -56,6 +56,18 @@ impl Routine for CubeRoutine {
                     });
                 }
 
+                // Reject a forced blueprint whose accumulators exceed the device's
+                // shared-memory limit.
+                let bytes_per_accumulator = bytes_per_accumulator(&problem, &settings);
+                let requested = bytes_per_accumulator * blueprint.num_shared_accumulators;
+                let available = client.properties().hardware.max_shared_memory_size;
+                if requested > available {
+                    return Err(ReduceError::SharedMemoryOverflow {
+                        requested,
+                        available,
+                    });
+                }
+
                 let working_cubes = working_cubes(&settings, &problem);
                 let (cube_count, launched_cubes) =
                     cube_count_spread_with_total(client, working_cubes);
@@ -111,6 +123,18 @@ fn generate_blueprint<R: Runtime>(
     let working_units = working_cubes * problem.reduce_len.div_ceil(settings.vector_size_input);
     let plane_count =
         calculate_plane_count_per_cube(working_units, plane_size, hardware_properties);
+
+    // Occupancy sizes the cube above; shrink the plane count if the resulting
+    // shared-memory footprint (which scales with `k` for `ArgTopK` / `TopK`) would
+    // overrun the device limit, keeping `cube_dim.x = plane_size`.
+    let plane_count = clamp_plane_count(
+        bytes_per_accumulator(&problem, settings),
+        client.properties().hardware.max_shared_memory_size,
+        plane_size,
+        plane_count,
+        use_planes,
+    )?;
+
     let cube_dim = CubeDim::new_2d(plane_size, plane_count);
     let cube_size = cube_dim.num_elems();
 
@@ -160,5 +184,101 @@ fn working_cubes(settings: &ReduceVectorSettings, problem: &ReduceProblem) -> us
     match settings.vectorization_mode {
         VectorizationMode::Parallel => problem.reduce_count / settings.vector_size_output,
         VectorizationMode::Perpendicular => problem.reduce_count / settings.vector_size_input,
+    }
+}
+
+/// Shared bytes per accumulator slot for this problem's instruction.
+fn bytes_per_accumulator(problem: &ReduceProblem, settings: &ReduceVectorSettings) -> usize {
+    problem.instruction.shared_memory_bytes_per_accumulator(
+        problem.dtypes.accumulation.size(),
+        settings.vector_size_input,
+    )
+}
+
+/// Shrink `plane_count` until the cube's shared footprint fits `available` bytes,
+/// keeping `cube_dim.x = plane_size`, or fail if even one plane does not fit. With
+/// `use_planes` there is one accumulator per plane, otherwise one per unit
+/// (`plane_size * plane_count`).
+fn clamp_plane_count(
+    bytes_per_accumulator: usize,
+    available: usize,
+    plane_size: u32,
+    plane_count: u32,
+    use_planes: bool,
+) -> Result<u32, ReduceError> {
+    if bytes_per_accumulator == 0 {
+        return Ok(plane_count);
+    }
+
+    let max_accumulators = available / bytes_per_accumulator;
+
+    // The smallest cube we emit is a single plane: one accumulator in plane mode,
+    // else `plane_size`. If even that does not fit the config is infeasible.
+    let min_accumulators = if use_planes { 1 } else { plane_size as usize };
+    if max_accumulators < min_accumulators {
+        return Err(ReduceError::SharedMemoryOverflow {
+            requested: bytes_per_accumulator * min_accumulators,
+            available,
+        });
+    }
+
+    let max_plane_count = match use_planes {
+        true => max_accumulators,
+        false => max_accumulators / plane_size as usize,
+    };
+
+    Ok(plane_count.min(max_plane_count as u32).max(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clamp_plane_count;
+    use crate::ReduceError;
+
+    // RTX 4090 (Ada) opt-in shared-memory limit.
+    const ADA_SHARED: usize = 101_376;
+    const PLANE_SIZE: u32 = 32;
+
+    /// ArgTopK(k) over f32, no vectorization: k value + k u32 index slices of 4
+    /// bytes, so 8 * k bytes per accumulator.
+    fn argtopk_bytes(k: usize) -> usize {
+        8 * k
+    }
+
+    #[test]
+    fn clamps_argtopk_to_fit_and_leaves_sum_alone() {
+        // Sum (4 bytes/accumulator) never overruns, so the wide cube is preserved.
+        assert_eq!(
+            clamp_plane_count(4, ADA_SHARED, PLANE_SIZE, 32, false).unwrap(),
+            32
+        );
+
+        // k = 13 at width 1024 needs 8*13*1024 = 106496 > 101376, so it must shrink.
+        // Across every feasible k the clamped width must fit.
+        assert!(
+            clamp_plane_count(argtopk_bytes(13), ADA_SHARED, PLANE_SIZE, 32, false).unwrap() < 32
+        );
+        for k in 1..=396 {
+            let clamped =
+                clamp_plane_count(argtopk_bytes(k), ADA_SHARED, PLANE_SIZE, 32, false).unwrap();
+            let width = clamped as usize * PLANE_SIZE as usize;
+            assert!(
+                clamped >= 1 && argtopk_bytes(k) * width <= ADA_SHARED,
+                "k={k}"
+            );
+        }
+    }
+
+    #[test]
+    fn errors_when_one_warp_cannot_fit() {
+        // k = 397 needs 8*397*32 = 101632 bytes for a single warp, just over the
+        // limit, so even the minimum cube is infeasible.
+        let err =
+            clamp_plane_count(argtopk_bytes(397), ADA_SHARED, PLANE_SIZE, 32, false).unwrap_err();
+        assert!(matches!(
+            err,
+            ReduceError::SharedMemoryOverflow { requested, available }
+                if available == ADA_SHARED && requested == argtopk_bytes(397) * PLANE_SIZE as usize
+        ));
     }
 }

--- a/crates/cubek-reduce/tests/reduce/it/argtopk_shared_memory.rs
+++ b/crates/cubek-reduce/tests/reduce/it/argtopk_shared_memory.rs
@@ -1,0 +1,50 @@
+//! End-to-end coverage for the shared-memory clamp on the inferred `Cube` routine.
+//!
+//! Before the clamp, the inferred Cube blueprint sized its shared allocation from
+//! plane geometry alone, so `ArgTopK(k)` requested `8 * k * cube_width` bytes and the
+//! launch was rejected once `k` passed ~12 on a 99 KiB device, even though a narrower
+//! cube fit. Gated behind `heavy` like the other cube tests (the kernels are slow to
+//! compile, the top-k insert/merge are unrolled over `k`).
+
+#![cfg(feature = "heavy")]
+
+use cubecl::zspace::{Shape, Strides};
+use cubek_reduce::{
+    ReduceStrategy,
+    launch::{RoutineStrategy, VectorizationStrategy},
+    routines::{BlueprintStrategy, cube::CubeStrategy},
+};
+
+use crate::reduce::it::test_case::TestCase;
+
+fn inferred_cube_strategy(use_planes: bool) -> ReduceStrategy {
+    ReduceStrategy {
+        vectorization: VectorizationStrategy {
+            parallel_output_vectorization: false,
+        },
+        routine: RoutineStrategy::Cube(BlueprintStrategy::Inferred(CubeStrategy { use_planes })),
+    }
+}
+
+/// Run an inferred-Cube `ArgTopK(k)` over `[64, 4096]` (axis 1), the shape from the
+/// bug report, and assert the output matches the CPU top-k reference. With the old
+/// geometry the inferred cube width is 1024, so `8 * k * 1024` overruns shared
+/// memory for `k >= 13`. The clamp must shrink the width and let the launch through.
+fn run_wide_argtopk(k: usize) {
+    TestCase::new::<f32>(
+        Shape::new([64, 4096]),
+        Strides::new(&[4096, 1]),
+        Some(1),
+        inferred_cube_strategy(false),
+    )
+    .test_argtopk(k);
+}
+
+#[test]
+fn argtopk_k13_inferred_cube_launches() {
+    // The smallest k that failed to launch before the fix (8 * 13 * 1024 = 106496
+    // bytes vs the 101376-byte Ada limit). Larger k is launchable too, but the
+    // top-k codegen is unrolled over k and compiles slowly (a separate issue), so
+    // a single representative k keeps this suite fast.
+    run_wide_argtopk(13);
+}

--- a/crates/cubek-reduce/tests/reduce/it/mod.rs
+++ b/crates/cubek-reduce/tests/reduce/it/mod.rs
@@ -1,5 +1,6 @@
 pub mod test_case;
 
+mod argtopk_shared_memory;
 mod logical;
 
 macro_rules! testgen_reduce {


### PR DESCRIPTION
When you run a top-k reduction with the inferred `Cube` routine, the routine has to pick how wide a cube to launch, and that width decides how much shared memory it allocates. It was picking that width from occupancy alone and never checking it against the device's shared-memory limit. That is fine for `Sum` or `Max`, where each slot in shared memory holds a single value, but `ArgTopK(k)` and `TopK(k)` keep `k` values (and `ArgTopK` also `k` indices) per slot, so the allocation grows with `k`. Past a certain `k` the chosen width asks for more shared memory than the device has, and the launch is rejected, even though a narrower cube would have fit and run correctly.

I hit this on a kNN benchmark on an RTX 4090, whose shared-memory limit is `101376` bytes. The inferred routine always picks a `1024`-wide cube, and `ArgTopK` asks for `8 * k * 1024` bytes, so `k = 12` fits at `98304` bytes but `k = 13` wants `106496`, more than the device has. Every `ArgTopK` past `k = 12` then failed the same way: the driver refused the launch with a "Too much shared memory requested" error, which (because the launch is asynchronous) only surfaced later when the queue drained, for example at the next read. The reduction never ran, so the whole range past `k = 12` was unreachable through the inferred routine, which is exactly the range a kNN workload needs.

The correction I am proposing in this PR is to let the width selector account for shared memory the same way it already accounts for occupancy. Each reduce operation can now report how many bytes one accumulator slot costs, and the `Cube` blueprint shrinks the cube (keeping `cube_dim.x` at one plane, a warp on this CUDA device) until the total fits the device limit, never going below a single plane. If even one warp cannot fit, it returns a clear `SharedMemoryOverflow` error instead of letting the driver fail the launch with a raw resource message. With this, `k = 13` picks a narrower cube and runs, and the feasible `k` range widens a lot. Ordinary reductions are untouched, since their per-slot cost is a single element and the new clamp never triggers.

There is a separate problem around compile time at large `k` that I plan to work on in a follow-up after this PR is merged. It is out of scope here.

I am not a kernel expert, so this needs a careful review from someone who is. That said, it does work on my RTX 4090: the `ArgTopK` cases that the current `main` branch of cubek rejects at launch now run and match a CPU top-k reference, where before they crashed.
