### PR TITLE
Fix interpolate autotune key

### DIFF
--- a/crates/cubek-interpolate/src/definition/base.rs
+++ b/crates/cubek-interpolate/src/definition/base.rs
@@ -4,6 +4,7 @@ use crate::{
     routines::InterpolateBlueprint,
 };
 use cubecl::prelude::*;
+use serde::{Deserialize, Serialize};
 
 // Base trait for interpolation algorithms.
 #[cube]
@@ -16,7 +17,7 @@ pub trait Interpolate {
 }
 
 /// Algorithm used for upsampling.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CubeType)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CubeType, Serialize, Deserialize)]
 pub enum InterpolateMode {
     /// Nearest-neighbor interpolation.
     /// <https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation>
@@ -35,7 +36,7 @@ pub enum InterpolateMode {
     Lanczos3,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CubeType)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, CubeType, Serialize, Deserialize)]
 pub enum NearestMode {
     // Matches Scikit-Image and PIL nearest neighbours interpolation algorithms.
     Exact,

--- a/crates/cubek-interpolate/src/launch/tune_key.rs
+++ b/crates/cubek-interpolate/src/launch/tune_key.rs
@@ -1,3 +1,4 @@
+use crate::definition::InterpolateMode;
 use cubecl::{AutotuneKey, ir::ElemType};
 use serde::{Deserialize, Serialize};
 
@@ -6,6 +7,7 @@ use serde::{Deserialize, Serialize};
 pub struct InterpolateAutotuneKey {
     elem_input: ElemType,
     elem_output: ElemType,
+    mode: InterpolateMode,
 
     /// Whether the number of channels is a power of 4, which allows for more efficient vectorized processing.
     ///
@@ -43,6 +45,7 @@ impl InterpolateAutotuneKey {
     pub fn generate(
         elem_input: ElemType,
         elem_output: ElemType,
+        mode: InterpolateMode,
         input_shape: &[usize],
         output_size: &[usize; 2],
     ) -> Self {
@@ -56,6 +59,7 @@ impl InterpolateAutotuneKey {
         InterpolateAutotuneKey::new(
             elem_input,
             elem_output,
+            mode,
             channels_power_of_4,
             channels,
             output_height,


### PR DESCRIPTION
## Fix

This PR fixes an issue with interpolate autotune key not depending on the interpolation mode.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
