### PR TITLE
Run float Gemm on GPU for all operand layouts by normalizing to the Dot variant

### DIFF
--- a/crates/cubek-matmul/src/routines/gemm/launch.rs
+++ b/crates/cubek-matmul/src/routines/gemm/launch.rs
@@ -36,6 +36,36 @@ fn vector_size_for<R: Runtime>(
         .ok_or(VectorizationError::NoValidVectorization)
 }
 
+/// Return `binding` materialized into the `target` matrix layout, copying the
+/// data only when its current layout differs. `RowMajor` leaves the last dim
+/// contiguous, `ColMajor` the second-to-last.
+#[allow(clippy::result_large_err)]
+fn make_k_contiguous<R: Runtime>(
+    client: &ComputeClient<R>,
+    binding: InputBinding<R>,
+    target: MatrixLayout,
+) -> Result<InputBinding<R>, MatmulSetupError> {
+    let rank = binding.shape().len();
+    let layout = MatrixLayout::from_shape_and_strides(
+        binding.shape(),
+        &binding.data().strides,
+        binding.scheme(),
+    )?;
+    if layout == target {
+        return Ok(binding);
+    }
+    Ok(match target {
+        MatrixLayout::RowMajor => binding.into_contiguous(client)?,
+        MatrixLayout::ColMajor => {
+            let mut binding = binding;
+            binding.swap_dims(rank - 2, rank - 1);
+            let mut binding = binding.into_contiguous(client)?;
+            binding.swap_dims(rank - 2, rank - 1);
+            binding
+        }
+    })
+}
+
 #[allow(clippy::result_large_err)]
 pub fn launch_ref<R: Runtime>(
     client: &ComputeClient<R>,
@@ -49,6 +79,28 @@ pub fn launch_ref<R: Runtime>(
     // materialize such operands so they read as plain contiguous tensors.
     lhs = into_contiguous_if_highly_permuted(client, lhs)?;
     rhs = into_contiguous_if_highly_permuted(client, rhs)?;
+
+    // On GPU only the `Dot` variant has a kernel, and it needs both operands
+    // K-contiguous, so normalize each float matrix operand to that layout.
+    //
+    // Quantized operands are excluded here by the `scheme().is_none()` guards. A
+    // quantized operand that is not already K-contiguous can only reach `Dot` by
+    // being transposed, and that transpose repacks its u32 buffer through cubecl
+    // `into_contiguous_packed`, which currently writes a zero buffer. Quantized
+    // matmul on GPU is therefore BLOCKED on that cubecl bug being fixed upstream.
+    // When it lands, remove these guards so quantized operands take the same path.
+    let plane_dim = client.properties().hardware.plane_size_max as usize;
+    if plane_dim > 1 {
+        let rank = lhs.shape().len();
+        let m = lhs.shape().to_vec()[rank - 2];
+        let n = rhs.shape().to_vec()[rank - 1];
+        if m > 1 && lhs.scheme().is_none() {
+            lhs = make_k_contiguous(client, lhs, MatrixLayout::RowMajor)?;
+        }
+        if n > 1 && rhs.scheme().is_none() {
+            rhs = make_k_contiguous(client, rhs, MatrixLayout::ColMajor)?;
+        }
+    }
 
     let rank = rhs.shape().len();
     let lhs_shape = lhs.shape();

--- a/crates/cubek-matmul/tests/matmul/extended/gemm/mod.rs
+++ b/crates/cubek-matmul/tests/matmul/extended/gemm/mod.rs
@@ -1,3 +1,4 @@
+use crate::matmul::launcher_strategy::run_with_strides;
 use crate::matmul::test_matmul_strategy;
 use cubecl::{Runtime, frontend::CubePrimitive, ir::AddressType, zspace::shape};
 use cubek_matmul::{routines::BlueprintStrategy, strategy::Strategy};
@@ -8,15 +9,15 @@ use cubek_matmul::{
     routines::gemm::GemmStrategy,
 };
 use cubek_std::MatrixLayout;
+use cubek_test_utils::{TestOutcome, ValidationResult};
 
 type TestRuntime = cubecl::TestRuntime;
 
 /// Unified harness for the gemm family. Drives full GEMM (all 4 layout
-/// combinations), vec-mat (m = 1), and mat-vec (n = 1) through the same
-/// case struct and `Strategy::Gemm`. The `plane_parallel.rs` cases cover
-/// the Row-Col (Dot) variant — the same set runs on any backend; the
-/// `outer_product.rs` cases additionally cover Row-Row / Col-Row / Col-Col,
-/// which are CPU-only (the family enforces `plane_dim == 1` for those).
+/// combinations), vec-mat (m = 1), and mat-vec (n = 1) through the same case
+/// struct and `Strategy::Gemm`. `plane_parallel.rs` covers the Row-Col (Dot)
+/// variant. `outer_product.rs` covers Row-Row, Col-Row, and Col-Col, which run
+/// on CPU directly and on GPU after `launch_ref` normalizes them to Dot.
 struct GemmTestCase {
     pub m: usize,
     pub n: usize,
@@ -51,6 +52,20 @@ impl GemmTestCase {
         let client = TestRuntime::client(&Default::default());
         let problem = self.to_problem();
         test_matmul_strategy(client, problem, self.strategy);
+    }
+
+    /// Like [`test`], but asserts the matmul actually ran and validated rather
+    /// than letting the test policy accept a config rejection. Use for layouts
+    /// that must execute on GPU, where the default `correct` policy would
+    /// otherwise silently accept a `CompileError` and hide a regression.
+    pub(crate) fn test_executes(self) {
+        let client = TestRuntime::client(&Default::default());
+        let problem = self.to_problem();
+        let outcome = run_with_strides(client, problem, self.strategy);
+        assert!(
+            matches!(outcome, TestOutcome::Validated(ValidationResult::Pass)),
+            "expected the matmul to execute and validate, got {outcome:?}"
+        );
     }
 }
 

--- a/crates/cubek-matmul/tests/matmul/extended/gemm/outer_product.rs
+++ b/crates/cubek-matmul/tests/matmul/extended/gemm/outer_product.rs
@@ -425,3 +425,56 @@ pub fn matvec_large_col_major() {
     }
     .test();
 }
+
+// Assert these layouts actually execute on GPU instead of being silently rejected.
+
+#[test]
+pub fn matmat_row_row_executes() {
+    let (lhs_layout, rhs_layout) = matmat_row_row();
+    GemmTestCase {
+        m: 32,
+        n: 32,
+        k: 256,
+        lhs_batch: 1,
+        rhs_batch: 1,
+        lhs_layout,
+        rhs_layout,
+        elems: elems(),
+        strategy: outer_product(),
+    }
+    .test_executes();
+}
+
+#[test]
+pub fn matmat_col_col_executes() {
+    let (lhs_layout, rhs_layout) = matmat_col_col();
+    GemmTestCase {
+        m: 32,
+        n: 32,
+        k: 256,
+        lhs_batch: 1,
+        rhs_batch: 1,
+        lhs_layout,
+        rhs_layout,
+        elems: elems(),
+        strategy: outer_product(),
+    }
+    .test_executes();
+}
+
+#[test]
+pub fn matmat_col_row_executes() {
+    let (lhs_layout, rhs_layout) = matmat_col_row();
+    GemmTestCase {
+        m: 32,
+        n: 32,
+        k: 256,
+        lhs_batch: 1,
+        rhs_batch: 1,
+        lhs_layout,
+        rhs_layout,
+        elems: elems(),
+        strategy: outer_product(),
+    }
+    .test_executes();
+}


### PR DESCRIPTION
On GPU the Gemm routine only had a kernel for the `Dot` variant, which needs the left operand `RowMajor` and the right operand `ColMajor`. Any other operand layout fell to an outer-product variant that is CPU-only, so a Gemm on GPU with for example a `RowMajor` right operand was rejected with `requires plane_dim == 1 (CPU-only)` and never ran.

On GPU, `launch_ref` now transposes each float matrix operand to its K-contiguous layout (left to `RowMajor`, right to `ColMajor`) before the variant is chosen, so every layout resolves to `Dot`. Operands already in that layout are left alone, and CPU is unaffected since the normalization is gated on `plane_dim > 1`. The change covers float operands only, so quantized operands keep their current behavior.

The new `matmat_*_executes` tests assert the matmul actually runs on GPU rather than letting the default test policy silently accept a rejected config. They fail before this change on GPU and pass after, verified on `cuda`, `wgpu`, and `cpu`.

The quantized variants of these layouts likely need the analogous normalization, but testing that now is complex because it depends on other fixes still in review across cubecl and cubek: tracel-ai/cubecl#1390 (the `into_contiguous` packed zero-buffer fix a packed transpose relies on), tracel-ai/cubecl#1391 (the quantized view vector-size guard), and tracel-ai/cubek#374 (the quantized matmul read path). Once those land it should be easy to resume: drop the `scheme().is_none()` guards and add the matching `_executes` cases.
