### PR TITLE
Fix CUDA WMMA query staging in attention

### DIFF
--- a/crates/cubek-attention/src/components/global/simple/reader/query.rs
+++ b/crates/cubek-attention/src/components/global/simple/reader/query.rs
@@ -34,6 +34,8 @@ impl<'a, AP: AttentionPrecision> QueryReader<'a, AP> {
 
     pub fn get_tile<P: AttentionPartitioner>(
         &self,
+        staged: &mut [Vector<QG<AP>, QGS<AP>>],
+        #[comptime] shared_stage: bool,
         tile: Coords2d,
         #[comptime] tile_size: AttentionTileSize,
         #[comptime] partition_seq_q: u32,
@@ -46,36 +48,58 @@ impl<'a, AP: AttentionPrecision> QueryReader<'a, AP> {
         let vector_size = self.gmem_config.vector_size.comptime() as u32;
         let vectors_per_row = comptime!(tile_size.head_dim / vector_size);
         let num_vectors = comptime!((tile_size.seq_q * vectors_per_row) as usize);
-
         let row_base = row * tile_size.seq_q;
         let col_base = col * tile_size.head_dim;
 
-        // Stage the tile in registers through checked view reads: the view's
-        // layout resolves the tensor's real strides (query views are often
-        // permuted — `(b, seq, heads, hd)` swapped to `(b, heads, seq, hd)`),
-        // and rows past `seq_q` read zero instead of out of bounds. The
-        // q-stage span rarely divides `seq_q`, so tail tiles overhang the
-        // tensor — and the memory behind it may end right there (exact-sized
-        // persistent allocations do). When `seq_q` divides the span the
-        // bounds check is compiled out.
-        let mut staged = Array::<Vector<QG<AP>, QGS<AP>>>::new(num_vectors);
-        #[unroll]
-        for r in 0..tile_size.seq_q {
-            #[unroll]
-            for v in 0..vectors_per_row {
-                staged[(r * vectors_per_row + v) as usize] = self
+        #[comptime]
+        if shared_stage {
+            // CMMA/WMMA can load only from global or shared memory. Cooperatively
+            // materialize the potentially strided/tail tile into this plane's
+            // shared-memory slot; a thread-local Array makes CUDA emit a trap-only
+            // kernel ("cannot perform wmma load or store on local memory").
+            let num_vectors_runtime = comptime!(num_vectors as u32).runtime();
+            let plane_offset = UNIT_POS_Y * num_vectors_runtime;
+            let mut index = UNIT_POS_PLANE;
+            while index < num_vectors_runtime {
+                let r = index / vectors_per_row.runtime();
+                let v = index % vectors_per_row.runtime();
+                staged[(plane_offset + index) as usize] = self
                     .query
                     .read_checked((row_base + r, col_base + v * vector_size));
+                index += PLANE_DIM;
             }
-        }
+            sync_plane();
 
-        StridedTile::<QG<AP>, QGS<AP>>::new_strided(
-            staged.slice(0, num_vectors),
-            0,
-            comptime!(num_vectors as u32).runtime(),
-            vectors_per_row.runtime(),
-            Swizzle::none(),
-            self.gmem_config.matrix_layout,
-        )
+            let end = plane_offset + num_vectors_runtime;
+            StridedTile::<QG<AP>, QGS<AP>>::new_strided(
+                &staged[plane_offset as usize..end as usize],
+                0,
+                num_vectors_runtime,
+                vectors_per_row.runtime(),
+                Swizzle::none(),
+                self.gmem_config.matrix_layout,
+            )
+        } else {
+            // Register attention may load directly from thread-local storage.
+            let mut local = Array::<Vector<QG<AP>, QGS<AP>>>::new(num_vectors);
+            #[unroll]
+            for r in 0..tile_size.seq_q {
+                #[unroll]
+                for v in 0..vectors_per_row {
+                    local[(r * vectors_per_row + v) as usize] = self
+                        .query
+                        .read_checked((row_base + r, col_base + v * vector_size));
+                }
+            }
+
+            StridedTile::<QG<AP>, QGS<AP>>::new_strided(
+                local.slice(0, num_vectors),
+                0,
+                comptime!(num_vectors as u32).runtime(),
+                vectors_per_row.runtime(),
+                Swizzle::none(),
+                self.gmem_config.matrix_layout,
+            )
+        }
     }
 }

--- a/crates/cubek-attention/src/components/stage/base.rs
+++ b/crates/cubek-attention/src/components/stage/base.rs
@@ -161,6 +161,7 @@ pub struct SharedPartitionAttentionConfig {
     pub partition_size: AttentionPartitionSize,
     pub stage_size: AttentionStageSize,
     pub num_planes: u32,
+    pub query_vector_size: u32,
     pub key_smem_config: StageMemoryConfig,
     pub value_smem_config: StageMemoryConfig,
     pub out_smem_config: StageMemoryConfig,

--- a/crates/cubek-attention/src/components/stage/partition_attention.rs
+++ b/crates/cubek-attention/src/components/stage/partition_attention.rs
@@ -248,6 +248,15 @@ impl<
         let partition_seq_q = config.shared().partition_size.seq_q;
         let partition_head_dim = config.shared().partition_size.head_dim;
         let attention_tile_size = config.tile_size();
+        let shared_stage = config.tile_attention().requires_shared_query_stage();
+        let staging_len = comptime!(if shared_stage {
+            (attention_tile_size.seq_q * attention_tile_size.head_dim
+                / config.shared().query_vector_size
+                * config.num_planes()) as usize
+        } else {
+            1
+        });
+        let mut staged = Shared::<[Vector<QG<AP>, QGS<AP>>]>::new_slice(staging_len);
 
         #[unroll]
         for q in 0..partition_seq_q as usize {
@@ -255,6 +264,8 @@ impl<
             for hd in 0..partition_head_dim as usize {
                 let tile_to_write = registers.get_mut(q, hd, partition_head_dim as usize);
                 let tile_read = reader.get_tile::<P>(
+                    &mut staged,
+                    shared_stage,
                     (q as u32, hd as u32).runtime(),
                     attention_tile_size,
                     partition_seq_q,
@@ -267,7 +278,13 @@ impl<
                         &Tile::new_SharedTile(SharedTile::wrap::<QGS<AP>>(tile_read)),
                         cubek_std::StageIdent::Lhs,
                     );
+                #[comptime]
+                if shared_stage {
+                    sync_plane();
+                }
             }
         }
+
+        unsafe { staged.free() };
     }
 }

--- a/crates/cubek-attention/src/components/stage/plane/setup.rs
+++ b/crates/cubek-attention/src/components/stage/plane/setup.rs
@@ -109,6 +109,7 @@ impl<SK: StageFamily, SV: StageFamily, SO: StageFamily> StageAttentionFamily
                 partition_size: blueprint.tiling_scheme.partition_size,
                 stage_size: blueprint.tiling_scheme.stage_size,
                 num_planes,
+                query_vector_size: blueprint.vector_sizes.query as u32,
                 key_smem_config,
                 value_smem_config,
                 out_smem_config,

--- a/crates/cubek-attention/src/components/stage/unit/setup.rs
+++ b/crates/cubek-attention/src/components/stage/unit/setup.rs
@@ -112,6 +112,7 @@ impl<SK: StageFamily, SV: StageFamily, SO: StageFamily> StageAttentionFamily
                 partition_size: blueprint.tiling_scheme.partition_size,
                 stage_size: blueprint.tiling_scheme.stage_size,
                 num_planes,
+                query_vector_size: blueprint.vector_sizes.query as u32,
                 key_smem_config,
                 value_smem_config,
                 out_smem_config,

--- a/crates/cubek-attention/src/components/tile/attention.rs
+++ b/crates/cubek-attention/src/components/tile/attention.rs
@@ -61,6 +61,10 @@ impl TileAttention {
         self.materialized_mask
     }
 
+    pub fn requires_shared_query_stage(&self) -> bool {
+        matches!(self.score_matmul, AttentionTileMatmul::Cmma(_))
+    }
+
     /// Workspace kind for the softmax round-trip, chosen by the score matmul
     /// variant.
     pub fn softmax_kind(&self) -> SoftmaxKind {


### PR DESCRIPTION
## Problem

`QueryReader` materialized strided/permuted query tiles in a thread-local
`Array`. That works for the register attention path, but CUDA WMMA loads only
accept global or shared memory. For the accelerated path, CubeCL therefore
emitted a trap-only kernel (`cannot perform wmma load or store on local
memory`). Reading directly from a contiguous pointer is not correct either:
query views can be permuted and the final sequence tile can overhang `seq_q`.

## Fix

- Cooperatively stage CMMA/WMMA query tiles into a per-plane shared-memory
  slot using the view's checked reads, preserving real strides and zero-filled
  tail behavior.
- Synchronize each plane before the WMMA copy and before reusing its slot.
- Keep the existing thread-local staging path for register attention.
- Carry the query vector width through the stage configuration so shared
  allocation is exact.

## Validation

- CubeK black-box accelerated-attention tests pass on an NVIDIA A100-SXM4.
- Compute Sanitizer memcheck reports no invalid accesses on the accelerated
  path, including non-divisible sequence tails.
- Hermes CUDA attention forward/backward tests and a sequence-length 4096
  training smoke pass with this revision pinned.
