### PR TITLE
bench(reduce): make the reduce benchmarks measurable

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -45,15 +45,36 @@ pub fn all() -> &'static [&'static dyn BenchmarkCategory] {
 /// Loop over every (strategy, problem) for `category`, run each at 10 samples,
 /// and print the resulting durations using the category's preferred
 /// [`cubecl::benchmark::TimingMethod`]. Used by `benches/*.rs` via [`run_bench!`].
+///
+/// Three env vars narrow or lengthen a run, which matters on a GPU whose clocks
+/// idle low (a desktop card at 210MHz of a 3150MHz max, say): a handful of short
+/// samples then gets measured while the clocks are still ramping, and identical
+/// kernels can differ by the ratio of those two clocks. Isolating one case and
+/// raising the sample count is the difference between a usable number and noise.
+///
+/// * `CUBEK_BENCH_PROBLEM`  — substring; keep only matching problem ids
+/// * `CUBEK_BENCH_STRATEGY` — substring; keep only matching strategy ids
+/// * `CUBEK_BENCH_SAMPLES`  — sample count (default 10)
 pub fn run_category(category: &dyn BenchmarkCategory) {
     use cubecl::benchmark::BenchmarkDurations;
 
-    const SAMPLES: usize = 10;
+    let problem_filter = std::env::var("CUBEK_BENCH_PROBLEM").unwrap_or_default();
+    let strategy_filter = std::env::var("CUBEK_BENCH_STRATEGY").unwrap_or_default();
+    let samples: usize = std::env::var("CUBEK_BENCH_SAMPLES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
 
     for problem in category.problems() {
+        if !problem.id.contains(&problem_filter) {
+            continue;
+        }
         for strategy in category.strategies() {
+            if !strategy.id.contains(&strategy_filter) {
+                continue;
+            }
             println!("---- {} / {} ----", strategy.label, problem.label);
-            match category.run(&strategy.id, &problem.id, SAMPLES) {
+            match category.run(&strategy.id, &problem.id, samples) {
                 Ok(samples) => {
                     if let Some(tflops) = samples.tflops {
                         println!("{tflops:.3} TFLOPS");

--- a/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use cubecl::{
     Runtime, TestRuntime,
-    benchmark::{Benchmark, TimingMethod},
+    benchmark::{Benchmark, ProfileDuration, TimingMethod},
     client::ComputeClient,
     future,
     prelude::*,
@@ -34,8 +34,12 @@ pub fn bench(
         _e: PhantomData,
     };
 
+    // Device timing (hardware timestamps) rather than system timing: the reduce
+    // problems are ~270 MB, and wall-clock timing of launch+sync picked up enough
+    // host-side noise that identical kernels varied by over 10x between runs,
+    // which made fused-vs-two-launch comparisons meaningless.
     let durations = bench
-        .run(TimingMethod::System)
+        .run(TimingMethod::Device)
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
@@ -95,6 +99,15 @@ impl<E: Float> Benchmark for ReduceBench<E> {
         .map_err(|err| format!("{err}"))?;
 
         Ok(())
+    }
+
+    /// Measure with device timestamps around the launch, so the reported duration
+    /// is the kernel's, not the host's view of launch+sync.
+    fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
+        self.client
+            .profile(|| self.execute(args), "reduce-bench")
+            .map(|it| it.1)
+            .map_err(|err| format!("{err:?}"))
     }
 
     fn num_samples(&self) -> usize {


### PR DESCRIPTION

## Why

The reduce benchmarks are currently not trustworthy enough to base a decision on.
Running the suite twice on the same commit, **identical kernels differed by up to 16x**,
and 18 of 48 comparable entries moved by more than 15% between runs. Some examples
(same code, two consecutive runs):

| entry | run 1 | run 2 | ratio |
|---|---|---|---|
| Cube use_planes (parallel) / TopK(1) values only | 0.953 ms | 14.479 ms | 15.2x |
| Plane independent (serial) / ArgTopK(1) | 7.141 ms | 0.487 ms | 14.7x |
| Unit (serial) / TopK(3) values only | 21.072 ms | 1.727 ms | 12.2x |

Two causes, both of which this PR addresses:

1. **System timing.** `bench()` used `TimingMethod::System`, which wall-clocks
   launch+sync on ~270 MB problems and picks up host-side noise. (Note this is true of
   the other benches too: cubecl's `Benchmark::run` only calls the `profile` override
   for `TimingMethod::Device`, so e.g. gemm's override is currently dead code — it
   passes `System`.)

2. **Samples far too short for a cold GPU.** The harness does 5 warmups and 10 samples.
   On a desktop card whose SM clock idles at **210 MHz against a 3150 MHz max**
   (persistence mode off), that is a few ms of GPU work — measured entirely while the
   clocks are still ramping. The noise is *bimodal*: an entry reads either ~415 µs or
   ~866 µs, almost exactly 2x, which is dangerously easy to mistake for a real effect.
   The ratio of those two clocks (15x) is the variance observed above.

## What

- Measure with `TimingMethod::Device` and a `profile` override using hardware timestamps
  around the launch.
- Add three env vars to `run_category` so a single case can be isolated and lengthened:
  `CUBEK_BENCH_PROBLEM`, `CUBEK_BENCH_STRATEGY`, `CUBEK_BENCH_SAMPLES` (default 10,
  unchanged).

## Result

With `CUBEK_BENCH_SAMPLES=300` the clocks reach ~2900 MHz and stay there, and repeated
runs of the same case agree to within **0.1%**:

```
Cube use_planes (serial) / TopK(3) values only    Median 415.2µs   Min 414.2µs   Max 416.3µs
```

That is also physically sensible: 268 MB / 415 µs ≈ 646 GB/s, ~96% of the card's
~672 GB/s peak — the reduce kernels are memory-bandwidth-bound, as expected.

Measured on an RTX 4070 Ti SUPER. The defaults are unchanged, so nothing regresses for
existing users of the bench; the env vars are opt-in.

## Notes

No kernel code is touched — this is bench-only. Split out of the `reduce_with_indices`
work, where these numbers were what made the perf claim there believable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
