### PR TITLE
feat(attention): emit forward LSE and harden matmul tuning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.1"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.1", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.1"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "05cac67370653ef6ed6b76730b20a0cb4bede117", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "05cac67370653ef6ed6b76730b20a0cb4bede117", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "05cac67370653ef6ed6b76730b20a0cb4bede117", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.1", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.1", default-features = false }

--- a/crates/cubek-attention/src/components/batch/base.rs
+++ b/crates/cubek-attention/src/components/batch/base.rs
@@ -40,6 +40,28 @@ pub trait BatchAttentionFamily: Send + Sync + 'static {
         attention_blueprint: Self::Blueprint,
     ) -> Result<(), LaunchError>;
 
+    /// [`Self::launch_unchecked`] with an additional flat
+    /// `[batch * heads, seq_q]` FP32 tensor receiving the per-row softmax
+    /// log-sum-exp.
+    ///
+    /// # Safety
+    ///
+    /// Out-of-bounds can happen
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn launch_unchecked_with_lse<AA: AttentionArgs, R: Runtime>(
+        client: &ComputeClient<R>,
+        cube_dim: CubeDim,
+        cube_count: CubeCount,
+        address_type: AddressType,
+        input: InputRuntimeArg<AA, R>,
+        output: OutputRuntimeArg<AA, R>,
+        lse: cubecl::prelude::TensorArg<R>,
+        cube_mapping: CubeMappingLaunch<R>,
+        dtypes: &AttentionElems,
+        vector_sizes: &AttentionVectorSizes,
+        attention_blueprint: Self::Blueprint,
+    ) -> Result<(), LaunchError>;
+
     /// Constructs the configuration based on the algorithm's blueprint.
     ///
     /// This function may return an error if the configuration cannot be supported.
@@ -61,6 +83,19 @@ pub trait BatchAttention<AP: AttentionPrecision>: 'static {
         value: VirtualTensor<VG<AP>, VGS<AP>>,
         mask: ComptimeOption<VirtualTensor<MSK<AP>, MSKS<AP>>>,
         out: VirtualTensor<OG<AP>, OGS<AP>, ReadWrite>,
+        cube_mapping: CubeMapping,
+        #[comptime] config: Self::Config,
+    );
+
+    /// [`BatchAttention::execute`] that also writes the per-row softmax
+    /// log-sum-exp into `lse` (flat `[batch * heads, seq_q]`, FP32).
+    fn execute_with_lse(
+        query: VirtualTensor<QG<AP>, QGS<AP>>,
+        key: VirtualTensor<KG<AP>, KGS<AP>>,
+        value: VirtualTensor<VG<AP>, VGS<AP>>,
+        mask: ComptimeOption<VirtualTensor<MSK<AP>, MSKS<AP>>>,
+        out: VirtualTensor<OG<AP>, OGS<AP>, ReadWrite>,
+        lse: &mut Tensor<f32>,
         cube_mapping: CubeMapping,
         #[comptime] config: Self::Config,
     );

--- a/crates/cubek-attention/src/components/batch/entry_point.rs
+++ b/crates/cubek-attention/src/components/batch/entry_point.rs
@@ -114,3 +114,105 @@ pub(crate) fn attention<
         (OG, OGS, OS, OSS),
     )>::execute(query, key, value, mask, out, cube_mapping, config);
 }
+
+#[cube(launch_unchecked, explicit_define, address_type = "dynamic")]
+/// Launches the attention kernel, also emitting the per-row softmax
+/// log-sum-exp into `lse` (flat `[batch * heads, seq_q]`, FP32).
+pub(crate) fn attention_with_lse<
+    Args: AttentionArgs,
+    QG: Float,
+    QGS: Size,
+    KG: Float,
+    KGS: Size,
+    VG: Float,
+    VGS: Size,
+    MSK: Numeric,
+    MSKS: Size,
+    OG: Float,
+    OGS: Size,
+    BMMF: BatchAttentionFamily<Blueprint = AttentionBlueprint>,
+>(
+    inputs: &Input<Args, (QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS)>,
+    output: &mut Output<Args, (OG, OGS)>,
+    lse: &mut Tensor<f32>,
+    cube_mapping: CubeMapping,
+    #[comptime] blueprint: AttentionBlueprint,
+    #[comptime] dtypes: AttentionElems,
+    #[define(QG, KG, VG, MSK, OG)] _elem_types: [StorageType; 5],
+    #[define(QGS, KGS, VGS, MSKS, OGS)] _sizes: [usize; 5],
+) {
+    let device_props = comptime::device_properties();
+    let config = comptime!(BMMF::expand_config(&device_props, blueprint, &dtypes));
+    if config.is_err() {
+        push_validation_error(config.err().unwrap().to_string());
+        comptime!(return);
+    }
+    let config = config.unwrap();
+
+    let mut state = Args::init_state(inputs, output);
+
+    let query =
+        TensorQuery::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(&state);
+    let query = VirtualTensor::<QG, QGS>::new::<
+        TensorQuery<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+    >(query);
+
+    let key =
+        TensorKey::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(&state);
+    let key = VirtualTensor::<KG, KGS>::new::<
+        TensorKey<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+    >(key);
+
+    let value =
+        TensorValue::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(&state);
+    let value = VirtualTensor::<VG, VGS>::new::<
+        TensorValue<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+    >(value);
+
+    let has_mask = Args::has_mask(&state);
+    let mask = has_mask.map(|_| {
+        let mask = TensorMask::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(
+            &state,
+        );
+        VirtualTensor::<MSK, MSKS>::new::<
+            TensorMask<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+        >(mask)
+    });
+
+    let out = TensorOutput::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(
+        &mut state,
+    );
+    let out = VirtualTensor::<OG, OGS, ReadWrite>::new::<
+        TensorOutput<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+    >(out);
+
+    let stage_config = config.global_config().stage_config();
+    let key_stage = stage_config.key_smem_config();
+    let value_stage = stage_config.value_smem_config();
+    let out_stage = stage_config.out_smem_config();
+
+    let define!(QT) = dtypes.query_tile;
+    let define!(KS) = key_stage.dtype;
+    let size!(KSS) = key_stage.vector_size as usize;
+    let define!(VS) = value_stage.dtype;
+    let size!(VSS) = value_stage.vector_size as usize;
+    let define!(KVT) = dtypes.key_value_tile;
+    let define!(SM) = dtypes.softmax_acc;
+    let define!(SML) = dtypes.softmax_lhs;
+    let define!(ACC) = dtypes.accumulator;
+    let define!(OS) = out_stage.dtype;
+    let size!(OSS) = out_stage.vector_size as usize;
+
+    BMMF::Attention::<(
+        (QG, QGS, QT),
+        (KG, KGS, KS, KSS),
+        (VG, VGS, VS, VSS),
+        KVT,
+        SM,
+        SML,
+        ACC,
+        MSK,
+        MSKS,
+        (OG, OGS, OS, OSS),
+    )>::execute_with_lse(query, key, value, mask, out, lse, cube_mapping, config);
+}

--- a/crates/cubek-attention/src/components/batch/simple/attention.rs
+++ b/crates/cubek-attention/src/components/batch/simple/attention.rs
@@ -67,4 +67,53 @@ impl<GA: GlobalAttention<AP>, AP: AttentionPrecision> BatchAttention<AP>
             config.global_config(),
         )
     }
+
+    fn execute_with_lse(
+        query: VirtualTensor<QG<AP>, QGS<AP>>,
+        key: VirtualTensor<KG<AP>, KGS<AP>>,
+        value: VirtualTensor<VG<AP>, VGS<AP>>,
+        mask: ComptimeOption<VirtualTensor<MSK<AP>, MSKS<AP>>>,
+        out: VirtualTensor<OG<AP>, OGS<AP>, ReadWrite>,
+        lse: &mut Tensor<f32>,
+        cube_mapping: CubeMapping,
+        #[comptime] config: Self::Config,
+    ) {
+        #[allow(clippy::collapsible_if)]
+        if cube_mapping.can_yield_extra_cubes {
+            if CUBE_POS >= cube_mapping.num_valid_cubes() {
+                terminate!();
+            }
+        }
+
+        let global_config = config.global_config();
+        let (q_index, batch_index) = cube_pos_to_q_batch_heads(&cube_mapping);
+
+        let stage_q_offset = q_index * global_config.stage_config().elements_in_stage_seq_q();
+
+        // Assume [batch, num_heads, seq_*, head_dim] layout
+        let seq_q = query.shape(2) as u32;
+        let seq_kv = key.shape(2) as u32;
+        let num_heads = query.shape(1) as u32;
+
+        GA::execute_with_lse(
+            GA::init_query_reader(batch_index, num_heads, stage_q_offset, query, global_config),
+            GA::init_key_reader(batch_index, num_heads, key, global_config),
+            GA::init_value_reader(batch_index, num_heads, value, global_config),
+            GA::init_mask_reader(
+                batch_index,
+                num_heads,
+                stage_q_offset,
+                mask,
+                seq_kv,
+                global_config,
+            ),
+            GA::init_writer(batch_index, num_heads, stage_q_offset, out, global_config),
+            lse,
+            batch_index,
+            stage_q_offset,
+            seq_q,
+            seq_kv,
+            config.global_config(),
+        )
+    }
 }

--- a/crates/cubek-attention/src/components/batch/simple/setup.rs
+++ b/crates/cubek-attention/src/components/batch/simple/setup.rs
@@ -9,7 +9,7 @@ use crate::{
     components::{
         batch::{
             BatchAttentionFamily,
-            entry_point::attention,
+            entry_point::{attention, attention_with_lse},
             simple::{SimpleBatchAttention, config::SimpleBatchConfig},
         },
         global::GlobalAttentionFamily,
@@ -51,6 +51,53 @@ impl<GA: GlobalAttentionFamily> BatchAttentionFamily for SimpleBatchAttentionFam
                 address_type,
                 input,
                 output,
+                cube_mapping,
+                blueprint,
+                dtypes.clone(),
+                dtypes.into(),
+                vector_sizes.into(),
+            )
+        };
+
+        Ok(())
+    }
+
+    unsafe fn launch_unchecked_with_lse<AA: AttentionArgs, R: cubecl::Runtime>(
+        client: &cubecl::prelude::ComputeClient<R>,
+        cube_dim: cubecl::CubeDim,
+        cube_count: cubecl::CubeCount,
+        address_type: AddressType,
+        input: InputRuntimeArg<AA, R>,
+        output: OutputRuntimeArg<AA, R>,
+        lse: cubecl::prelude::TensorArg<R>,
+        cube_mapping: CubeMappingLaunch<R>,
+        dtypes: &AttentionElems,
+        vector_sizes: &AttentionVectorSizes,
+        blueprint: Self::Blueprint,
+    ) -> Result<(), LaunchError> {
+        unsafe {
+            attention_with_lse::launch_unchecked::<
+                AA,
+                QG,
+                QGS,
+                KG,
+                KGS,
+                VG,
+                VGS,
+                MSK,
+                MSKS,
+                OG,
+                OGS,
+                Self,
+                R,
+            >(
+                client,
+                cube_count,
+                cube_dim,
+                address_type,
+                input,
+                output,
+                lse,
                 cube_mapping,
                 blueprint,
                 dtypes.clone(),

--- a/crates/cubek-attention/src/components/global/base.rs
+++ b/crates/cubek-attention/src/components/global/base.rs
@@ -59,6 +59,24 @@ pub trait GlobalAttention<AP: AttentionPrecision>: 'static {
         #[comptime] config: Self::Config,
     );
 
+    /// [`GlobalAttention::execute`] that also writes the per-row softmax
+    /// log-sum-exp into `lse` (flat `[batch * heads, seq_q]`, FP32) for a
+    /// training backward pass.
+    #[allow(clippy::too_many_arguments)]
+    fn execute_with_lse(
+        query_reader: QueryReader<AP>,
+        key_reader: Self::KeyReader,
+        value_reader: Self::ValueReader,
+        mask_reader: Self::MaskReader,
+        writer: Self::Writer<'_>,
+        lse: &mut Tensor<f32>,
+        batch_index: u32,
+        stage_q_offset: u32,
+        seq_q: u32,
+        seq_kv: u32,
+        #[comptime] config: Self::Config,
+    );
+
     // `batch_index` flattens the query's `(batch, head)`; every reader resolves
     // it with the query's `num_heads`, never its own tensor's head extent.
 

--- a/crates/cubek-attention/src/components/global/simple/attention.rs
+++ b/crates/cubek-attention/src/components/global/simple/attention.rs
@@ -135,6 +135,91 @@ impl<
         )
     }
 
+    fn execute_with_lse(
+        query_reader: QueryReader<AP>,
+        mut key_reader: Self::KeyReader,
+        mut value_reader: Self::ValueReader,
+        mut mask_reader: Self::MaskReader,
+        mut writer: Self::Writer<'_>,
+        lse: &mut Tensor<f32>,
+        batch_index: u32,
+        stage_q_offset: u32,
+        seq_q: u32,
+        seq_kv: u32,
+        #[comptime] config: Self::Config,
+    ) {
+        let mut query_registers = SA::init_query(config.stage_config);
+        SA::read_query(&query_reader, &mut query_registers, config.stage_config);
+
+        let mut key_registers = SA::init_key(config.stage_config);
+        let mut value_registers = SA::init_value(config.stage_config);
+        let mut mask_registers = SA::init_mask(
+            ComptimeOption::new_Some((seq_q, seq_kv)),
+            config.stage_config,
+        );
+        let mut softmax_registers = SA::init_softmax(config.stage_config);
+        let mut output_registers = SA::init_output(config.stage_config);
+
+        let mut stage_state = SA::init_state(config.stage_config);
+
+        let num_stage_iterations =
+            seq_kv.div_ceil(config.stage_config.elements_in_partition_seq_kv());
+
+        let barrier = ();
+
+        for _ in 0..num_stage_iterations {
+            key_reader.load_stage(&barrier, config.key_reader_config);
+            value_reader.load_stage(&barrier, config.value_reader_config);
+
+            sync_cube();
+
+            SA::execute(
+                &query_registers,
+                &key_reader.stage(),
+                &value_reader.stage(),
+                &mut key_registers,
+                &mut value_registers,
+                &mask_reader,
+                &mut mask_registers,
+                &mut softmax_registers,
+                &mut output_registers,
+                &mut stage_state,
+                config.stage_config,
+            );
+
+            sync_cube();
+
+            key_reader.advance_view();
+            value_reader.advance_view();
+            mask_reader.advance_view();
+        }
+
+        // The final running state carries the per-row (max, sum) this
+        // partition produced; emit its log-sum-exp before the rescale
+        // consumes the state.
+        let partition_q_offset = <SA::Partitioner as AttentionPartitioner>::seq_q_index()
+            * config.stage_config.elements_in_partition_seq_q();
+        SA::write_lse(
+            &softmax_registers,
+            &stage_state,
+            lse,
+            batch_index,
+            stage_q_offset + partition_q_offset,
+            seq_q,
+            config.stage_config,
+        );
+
+        SA::rescale(&mut output_registers, stage_state, config.stage_config);
+
+        let mut out_stage = writer.stage();
+        SA::write::<Self::Writer<'_>, Self::Config>(
+            &mut output_registers,
+            &mut out_stage,
+            &mut writer,
+            config.stage_config,
+        )
+    }
+
     fn init_query_reader(
         batch_index: u32,
         num_heads: u32,

--- a/crates/cubek-attention/src/components/stage/base.rs
+++ b/crates/cubek-attention/src/components/stage/base.rs
@@ -106,6 +106,22 @@ pub trait StageAttention<AP: AttentionPrecision>: 'static {
         #[comptime] config: Self::Config,
     );
 
+    /// Writes the per-row log-sum-exp (`m + ln(l)`, natural log, exactly
+    /// `-inf` for fully-masked rows) from the final running state into a
+    /// flat `[batch * heads, seq_q]` FP32 tensor. `base_row` is the global
+    /// row of this partition's first tile row; `row_bound` bounds writes to
+    /// the valid sequence length. The softmax partition supplies the tile
+    /// layout that maps unit-local rows to absolute rows.
+    fn write_lse(
+        softmax_partition: &Self::SoftmaxPartition,
+        state: &Sequence<Self::RunningState>,
+        lse: &mut Tensor<f32>,
+        batch_index: u32,
+        base_row: u32,
+        row_bound: u32,
+        #[comptime] config: Self::Config,
+    );
+
     fn write<W: WriteEventListener, G: GlobalAttentionConfig>(
         acc: &mut Self::OutputPartition,
         stage: &mut Self::OutStage,

--- a/crates/cubek-attention/src/components/stage/partition/softmax.rs
+++ b/crates/cubek-attention/src/components/stage/partition/softmax.rs
@@ -50,6 +50,10 @@ impl<Acc: Float, Lhs: Float> SoftmaxPartition<Acc, Lhs> {
         &mut self.score_tiles[q]
     }
 
+    pub fn get_score(&self, #[comptime] q: usize) -> &Tile<Acc, Plane> {
+        &self.score_tiles[q]
+    }
+
     pub fn get_softmaxed(&mut self, #[comptime] q: usize) -> &Tile<Lhs, Plane> {
         &self.softmaxed_tiles[q]
     }

--- a/crates/cubek-attention/src/components/stage/partition_attention.rs
+++ b/crates/cubek-attention/src/components/stage/partition_attention.rs
@@ -169,6 +169,31 @@ impl<
         sequence
     }
 
+    fn write_lse(
+        softmax_partition: &Self::SoftmaxPartition,
+        state: &Sequence<Self::RunningState>,
+        lse: &mut Tensor<f32>,
+        batch_index: u32,
+        base_row: u32,
+        row_bound: u32,
+        #[comptime] config: Self::Config,
+    ) {
+        let p = config.shared().partition_size;
+        let tile_seq_q = config.tile_size().seq_q;
+        let batch_offset = batch_index as usize * lse.stride(0);
+
+        #[unroll]
+        for q in 0..p.seq_q as usize {
+            softmax_partition.get_score(q).store_row_lse(
+                &state[q],
+                lse,
+                batch_offset,
+                base_row + q as u32 * tile_seq_q,
+                row_bound,
+            );
+        }
+    }
+
     fn write<W: WriteEventListener, G: GlobalAttentionConfig>(
         acc: &mut OutputPartition<ACC<AP>>,
         stage: &mut SO,

--- a/crates/cubek-attention/src/forward/launch/base.rs
+++ b/crates/cubek-attention/src/forward/launch/base.rs
@@ -28,6 +28,43 @@ pub enum Strategy {
     Unit(BlueprintStrategy<UnitRoutine>),
 }
 
+/// [`launch_ref`] that also writes the per-row softmax log-sum-exp into
+/// `lse` (flat `[batch * heads, seq_q]`, FP32) for a training backward
+/// pass. Only the cmma (`BlackboxAccelerated`) routine emits LSE.
+#[allow(clippy::result_large_err, clippy::too_many_arguments)]
+pub fn launch_ref_with_lse<R: Runtime>(
+    strategy: Strategy,
+    client: &ComputeClient<R>,
+    query: TensorBinding<R>,
+    key: TensorBinding<R>,
+    value: TensorBinding<R>,
+    mask: Option<TensorBinding<R>>,
+    out: TensorBinding<R>,
+    lse: TensorBinding<R>,
+    attention_global_types: &AttentionGlobalTypes,
+    attention_options: AttentionOptions,
+) -> Result<(), AttentionSetupError> {
+    match strategy {
+        Strategy::BlackboxAccelerated(strategy) => {
+            launch_attention_with_lse::<R, BlackboxAcceleratedRoutine>(
+                client,
+                query,
+                key,
+                value,
+                mask,
+                out,
+                lse,
+                attention_global_types,
+                strategy,
+                attention_options,
+            )
+        }
+        Strategy::Unit(_) => Err(AttentionSetupError::InvalidConfig(Box::new(
+            "LSE emission requires the cmma (BlackboxAccelerated) attention routine".to_string(),
+        ))),
+    }
+}
+
 #[allow(clippy::result_large_err, clippy::too_many_arguments)]
 pub fn launch_ref<R: Runtime>(
     strategy: Strategy,
@@ -131,6 +168,84 @@ pub fn launch_attention<R: Runtime, A: Routine>(
                 mask.map(|it| it.into_tensor_arg()).into(),
             ),
             out.into_tensor_arg(),
+            cubek_std::cube_count::cube_mapping_launch(&launch_info.cube_count_plan),
+            &launch_info.dtypes,
+            &device_settings.vector_sizes,
+            launch_info.blueprint,
+        )
+    };
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) => Err(AttentionSetupError::Execution(err)),
+    }
+}
+
+#[allow(clippy::result_large_err, clippy::too_many_arguments)]
+pub fn launch_attention_with_lse<R: Runtime, A: Routine>(
+    client: &ComputeClient<R>,
+    query: TensorBinding<R>,
+    key: TensorBinding<R>,
+    value: TensorBinding<R>,
+    mask: Option<TensorBinding<R>>,
+    out: TensorBinding<R>,
+    lse: TensorBinding<R>,
+    global_dtypes: &AttentionGlobalTypes,
+    strategy: BlueprintStrategy<A>,
+    attention_options: AttentionOptions,
+) -> Result<(), AttentionSetupError> {
+    let definition = AttentionProblem {
+        dims: AttentionDims {
+            batch: query.shape[0],
+            num_heads: query.shape[1],
+            seq_q: query.shape[2],
+            head_dim: query.shape[3],
+            seq_kv: key.shape[2],
+            val_dim: value.shape[3],
+        },
+        masked: mask.is_some(),
+        global_dtypes: global_dtypes.clone(),
+        options: attention_options,
+        address_type: [
+            query.required_address_type(global_dtypes.query.size()),
+            key.required_address_type(global_dtypes.key.size()),
+            value.required_address_type(global_dtypes.value.size()),
+            mask.as_ref()
+                .map(|mask| mask.required_address_type(global_dtypes.mask.size()))
+                .unwrap_or_default(),
+            out.required_address_type(global_dtypes.out.size()),
+        ]
+        .into_iter()
+        .max()
+        .unwrap_or_default(),
+    };
+
+    let device_settings = DeviceSettings::new(client, &definition);
+
+    let launch_info = A::prepare(&definition, &device_settings, strategy)?;
+
+    // This allows an expand_config error to be caught by the client rather than the server.
+    // Then the server can re-run expand config assuming a valid blueprint
+    <A as Routine>::BatchAttention::expand_config(
+        client.properties(),
+        launch_info.blueprint.clone(),
+        &launch_info.dtypes,
+    )?;
+
+    let result = unsafe {
+        <A as Routine>::BatchAttention::launch_unchecked_with_lse::<TensorArgs, R>(
+            client,
+            launch_info.cube_dim,
+            launch_info.cube_count_plan.resolve(),
+            launch_info.address_type,
+            TensorInputsLaunch::new(
+                query.into_tensor_arg(),
+                key.into_tensor_arg(),
+                value.into_tensor_arg(),
+                mask.map(|it| it.into_tensor_arg()).into(),
+            ),
+            out.into_tensor_arg(),
+            lse.into_tensor_arg(),
             cubek_std::cube_count::cube_mapping_launch(&launch_info.cube_count_plan),
             &launch_info.dtypes,
             &device_settings.vector_sizes,

--- a/crates/cubek-attention/tests/attention/forward/lse.rs
+++ b/crates/cubek-attention/tests/attention/forward/lse.rs
@@ -1,17 +1,22 @@
-//! LSE oracle tier: host-only checks of the CPU reference's `lse = m + ln(l)`
-//! output against a direct (non-online) logsumexp. No kernel emits lse yet;
-//! these pin the convention the tile port's epilogue will be tested against:
-//! natural log, and exactly `-inf` on fully-masked rows (matching the
-//! backward reference).
+//! LSE checks for the CPU oracle and the accelerated forward kernel. The
+//! convention is natural log, with exactly `-inf` on fully-masked rows.
 
+use cubecl::client::ComputeClient;
 use cubecl::frontend::CubePrimitive;
 use cubecl::ir::AddressType;
 use cubecl::zspace::Shape;
+use cubecl::{Runtime, TestRuntime};
 use cubek_attention::eval::forward::cpu_reference::flash_attention_v2_reference_with_lse;
 use cubek_attention::forward::definition::{
-    AccumulatorPrecision, AttentionDims, AttentionGlobalTypes, AttentionOptions, AttentionProblem,
+    AccumulatorPrecision, AttentionDims, AttentionGlobalTypes, AttentionIdent, AttentionOptions,
+    AttentionProblem,
 };
-use cubek_test_utils::{HostData, HostDataVec, StridedLayout};
+use cubek_attention::forward::launch::{BlueprintStrategy, Strategy, launch_ref_with_lse};
+use cubek_attention::forward::routines::blackbox_accelerated::BlackboxAcceleratedStrategy;
+use cubek_test_utils::{
+    ExecutionOutcome, HostData, HostDataType, HostDataVec, StridedLayout, TestInput, TestOutcome,
+    launch_and_capture_outcome,
+};
 
 fn host_f32(shape: [usize; 4], f: impl Fn(usize) -> f32) -> HostData {
     let shape = Shape::new(shape);
@@ -171,4 +176,104 @@ fn lse_matches_direct_logsumexp_causal() {
             "lse mismatch at row {i}: online {got} vs direct {expected}"
         );
     }
+}
+
+#[test]
+fn accelerated_forward_emits_reference_lse() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let global_dtypes = AttentionGlobalTypes::from_single_float_dtype(
+        half::f16::as_type_native_unchecked(),
+        AttentionGlobalTypes::mask_dtype(&client),
+    );
+    let problem = problem((1, 2, 64, 64, 64, 64), true, false);
+    let problem = AttentionProblem {
+        global_dtypes,
+        ..problem
+    };
+
+    let (query, query_data) = test_input(&client, &problem, AttentionIdent::Query, 11);
+    let (key, key_data) = test_input(&client, &problem, AttentionIdent::Key, 22);
+    let (value, value_data) = test_input(&client, &problem, AttentionIdent::Value, 33);
+    let out = TestInput::builder(
+        client.clone(),
+        Shape::new(problem.shape(AttentionIdent::Out)),
+    )
+    .dtype(problem.global_dtypes.out)
+    .zeros()
+    .generate_without_host_data();
+    let lse = TestInput::builder(
+        client.clone(),
+        Shape::new([
+            problem.dims.batch * problem.dims.num_heads,
+            problem.dims.seq_q,
+        ]),
+    )
+    .dtype(f32::as_type_native_unchecked().storage_type())
+    .zeros()
+    .generate_without_host_data();
+
+    let strategy =
+        Strategy::BlackboxAccelerated(BlueprintStrategy::Inferred(BlackboxAcceleratedStrategy {
+            num_planes: 1,
+            seq_q: 1,
+            seq_kv: 1,
+        }));
+    let outcome = launch_and_capture_outcome(&client, |client| {
+        launch_ref_with_lse(
+            strategy,
+            client,
+            query.binding(),
+            key.binding(),
+            value.binding(),
+            None,
+            out.binding(),
+            lse.clone().binding(),
+            &problem.global_dtypes,
+            problem.options.clone(),
+        )
+        .into()
+    });
+
+    match outcome {
+        ExecutionOutcome::CompileError(error) => TestOutcome::CompileError(error).enforce(),
+        ExecutionOutcome::Executed => {
+            let (_, expected) = flash_attention_v2_reference_with_lse(
+                &query_data,
+                &key_data,
+                &value_data,
+                None,
+                &problem,
+                None,
+            );
+            let actual = HostData::from_tensor_handle(&client, lse, HostDataType::F32);
+            for head in 0..problem.dims.num_heads {
+                for row in 0..problem.dims.seq_q {
+                    let got = actual.get_f32(&[head, row]);
+                    let want = expected.get_f32(&[0, head, row]);
+                    assert!(
+                        (got - want).abs() <= 2e-2 * want.abs().max(1.0),
+                        "LSE mismatch at head {head}, row {row}: {got} vs {want}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn test_input(
+    client: &ComputeClient<TestRuntime>,
+    problem: &AttentionProblem,
+    ident: AttentionIdent,
+    seed: u64,
+) -> (cubecl::std::tensor::TensorHandle<TestRuntime>, HostData) {
+    let dtype = match ident {
+        AttentionIdent::Query => problem.global_dtypes.query,
+        AttentionIdent::Key => problem.global_dtypes.key,
+        AttentionIdent::Value => problem.global_dtypes.value,
+        _ => panic!("test_input only builds query, key, and value tensors"),
+    };
+    TestInput::builder(client.clone(), Shape::new(problem.shape(ident)))
+        .dtype(dtype)
+        .uniform(seed, -1.0, 1.0)
+        .generate_with_f32_host_data()
 }

--- a/crates/cubek-matmul/src/strategy/tune_key.rs
+++ b/crates/cubek-matmul/src/strategy/tune_key.rs
@@ -18,9 +18,8 @@ pub struct MatmulAutotuneKey {
     pub analysis: MatmulAutotuneAnalysis,
 }
 
-/// Maximum factor relevant for strides. Currently set to 2^10 because that's 128-byte swizzle's
-/// repeat number, so it's the largest align that can have performance impacts.
-const MAX_STRIDE_FACTOR: u32 = 10;
+/// Minimum byte-alignment factor required by async-copy and TMA readers.
+const ASYNC_COPY_STRIDE_FACTOR: u32 = 4;
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
 pub struct MatmulProblemDefinition {
@@ -31,10 +30,12 @@ pub struct MatmulProblemDefinition {
     #[autotune(anchor)]
     pub k: usize,
     pub lhs_pow2_factor: u8,
-    /// Power of two that lhs strides are aligned to
+    /// Async-copy alignment class for lhs strides: `4` when all relevant
+    /// strides are 16-byte aligned, `0` otherwise.
     pub lhs_stride_factor: u8,
     pub rhs_pow2_factor: u8,
-    /// Power of two that rhs strides are aligned to
+    /// Async-copy alignment class for rhs strides: `4` when all relevant
+    /// strides are 16-byte aligned, `0` otherwise.
     pub rhs_stride_factor: u8,
     pub elem_lhs: StorageType,
     pub elem_rhs: StorageType,
@@ -135,16 +136,10 @@ impl MatmulAutotuneKey {
             k: k as u32,
         });
 
-        // The alignment factors below are computed from the *anchored* dims —
-        // the same bucketing the `m`/`n`/`k` fields get — never from the raw
-        // values. A dimension carrying a runtime-dependent length (a KV-cache
-        // width, a dynamic batch) would otherwise re-split every anchored
-        // bucket into one key per pow2-alignment class of the raw value, and
-        // the tuner would keep minting "new" problems the anchor deliberately
-        // treats as equal. The trade-off matches the anchor's: the whole
-        // bucket shares the kernel choice benchmarked on one representative,
-        // and the launch still derives the legal line size from the real
-        // tensors.
+        // Vectorization factors are computed from the anchored dims so a
+        // runtime-dependent length doesn't mint a key for every raw alignment
+        // inside one shape bucket. Kernel launches still derive their legal
+        // line sizes from the real tensors.
         let m_anchored = anchor(m, None, None, None);
         let n_anchored = anchor(n, None, None, None);
         let k_anchored = anchor(k, None, None, None);
@@ -166,26 +161,32 @@ impl MatmulAutotuneKey {
             MatrixBatchLayout::HighlyPermuted => 0,
         };
 
-        // The canonical tightest non-contiguous stride of each layout: the
-        // row stride — `cols` for a contiguous `[.., rows, cols]`, `rows` for
-        // its transposed view. Batch strides are products of these, so their
-        // alignment can only be higher.
+        // Async-copy and TMA candidates require every non-contiguous stride to
+        // be 16-byte aligned. This legality bit must come from the real
+        // strides: an anchored shape bucket can contain both aligned and
+        // unaligned tensors, and sharing a cached async-copy winner across
+        // those tensors would make the latter fail at launch. Collapsing the
+        // value to two classes preserves bounded key cardinality.
         let lhs_stride_factor = match matrix_layout_lhs {
-            MatrixBatchLayout::Contiguous => stride_factor(k_anchored, elem_lhs),
+            MatrixBatchLayout::Contiguous => {
+                async_copy_stride_factor(lhs_strides, ndims - 1, elem_lhs)
+            }
             // TMA can't handle discontiguous batches because they're all combined into one dim
             MatrixBatchLayout::MildlyPermuted {
                 transposed: true,
                 batch_swap: false,
-            } => stride_factor(m_anchored, elem_lhs),
+            } => async_copy_stride_factor(lhs_strides, ndims - 2, elem_lhs),
             _ => 0,
         };
         let rhs_stride_factor = match matrix_layout_rhs {
-            MatrixBatchLayout::Contiguous => stride_factor(n_anchored, elem_rhs),
+            MatrixBatchLayout::Contiguous => {
+                async_copy_stride_factor(rhs_strides, ndims - 1, elem_rhs)
+            }
             // TMA can't handle discontiguous batches because they're all combined into one dim
             MatrixBatchLayout::MildlyPermuted {
                 transposed: true,
                 batch_swap: false,
-            } => stride_factor(k_anchored, elem_rhs),
+            } => async_copy_stride_factor(rhs_strides, ndims - 2, elem_rhs),
             _ => 0,
         };
 
@@ -212,11 +213,23 @@ impl MatmulAutotuneKey {
     }
 }
 
-/// Stride alignment (in powers of two of bytes) of the canonical row stride
-/// `cols` — the tightest non-contiguous stride of the layout.
-fn stride_factor(cols: usize, elem: StorageType) -> u8 {
-    let bytes = (cols * elem.size_bits()) / 8;
-    bytes.trailing_zeros().min(MAX_STRIDE_FACTOR) as u8
+/// Classifies whether every non-contiguous stride meets the 16-byte alignment
+/// requirement shared by async-copy and TMA readers.
+fn async_copy_stride_factor(strides: &[usize], exclude_dim: usize, elem: StorageType) -> u8 {
+    let factor = strides
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != exclude_dim)
+        .map(|(_, stride)| (*stride * elem.size_bits()) / 8)
+        .map(|bytes| bytes.trailing_zeros())
+        .min()
+        .unwrap_or(ASYNC_COPY_STRIDE_FACTOR);
+
+    if factor >= ASYNC_COPY_STRIDE_FACTOR {
+        ASYNC_COPY_STRIDE_FACTOR as u8
+    } else {
+        0
+    }
 }
 
 /// Defines the potential vectorization.
@@ -251,18 +264,24 @@ mod tests {
         )
     }
 
-    /// Every raw length inside one anchored bucket must produce the same key:
-    /// a runtime-dependent dimension (a KV-cache width) may take any integer
-    /// value, and re-splitting the bucket by the raw value's alignment retunes
-    /// endlessly for problems the anchor treats as equal.
+    /// Raw lengths in one anchored bucket share a key when their async-copy
+    /// legality is the same, but aligned and unaligned tensors never do.
     #[test]
-    fn raw_lengths_within_a_bucket_share_one_key() {
-        // 65..=128 all anchor to the 128 bucket, at every alignment class:
-        // odd, 2-, 4-, 8-, 16-aligned, and the exact power of two.
+    fn bucket_is_split_only_by_async_copy_legality() {
         let reference = key(64, 69, 64);
-        for kv in [70, 76, 88, 96, 112, 128] {
-            assert_eq!(reference, key(64, kv, 64), "kv {kv} split the bucket");
+        for kv in [70, 74, 78] {
+            assert_eq!(
+                reference,
+                key(64, kv, 64),
+                "unaligned kv {kv} split the bucket"
+            );
         }
+
+        let aligned = key(64, 68, 64);
+        for kv in [72, 76, 80, 96, 112, 128] {
+            assert_eq!(aligned, key(64, kv, 64), "aligned kv {kv} split the bucket");
+        }
+        assert_ne!(reference, aligned);
     }
 
     /// Distinct anchored buckets still get distinct keys.
@@ -272,12 +291,10 @@ mod tests {
         assert_ne!(key(64, 128, 64), key(1, 128, 64));
     }
 
-    /// The transposed (`MildlyPermuted`) arm: a column-major LHS takes its alignment
-    /// factors from `m` (the row count) rather than `k`, so raw `m` lengths inside one
-    /// anchored bucket must share a key just as the contiguous `kv` case does. The
-    /// [`key`] helper above is all-contiguous, so it never reaches this branch.
+    /// The transposed (`MildlyPermuted`) arm derives legality from the real
+    /// column-major LHS strides as well.
     #[test]
-    fn transposed_lhs_shares_bucket_key() {
+    fn transposed_lhs_is_split_only_by_async_copy_legality() {
         // Column-major lhs `[b, m, k]`: `m` has stride 1, `k` has stride `m`, so
         // `row_stride < col_stride` and the layout is `MildlyPermuted { transposed }`.
         let key_t = |m: usize| {
@@ -294,10 +311,15 @@ mod tests {
                 None,
             )
         };
-        // 65..=128 all anchor to the 128 bucket, at every alignment class.
         let reference = key_t(69);
-        for m in [70, 76, 88, 96, 112, 128] {
-            assert_eq!(reference, key_t(m), "m {m} split the transposed bucket");
+        for m in [70, 74, 78] {
+            assert_eq!(reference, key_t(m), "unaligned m {m} split the bucket");
         }
+
+        let aligned = key_t(68);
+        for m in [72, 76, 80, 96, 112, 128] {
+            assert_eq!(aligned, key_t(m), "aligned m {m} split the bucket");
+        }
+        assert_ne!(reference, aligned);
     }
 }

--- a/crates/cubek-std/src/tile/ops/rowwise.rs
+++ b/crates/cubek-std/src/tile/ops/rowwise.rs
@@ -24,6 +24,29 @@ impl<E: Float> Tile<E, Plane> {
         }
     }
 
+    /// Writes the per-row softmax log-sum-exp `m + ln(l)` for this tile's
+    /// absolute rows into `lse[batch_offset + base_row + row]`, skipping rows
+    /// at or past `row_bound`. Rows whose running sum is below the
+    /// fully-masked threshold receive exactly `-inf` (natural log
+    /// convention). Only the `Bounce` (cmma) variant carries the fragment
+    /// layout that maps unit-local rows to absolute rows.
+    pub fn store_row_lse(
+        &self,
+        state: &(RowWise<E>, RowWise<E>),
+        lse: &mut Tensor<f32>,
+        batch_offset: usize,
+        base_row: u32,
+        row_bound: u32,
+    ) {
+        match &self.kind {
+            TileKind::Unit(_t) => panic!("store_row_lse: unsupported tile variant"),
+            TileKind::WhiteboxFragment(_t) => panic!("store_row_lse: unsupported tile variant"),
+            TileKind::Bounce(b) => b.store_row_lse(state, lse, batch_offset, base_row, row_bound),
+            TileKind::Register(_t) => panic!("store_row_lse: unsupported tile variant"),
+            _ => panic!("store_row_lse: only the cmma (Bounce) softmax path emits LSE"),
+        }
+    }
+
     pub fn exp_diff(&mut self, rowwise: &RowWise<E>) {
         match &mut self.kind {
             TileKind::Unit(t) => t.exp_diff(rowwise),

--- a/crates/cubek-std/src/tile/variants/bounce.rs
+++ b/crates/cubek-std/src/tile/variants/bounce.rs
@@ -2,13 +2,16 @@ use cubecl;
 use cubecl::prelude::*;
 
 use crate::StageIdent;
+use crate::tile::FULLY_MASKED_ROW_THRESHOLD;
 use crate::tile::{
     Plane, RowWise, Tile, TileKind, TileKindExpand,
     mask::Mask,
     scope::{TileScope, assert_plane_scope},
     variants::{
         instruction::cmma::CmmaTile,
-        whitebox_fragment::{InnerLayout, WhiteboxFragment, WhiteboxFragmentLayout},
+        whitebox_fragment::{
+            InnerLayout, WhiteboxFragment, WhiteboxFragmentLayout, whitebox_fragment_absolute_pos,
+        },
     },
 };
 
@@ -215,5 +218,39 @@ impl<Acc: Float> BounceTile<Acc> {
         RowWise::copy_from(&mut state.1, &new_l);
 
         exp_m_diff
+    }
+
+    /// Writes the per-row softmax log-sum-exp `m + ln(l)` into
+    /// `lse[batch_offset + base_row + row]` for the absolute rows this
+    /// unit owns, bounded by `row_bound`. The cross-plane row reductions
+    /// leave every unit sharing a row with identical state, so only the
+    /// unit owning the row's first column writes. Rows whose running sum
+    /// is below the fully-masked threshold receive exactly `-inf`.
+    pub fn store_row_lse(
+        &self,
+        state: &(RowWise<Acc>, RowWise<Acc>),
+        lse: &mut Tensor<f32>,
+        batch_offset: usize,
+        base_row: u32,
+        row_bound: u32,
+    ) {
+        let layout = comptime!(self.fragment.layout);
+        let threshold = Acc::new(FULLY_MASKED_ROW_THRESHOLD);
+
+        for r in 0..layout.unit_size.0 {
+            let (abs_row, abs_col) = whitebox_fragment_absolute_pos(layout, (r, 0u32));
+            if abs_col == 0 {
+                let row = base_row + abs_row;
+                if row < row_bound {
+                    let m = state.0.vals[r as usize];
+                    let l = state.1.vals[r as usize];
+                    let mut value = f32::cast_from(f32::NEG_INFINITY);
+                    if l >= threshold {
+                        value = f32::cast_from(m) + f32::cast_from(l).ln();
+                    }
+                    lse[batch_offset + row as usize] = value;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add an opt-in accelerated attention launch that emits per-row softmax log-sum-exp alongside the existing output
- thread the FP32 LSE tensor through the batch, global, stage, and Bounce tile layers without changing existing launch signatures
- extend the existing LSE oracle with an accelerated-kernel comparison
- prevent matmul autotune keys from sharing an async-copy winner between aligned and unaligned tensors in the same anchored shape bucket
- pin the consolidated CubeCL accelerator PR for downstream compatibility validation

This PR absorbs the temporary compatibility-only draft #429 so CubeK has one upstream review thread.

The LSE output is flat `[batch * heads, seq_q]`, uses natural log, and writes negative infinity for fully masked rows. Existing `launch_ref` and component signatures retain their behavior.

The matmul key keeps anchored M/N/K buckets and bounded cardinality. It adds only two stride-legality classes per operand: 16-byte aligned or not aligned. This prevents a cached async-copy/TMA candidate from failing when a later raw shape in the same bucket has incompatible strides.

## Dependency validation

- [x] CubeCL dependency: tracel-ai/cubecl#1440.
- [x] Burn PR tracel-ai/burn#5190 pins this PR head and the CubeCL PR head.
- [x] Upstream `main` is the direct base of this branch.
- [x] Cargo manifests reference only `tracel-ai/*` repositories.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p cubek-matmul strategy::tune_key --lib`
- `cargo check -p cubek-attention`
- `cargo test -p cubek-attention --no-run`
- A100 attention CPU-reference parity and end-to-end BF16 loss/gradient checks
- A100 299.9M-parameter MoE training smoke: five optimizer steps completed after reproducing the former invalid async-copy autotune selection

The current Linux CI failure occurred in runner setup: Microsoft's Ubuntu apt repositories returned HTTP 403 before checkout/build tests began. Code-quality and documentation jobs passed.
