### PR TITLE
Fix quantized matmul GEMV reading wrong elements from a packed operand

### DIFF
--- a/crates/cubek-matmul/src/components/global/memory/layout.rs
+++ b/crates/cubek-matmul/src/components/global/memory/layout.rs
@@ -229,6 +229,16 @@ impl<R: Runtime> GlobalLayoutLaunch<R> {
 
             let batch_layout = BatchLayoutLaunch::from_handle(values, problem);
 
+            // The packing axis follows the scheme packed dim, not config.matrix_layout:
+            // GEMV reads the RHS ColMajor while the packed buffer stays RowMajor.
+            let values_config = GlobalLayoutConfig {
+                matrix_layout: match scheme.packing_dim() {
+                    Some(1) => MatrixLayout::ColMajor,
+                    _ => MatrixLayout::RowMajor,
+                },
+                ..config
+            };
+
             GlobalLayoutLaunch::new(
                 VirtualLayoutLaunch::new::<BatchLayout>(batch_layout),
                 rows as u32,
@@ -237,7 +247,7 @@ impl<R: Runtime> GlobalLayoutLaunch<R> {
                 stride_col,
                 vector_size / scheme.num_quants(),
                 scheme.num_quants() as u32,
-                config,
+                values_config,
             )
         };
 

--- a/crates/cubek-matmul/tests/matmul/extended/quantization.rs
+++ b/crates/cubek-matmul/tests/matmul/extended/quantization.rs
@@ -461,6 +461,20 @@ pub fn test_matmul_quantized_lhs_q4s_rect() {
     });
 }
 
+#[test]
+pub fn test_matmul_quantized_rhs_gemv() {
+    // Vec-mat (m=1) with a packed quantized RHS through GEMV, whose read layout differs
+    // from the packed buffer layout.
+    run_quantized_matmul(QuantizedMatmulCase {
+        m: 1,
+        n: 64,
+        k: 64,
+        rhs_scheme: Some(tensor_scheme(QuantValue::Q4S)),
+        strategy: Strategy::GemvUnitPerpendicular(Default::default()),
+        ..Default::default()
+    });
+}
+
 /// Helper to convert TestTensor (which may be marked as quantized) to InputBinding.
 fn test_tensor_to_binding(tensor: TestTensor) -> InputBinding<TestRuntime> {
     match tensor.quantization {


### PR DESCRIPTION
`GlobalLayoutLaunch::from_quantized_handle` derived the value layout packing axis from `config.matrix_layout`, which is the layout the calling routine uses to read the operand rather than the axis the packed buffer is actually packed along. The `GemvUnitPerpendicular` routine reads the RHS with a `ColMajor` config while the packed values stay contiguous along the last dim, so `to_source_pos` divided the row axis by the packing factor instead of the column axis and the gather read the wrong elements.

The packing axis now comes from `scheme.packing_dim()`, matching the convention `MatrixLayout::from_shape_and_strides` already uses (`0` maps to `RowMajor`, `1` maps to `ColMajor`). The bounds-check flags from the routine config are preserved. This is not codebook-specific: a plain affine quantized RHS through GEMV reproduces it, which is why the regression test uses a `Symmetric` `Q4S` scheme.

New test `test_matmul_quantized_rhs_gemv` fails before the change and passes after. Before the fix, with `m=1, n=64, k=64` and a `Q4S` RHS, most output elements are wrong:

    Test failed: Got incorrect results: 37/64 elements mismatched (max |Δ|=11.257772, mean |Δ|=4.061798, worst at [0, 0, 38]) — shape=[1, 1, 64]
    First mismatches:
      [0, 0, 0]: got -0.4165744, expected 0.85803854, |Δ|=1.2746129 > ε=1.1428572
      [0, 0, 4]: got -3.057455, expected 1.9992565, |Δ|=5.0567117 > ε=2.2848647
      [0, 0, 16]: got 2.5816207, expected -4.7685385, |Δ|=7.350159 > ε=5.4497585

The existing affine quantized suite still passes, including `test_matmul_quantized_rhs_col_major`, the closest neighbour. Verified on `cpu`, `cuda`, and `wgpu`.
