### PR TITLE
chore: validate CubeCL accelerated GEMM branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ version = "0.3.0-pre.1"
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "0a62060a2c7a66c94f717d7cac0be0dc259bb607", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "0a62060a2c7a66c94f717d7cac0be0dc259bb607", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "460652cc9bb3a833332d6e9e58c40391a2236314", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "460652cc9bb3a833332d6e9e58c40391a2236314", default-features = false }
 ### For releases ###
 # cubecl = { version = "0.10.0", default-features = false }
 # cubecl-common = { version = "0.10.0", default-features = false }

--- a/crates/cubek-attention/src/components/batch/base.rs
+++ b/crates/cubek-attention/src/components/batch/base.rs
@@ -40,6 +40,28 @@ pub trait BatchAttentionFamily: Send + Sync + 'static {
         attention_blueprint: Self::Blueprint,
     ) -> Result<(), LaunchError>;
 
+    /// [`Self::launch_unchecked`] with an additional flat
+    /// `[batch * heads, seq_q]` FP32 tensor receiving the per-row softmax
+    /// log-sum-exp.
+    ///
+    /// # Safety
+    ///
+    /// Out-of-bounds can happen
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn launch_unchecked_with_lse<AA: AttentionArgs, R: Runtime>(
+        client: &ComputeClient<R>,
+        cube_dim: CubeDim,
+        cube_count: CubeCount,
+        address_type: AddressType,
+        input: InputRuntimeArg<AA, R>,
+        output: OutputRuntimeArg<AA, R>,
+        lse: cubecl::prelude::TensorArg<R>,
+        cube_mapping: CubeMappingLaunch<R>,
+        dtypes: &AttentionElems,
+        vector_sizes: &AttentionVectorSizes,
+        attention_blueprint: Self::Blueprint,
+    ) -> Result<(), LaunchError>;
+
     /// Constructs the configuration based on the algorithm's blueprint.
     ///
     /// This function may return an error if the configuration cannot be supported.
@@ -61,6 +83,19 @@ pub trait BatchAttention<AP: AttentionPrecision>: 'static {
         value: VirtualTensor<VG<AP>, VGS<AP>>,
         mask: ComptimeOption<VirtualTensor<MSK<AP>, MSKS<AP>>>,
         out: VirtualTensor<OG<AP>, OGS<AP>, ReadWrite>,
+        cube_mapping: CubeMapping,
+        #[comptime] config: Self::Config,
+    );
+
+    /// [`BatchAttention::execute`] that also writes the per-row softmax
+    /// log-sum-exp into `lse` (flat `[batch * heads, seq_q]`, FP32).
+    fn execute_with_lse(
+        query: VirtualTensor<QG<AP>, QGS<AP>>,
+        key: VirtualTensor<KG<AP>, KGS<AP>>,
+        value: VirtualTensor<VG<AP>, VGS<AP>>,
+        mask: ComptimeOption<VirtualTensor<MSK<AP>, MSKS<AP>>>,
+        out: VirtualTensor<OG<AP>, OGS<AP>, ReadWrite>,
+        lse: &mut Tensor<f32>,
         cube_mapping: CubeMapping,
         #[comptime] config: Self::Config,
     );

--- a/crates/cubek-attention/src/components/batch/entry_point.rs
+++ b/crates/cubek-attention/src/components/batch/entry_point.rs
@@ -114,3 +114,105 @@ pub(crate) fn attention<
         (OG, OGS, OS, OSS),
     )>::execute(query, key, value, mask, out, cube_mapping, config);
 }
+
+#[cube(launch_unchecked, explicit_define, address_type = "dynamic")]
+/// Launches the attention kernel, also emitting the per-row softmax
+/// log-sum-exp into `lse` (flat `[batch * heads, seq_q]`, FP32).
+pub(crate) fn attention_with_lse<
+    Args: AttentionArgs,
+    QG: Float,
+    QGS: Size,
+    KG: Float,
+    KGS: Size,
+    VG: Float,
+    VGS: Size,
+    MSK: Numeric,
+    MSKS: Size,
+    OG: Float,
+    OGS: Size,
+    BMMF: BatchAttentionFamily<Blueprint = AttentionBlueprint>,
+>(
+    inputs: &Input<Args, (QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS)>,
+    output: &mut Output<Args, (OG, OGS)>,
+    lse: &mut Tensor<f32>,
+    cube_mapping: CubeMapping,
+    #[comptime] blueprint: AttentionBlueprint,
+    #[comptime] dtypes: AttentionElems,
+    #[define(QG, KG, VG, MSK, OG)] _elem_types: [StorageType; 5],
+    #[define(QGS, KGS, VGS, MSKS, OGS)] _sizes: [usize; 5],
+) {
+    let device_props = comptime::device_properties();
+    let config = comptime!(BMMF::expand_config(&device_props, blueprint, &dtypes));
+    if config.is_err() {
+        push_validation_error(config.err().unwrap().to_string());
+        comptime!(return);
+    }
+    let config = config.unwrap();
+
+    let mut state = Args::init_state(inputs, output);
+
+    let query =
+        TensorQuery::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(&state);
+    let query = VirtualTensor::<QG, QGS>::new::<
+        TensorQuery<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+    >(query);
+
+    let key =
+        TensorKey::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(&state);
+    let key = VirtualTensor::<KG, KGS>::new::<
+        TensorKey<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+    >(key);
+
+    let value =
+        TensorValue::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(&state);
+    let value = VirtualTensor::<VG, VGS>::new::<
+        TensorValue<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+    >(value);
+
+    let has_mask = Args::has_mask(&state);
+    let mask = has_mask.map(|_| {
+        let mask = TensorMask::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(
+            &state,
+        );
+        VirtualTensor::<MSK, MSKS>::new::<
+            TensorMask<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+        >(mask)
+    });
+
+    let out = TensorOutput::<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>::new(
+        &mut state,
+    );
+    let out = VirtualTensor::<OG, OGS, ReadWrite>::new::<
+        TensorOutput<(QG, QGS), (KG, KGS), (VG, VGS), (MSK, MSKS), (OG, OGS), Args>,
+    >(out);
+
+    let stage_config = config.global_config().stage_config();
+    let key_stage = stage_config.key_smem_config();
+    let value_stage = stage_config.value_smem_config();
+    let out_stage = stage_config.out_smem_config();
+
+    let define!(QT) = dtypes.query_tile;
+    let define!(KS) = key_stage.dtype;
+    let size!(KSS) = key_stage.vector_size as usize;
+    let define!(VS) = value_stage.dtype;
+    let size!(VSS) = value_stage.vector_size as usize;
+    let define!(KVT) = dtypes.key_value_tile;
+    let define!(SM) = dtypes.softmax_acc;
+    let define!(SML) = dtypes.softmax_lhs;
+    let define!(ACC) = dtypes.accumulator;
+    let define!(OS) = out_stage.dtype;
+    let size!(OSS) = out_stage.vector_size as usize;
+
+    BMMF::Attention::<(
+        (QG, QGS, QT),
+        (KG, KGS, KS, KSS),
+        (VG, VGS, VS, VSS),
+        KVT,
+        SM,
+        SML,
+        ACC,
+        MSK,
+        MSKS,
+        (OG, OGS, OS, OSS),
+    )>::execute_with_lse(query, key, value, mask, out, lse, cube_mapping, config);
+}

--- a/crates/cubek-attention/src/components/batch/simple/attention.rs
+++ b/crates/cubek-attention/src/components/batch/simple/attention.rs
@@ -67,4 +67,53 @@ impl<GA: GlobalAttention<AP>, AP: AttentionPrecision> BatchAttention<AP>
             config.global_config(),
         )
     }
+
+    fn execute_with_lse(
+        query: VirtualTensor<QG<AP>, QGS<AP>>,
+        key: VirtualTensor<KG<AP>, KGS<AP>>,
+        value: VirtualTensor<VG<AP>, VGS<AP>>,
+        mask: ComptimeOption<VirtualTensor<MSK<AP>, MSKS<AP>>>,
+        out: VirtualTensor<OG<AP>, OGS<AP>, ReadWrite>,
+        lse: &mut Tensor<f32>,
+        cube_mapping: CubeMapping,
+        #[comptime] config: Self::Config,
+    ) {
+        #[allow(clippy::collapsible_if)]
+        if cube_mapping.can_yield_extra_cubes {
+            if CUBE_POS >= cube_mapping.num_valid_cubes() {
+                terminate!();
+            }
+        }
+
+        let global_config = config.global_config();
+        let (q_index, batch_index) = cube_pos_to_q_batch_heads(&cube_mapping);
+
+        let stage_q_offset = q_index * global_config.stage_config().elements_in_stage_seq_q();
+
+        // Assume [batch, num_heads, seq_*, head_dim] layout
+        let seq_q = query.shape(2) as u32;
+        let seq_kv = key.shape(2) as u32;
+        let num_heads = query.shape(1) as u32;
+
+        GA::execute_with_lse(
+            GA::init_query_reader(batch_index, num_heads, stage_q_offset, query, global_config),
+            GA::init_key_reader(batch_index, num_heads, key, global_config),
+            GA::init_value_reader(batch_index, num_heads, value, global_config),
+            GA::init_mask_reader(
+                batch_index,
+                num_heads,
+                stage_q_offset,
+                mask,
+                seq_kv,
+                global_config,
+            ),
+            GA::init_writer(batch_index, num_heads, stage_q_offset, out, global_config),
+            lse,
+            batch_index,
+            stage_q_offset,
+            seq_q,
+            seq_kv,
+            config.global_config(),
+        )
+    }
 }

--- a/crates/cubek-attention/src/components/batch/simple/setup.rs
+++ b/crates/cubek-attention/src/components/batch/simple/setup.rs
@@ -9,7 +9,7 @@ use crate::{
     components::{
         batch::{
             BatchAttentionFamily,
-            entry_point::attention,
+            entry_point::{attention, attention_with_lse},
             simple::{SimpleBatchAttention, config::SimpleBatchConfig},
         },
         global::GlobalAttentionFamily,
@@ -51,6 +51,53 @@ impl<GA: GlobalAttentionFamily> BatchAttentionFamily for SimpleBatchAttentionFam
                 address_type,
                 input,
                 output,
+                cube_mapping,
+                blueprint,
+                dtypes.clone(),
+                dtypes.into(),
+                vector_sizes.into(),
+            )
+        };
+
+        Ok(())
+    }
+
+    unsafe fn launch_unchecked_with_lse<AA: AttentionArgs, R: cubecl::Runtime>(
+        client: &cubecl::prelude::ComputeClient<R>,
+        cube_dim: cubecl::CubeDim,
+        cube_count: cubecl::CubeCount,
+        address_type: AddressType,
+        input: InputRuntimeArg<AA, R>,
+        output: OutputRuntimeArg<AA, R>,
+        lse: cubecl::prelude::TensorArg<R>,
+        cube_mapping: CubeMappingLaunch<R>,
+        dtypes: &AttentionElems,
+        vector_sizes: &AttentionVectorSizes,
+        blueprint: Self::Blueprint,
+    ) -> Result<(), LaunchError> {
+        unsafe {
+            attention_with_lse::launch_unchecked::<
+                AA,
+                QG,
+                QGS,
+                KG,
+                KGS,
+                VG,
+                VGS,
+                MSK,
+                MSKS,
+                OG,
+                OGS,
+                Self,
+                R,
+            >(
+                client,
+                cube_count,
+                cube_dim,
+                address_type,
+                input,
+                output,
+                lse,
                 cube_mapping,
                 blueprint,
                 dtypes.clone(),

--- a/crates/cubek-attention/src/components/global/base.rs
+++ b/crates/cubek-attention/src/components/global/base.rs
@@ -59,6 +59,24 @@ pub trait GlobalAttention<AP: AttentionPrecision>: 'static {
         #[comptime] config: Self::Config,
     );
 
+    /// [`GlobalAttention::execute`] that also writes the per-row softmax
+    /// log-sum-exp into `lse` (flat `[batch * heads, seq_q]`, FP32) for a
+    /// training backward pass.
+    #[allow(clippy::too_many_arguments)]
+    fn execute_with_lse(
+        query_reader: QueryReader<AP>,
+        key_reader: Self::KeyReader,
+        value_reader: Self::ValueReader,
+        mask_reader: Self::MaskReader,
+        writer: Self::Writer<'_>,
+        lse: &mut Tensor<f32>,
+        batch_index: u32,
+        stage_q_offset: u32,
+        seq_q: u32,
+        seq_kv: u32,
+        #[comptime] config: Self::Config,
+    );
+
     // `batch_index` flattens the query's `(batch, head)`; every reader resolves
     // it with the query's `num_heads`, never its own tensor's head extent.
 

--- a/crates/cubek-attention/src/components/global/simple/attention.rs
+++ b/crates/cubek-attention/src/components/global/simple/attention.rs
@@ -135,6 +135,91 @@ impl<
         )
     }
 
+    fn execute_with_lse(
+        query_reader: QueryReader<AP>,
+        mut key_reader: Self::KeyReader,
+        mut value_reader: Self::ValueReader,
+        mut mask_reader: Self::MaskReader,
+        mut writer: Self::Writer<'_>,
+        lse: &mut Tensor<f32>,
+        batch_index: u32,
+        stage_q_offset: u32,
+        seq_q: u32,
+        seq_kv: u32,
+        #[comptime] config: Self::Config,
+    ) {
+        let mut query_registers = SA::init_query(config.stage_config);
+        SA::read_query(&query_reader, &mut query_registers, config.stage_config);
+
+        let mut key_registers = SA::init_key(config.stage_config);
+        let mut value_registers = SA::init_value(config.stage_config);
+        let mut mask_registers = SA::init_mask(
+            ComptimeOption::new_Some((seq_q, seq_kv)),
+            config.stage_config,
+        );
+        let mut softmax_registers = SA::init_softmax(config.stage_config);
+        let mut output_registers = SA::init_output(config.stage_config);
+
+        let mut stage_state = SA::init_state(config.stage_config);
+
+        let num_stage_iterations =
+            seq_kv.div_ceil(config.stage_config.elements_in_partition_seq_kv());
+
+        let barrier = ();
+
+        for _ in 0..num_stage_iterations {
+            key_reader.load_stage(&barrier, config.key_reader_config);
+            value_reader.load_stage(&barrier, config.value_reader_config);
+
+            sync_cube();
+
+            SA::execute(
+                &query_registers,
+                &key_reader.stage(),
+                &value_reader.stage(),
+                &mut key_registers,
+                &mut value_registers,
+                &mask_reader,
+                &mut mask_registers,
+                &mut softmax_registers,
+                &mut output_registers,
+                &mut stage_state,
+                config.stage_config,
+            );
+
+            sync_cube();
+
+            key_reader.advance_view();
+            value_reader.advance_view();
+            mask_reader.advance_view();
+        }
+
+        // The final running state carries the per-row (max, sum) this
+        // partition produced; emit its log-sum-exp before the rescale
+        // consumes the state.
+        let partition_q_offset = <SA::Partitioner as AttentionPartitioner>::seq_q_index()
+            * config.stage_config.elements_in_partition_seq_q();
+        SA::write_lse(
+            &softmax_registers,
+            &stage_state,
+            lse,
+            batch_index,
+            stage_q_offset + partition_q_offset,
+            seq_q,
+            config.stage_config,
+        );
+
+        SA::rescale(&mut output_registers, stage_state, config.stage_config);
+
+        let mut out_stage = writer.stage();
+        SA::write::<Self::Writer<'_>, Self::Config>(
+            &mut output_registers,
+            &mut out_stage,
+            &mut writer,
+            config.stage_config,
+        )
+    }
+
     fn init_query_reader(
         batch_index: u32,
         num_heads: u32,

--- a/crates/cubek-attention/src/components/stage/base.rs
+++ b/crates/cubek-attention/src/components/stage/base.rs
@@ -106,6 +106,22 @@ pub trait StageAttention<AP: AttentionPrecision>: 'static {
         #[comptime] config: Self::Config,
     );
 
+    /// Writes the per-row log-sum-exp (`m + ln(l)`, natural log, exactly
+    /// `-inf` for fully-masked rows) from the final running state into a
+    /// flat `[batch * heads, seq_q]` FP32 tensor. `base_row` is the global
+    /// row of this partition's first tile row; `row_bound` bounds writes to
+    /// the valid sequence length. The softmax partition supplies the tile
+    /// layout that maps unit-local rows to absolute rows.
+    fn write_lse(
+        softmax_partition: &Self::SoftmaxPartition,
+        state: &Sequence<Self::RunningState>,
+        lse: &mut Tensor<f32>,
+        batch_index: u32,
+        base_row: u32,
+        row_bound: u32,
+        #[comptime] config: Self::Config,
+    );
+
     fn write<W: WriteEventListener, G: GlobalAttentionConfig>(
         acc: &mut Self::OutputPartition,
         stage: &mut Self::OutStage,

--- a/crates/cubek-attention/src/components/stage/partition/softmax.rs
+++ b/crates/cubek-attention/src/components/stage/partition/softmax.rs
@@ -50,6 +50,10 @@ impl<Acc: Float, Lhs: Float> SoftmaxPartition<Acc, Lhs> {
         &mut self.score_tiles[q]
     }
 
+    pub fn get_score(&self, #[comptime] q: usize) -> &Tile<Acc, Plane> {
+        &self.score_tiles[q]
+    }
+
     pub fn get_softmaxed(&mut self, #[comptime] q: usize) -> &Tile<Lhs, Plane> {
         &self.softmaxed_tiles[q]
     }

--- a/crates/cubek-attention/src/components/stage/partition_attention.rs
+++ b/crates/cubek-attention/src/components/stage/partition_attention.rs
@@ -169,6 +169,31 @@ impl<
         sequence
     }
 
+    fn write_lse(
+        softmax_partition: &Self::SoftmaxPartition,
+        state: &Sequence<Self::RunningState>,
+        lse: &mut Tensor<f32>,
+        batch_index: u32,
+        base_row: u32,
+        row_bound: u32,
+        #[comptime] config: Self::Config,
+    ) {
+        let p = config.shared().partition_size;
+        let tile_seq_q = config.tile_size().seq_q;
+        let batch_offset = batch_index as usize * lse.stride(0);
+
+        #[unroll]
+        for q in 0..p.seq_q as usize {
+            softmax_partition.get_score(q).store_row_lse(
+                &state[q],
+                lse,
+                batch_offset,
+                base_row + q as u32 * tile_seq_q,
+                row_bound,
+            );
+        }
+    }
+
     fn write<W: WriteEventListener, G: GlobalAttentionConfig>(
         acc: &mut OutputPartition<ACC<AP>>,
         stage: &mut SO,

--- a/crates/cubek-attention/src/forward/launch/base.rs
+++ b/crates/cubek-attention/src/forward/launch/base.rs
@@ -28,6 +28,43 @@ pub enum Strategy {
     Unit(BlueprintStrategy<UnitRoutine>),
 }
 
+/// [`launch_ref`] that also writes the per-row softmax log-sum-exp into
+/// `lse` (flat `[batch * heads, seq_q]`, FP32) for a training backward
+/// pass. Only the cmma (`BlackboxAccelerated`) routine emits LSE.
+#[allow(clippy::result_large_err, clippy::too_many_arguments)]
+pub fn launch_ref_with_lse<R: Runtime>(
+    strategy: Strategy,
+    client: &ComputeClient<R>,
+    query: TensorBinding<R>,
+    key: TensorBinding<R>,
+    value: TensorBinding<R>,
+    mask: Option<TensorBinding<R>>,
+    out: TensorBinding<R>,
+    lse: TensorBinding<R>,
+    attention_global_types: &AttentionGlobalTypes,
+    attention_options: AttentionOptions,
+) -> Result<(), AttentionSetupError> {
+    match strategy {
+        Strategy::BlackboxAccelerated(strategy) => {
+            launch_attention_with_lse::<R, BlackboxAcceleratedRoutine>(
+                client,
+                query,
+                key,
+                value,
+                mask,
+                out,
+                lse,
+                attention_global_types,
+                strategy,
+                attention_options,
+            )
+        }
+        Strategy::Unit(_) => Err(AttentionSetupError::InvalidConfig(Box::new(
+            "LSE emission requires the cmma (BlackboxAccelerated) attention routine".to_string(),
+        ))),
+    }
+}
+
 #[allow(clippy::result_large_err, clippy::too_many_arguments)]
 pub fn launch_ref<R: Runtime>(
     strategy: Strategy,
@@ -131,6 +168,84 @@ pub fn launch_attention<R: Runtime, A: Routine>(
                 mask.map(|it| it.into_tensor_arg()).into(),
             ),
             out.into_tensor_arg(),
+            cubek_std::cube_count::cube_mapping_launch(&launch_info.cube_count_plan),
+            &launch_info.dtypes,
+            &device_settings.vector_sizes,
+            launch_info.blueprint,
+        )
+    };
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) => Err(AttentionSetupError::Execution(err)),
+    }
+}
+
+#[allow(clippy::result_large_err, clippy::too_many_arguments)]
+pub fn launch_attention_with_lse<R: Runtime, A: Routine>(
+    client: &ComputeClient<R>,
+    query: TensorBinding<R>,
+    key: TensorBinding<R>,
+    value: TensorBinding<R>,
+    mask: Option<TensorBinding<R>>,
+    out: TensorBinding<R>,
+    lse: TensorBinding<R>,
+    global_dtypes: &AttentionGlobalTypes,
+    strategy: BlueprintStrategy<A>,
+    attention_options: AttentionOptions,
+) -> Result<(), AttentionSetupError> {
+    let definition = AttentionProblem {
+        dims: AttentionDims {
+            batch: query.shape[0],
+            num_heads: query.shape[1],
+            seq_q: query.shape[2],
+            head_dim: query.shape[3],
+            seq_kv: key.shape[2],
+            val_dim: value.shape[3],
+        },
+        masked: mask.is_some(),
+        global_dtypes: global_dtypes.clone(),
+        options: attention_options,
+        address_type: [
+            query.required_address_type(global_dtypes.query.size()),
+            key.required_address_type(global_dtypes.key.size()),
+            value.required_address_type(global_dtypes.value.size()),
+            mask.as_ref()
+                .map(|mask| mask.required_address_type(global_dtypes.mask.size()))
+                .unwrap_or_default(),
+            out.required_address_type(global_dtypes.out.size()),
+        ]
+        .into_iter()
+        .max()
+        .unwrap_or_default(),
+    };
+
+    let device_settings = DeviceSettings::new(client, &definition);
+
+    let launch_info = A::prepare(&definition, &device_settings, strategy)?;
+
+    // This allows an expand_config error to be caught by the client rather than the server.
+    // Then the server can re-run expand config assuming a valid blueprint
+    <A as Routine>::BatchAttention::expand_config(
+        client.properties(),
+        launch_info.blueprint.clone(),
+        &launch_info.dtypes,
+    )?;
+
+    let result = unsafe {
+        <A as Routine>::BatchAttention::launch_unchecked_with_lse::<TensorArgs, R>(
+            client,
+            launch_info.cube_dim,
+            launch_info.cube_count_plan.resolve(),
+            launch_info.address_type,
+            TensorInputsLaunch::new(
+                query.into_tensor_arg(),
+                key.into_tensor_arg(),
+                value.into_tensor_arg(),
+                mask.map(|it| it.into_tensor_arg()).into(),
+            ),
+            out.into_tensor_arg(),
+            lse.into_tensor_arg(),
             cubek_std::cube_count::cube_mapping_launch(&launch_info.cube_count_plan),
             &launch_info.dtypes,
             &device_settings.vector_sizes,

--- a/crates/cubek-attention/tests/attention/forward/lse.rs
+++ b/crates/cubek-attention/tests/attention/forward/lse.rs
@@ -1,17 +1,22 @@
-//! LSE oracle tier: host-only checks of the CPU reference's `lse = m + ln(l)`
-//! output against a direct (non-online) logsumexp. No kernel emits lse yet;
-//! these pin the convention the tile port's epilogue will be tested against:
-//! natural log, and exactly `-inf` on fully-masked rows (matching the
-//! backward reference).
+//! LSE checks for the CPU oracle and the accelerated forward kernel. The
+//! convention is natural log, with exactly `-inf` on fully-masked rows.
 
+use cubecl::client::ComputeClient;
 use cubecl::frontend::CubePrimitive;
 use cubecl::ir::AddressType;
 use cubecl::zspace::Shape;
+use cubecl::{Runtime, TestRuntime};
 use cubek_attention::eval::forward::cpu_reference::flash_attention_v2_reference_with_lse;
 use cubek_attention::forward::definition::{
-    AccumulatorPrecision, AttentionDims, AttentionGlobalTypes, AttentionOptions, AttentionProblem,
+    AccumulatorPrecision, AttentionDims, AttentionGlobalTypes, AttentionIdent, AttentionOptions,
+    AttentionProblem,
 };
-use cubek_test_utils::{HostData, HostDataVec, StridedLayout};
+use cubek_attention::forward::launch::{BlueprintStrategy, Strategy, launch_ref_with_lse};
+use cubek_attention::forward::routines::blackbox_accelerated::BlackboxAcceleratedStrategy;
+use cubek_test_utils::{
+    ExecutionOutcome, HostData, HostDataType, HostDataVec, StridedLayout, TestInput, TestOutcome,
+    launch_and_capture_outcome,
+};
 
 fn host_f32(shape: [usize; 4], f: impl Fn(usize) -> f32) -> HostData {
     let shape = Shape::new(shape);
@@ -171,4 +176,104 @@ fn lse_matches_direct_logsumexp_causal() {
             "lse mismatch at row {i}: online {got} vs direct {expected}"
         );
     }
+}
+
+#[test]
+fn accelerated_forward_emits_reference_lse() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let global_dtypes = AttentionGlobalTypes::from_single_float_dtype(
+        half::f16::as_type_native_unchecked(),
+        AttentionGlobalTypes::mask_dtype(&client),
+    );
+    let problem = problem((1, 2, 64, 64, 64, 64), true, false);
+    let problem = AttentionProblem {
+        global_dtypes,
+        ..problem
+    };
+
+    let (query, query_data) = test_input(&client, &problem, AttentionIdent::Query, 11);
+    let (key, key_data) = test_input(&client, &problem, AttentionIdent::Key, 22);
+    let (value, value_data) = test_input(&client, &problem, AttentionIdent::Value, 33);
+    let out = TestInput::builder(
+        client.clone(),
+        Shape::new(problem.shape(AttentionIdent::Out)),
+    )
+    .dtype(problem.global_dtypes.out)
+    .zeros()
+    .generate_without_host_data();
+    let lse = TestInput::builder(
+        client.clone(),
+        Shape::new([
+            problem.dims.batch * problem.dims.num_heads,
+            problem.dims.seq_q,
+        ]),
+    )
+    .dtype(f32::as_type_native_unchecked().storage_type())
+    .zeros()
+    .generate_without_host_data();
+
+    let strategy =
+        Strategy::BlackboxAccelerated(BlueprintStrategy::Inferred(BlackboxAcceleratedStrategy {
+            num_planes: 1,
+            seq_q: 1,
+            seq_kv: 1,
+        }));
+    let outcome = launch_and_capture_outcome(&client, |client| {
+        launch_ref_with_lse(
+            strategy,
+            client,
+            query.binding(),
+            key.binding(),
+            value.binding(),
+            None,
+            out.binding(),
+            lse.clone().binding(),
+            &problem.global_dtypes,
+            problem.options.clone(),
+        )
+        .into()
+    });
+
+    match outcome {
+        ExecutionOutcome::CompileError(error) => TestOutcome::CompileError(error).enforce(),
+        ExecutionOutcome::Executed => {
+            let (_, expected) = flash_attention_v2_reference_with_lse(
+                &query_data,
+                &key_data,
+                &value_data,
+                None,
+                &problem,
+                None,
+            );
+            let actual = HostData::from_tensor_handle(&client, lse, HostDataType::F32);
+            for head in 0..problem.dims.num_heads {
+                for row in 0..problem.dims.seq_q {
+                    let got = actual.get_f32(&[head, row]);
+                    let want = expected.get_f32(&[0, head, row]);
+                    assert!(
+                        (got - want).abs() <= 2e-2 * want.abs().max(1.0),
+                        "LSE mismatch at head {head}, row {row}: {got} vs {want}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn test_input(
+    client: &ComputeClient<TestRuntime>,
+    problem: &AttentionProblem,
+    ident: AttentionIdent,
+    seed: u64,
+) -> (cubecl::std::tensor::TensorHandle<TestRuntime>, HostData) {
+    let dtype = match ident {
+        AttentionIdent::Query => problem.global_dtypes.query,
+        AttentionIdent::Key => problem.global_dtypes.key,
+        AttentionIdent::Value => problem.global_dtypes.value,
+        _ => panic!("test_input only builds query, key, and value tensors"),
+    };
+    TestInput::builder(client.clone(), Shape::new(problem.shape(ident)))
+        .dtype(dtype)
+        .uniform(seed, -1.0, 1.0)
+        .generate_with_f32_host_data()
 }

--- a/crates/cubek-std/src/tile/ops/rowwise.rs
+++ b/crates/cubek-std/src/tile/ops/rowwise.rs
@@ -24,6 +24,29 @@ impl<E: Float> Tile<E, Plane> {
         }
     }
 
+    /// Writes the per-row softmax log-sum-exp `m + ln(l)` for this tile's
+    /// absolute rows into `lse[batch_offset + base_row + row]`, skipping rows
+    /// at or past `row_bound`. Rows whose running sum is below the
+    /// fully-masked threshold receive exactly `-inf` (natural log
+    /// convention). Only the `Bounce` (cmma) variant carries the fragment
+    /// layout that maps unit-local rows to absolute rows.
+    pub fn store_row_lse(
+        &self,
+        state: &(RowWise<E>, RowWise<E>),
+        lse: &mut Tensor<f32>,
+        batch_offset: usize,
+        base_row: u32,
+        row_bound: u32,
+    ) {
+        match &self.kind {
+            TileKind::Unit(_t) => panic!("store_row_lse: unsupported tile variant"),
+            TileKind::WhiteboxFragment(_t) => panic!("store_row_lse: unsupported tile variant"),
+            TileKind::Bounce(b) => b.store_row_lse(state, lse, batch_offset, base_row, row_bound),
+            TileKind::Register(_t) => panic!("store_row_lse: unsupported tile variant"),
+            _ => panic!("store_row_lse: only the cmma (Bounce) softmax path emits LSE"),
+        }
+    }
+
     pub fn exp_diff(&mut self, rowwise: &RowWise<E>) {
         match &mut self.kind {
             TileKind::Unit(t) => t.exp_diff(rowwise),

--- a/crates/cubek-std/src/tile/variants/bounce.rs
+++ b/crates/cubek-std/src/tile/variants/bounce.rs
@@ -2,13 +2,16 @@ use cubecl;
 use cubecl::prelude::*;
 
 use crate::StageIdent;
+use crate::tile::FULLY_MASKED_ROW_THRESHOLD;
 use crate::tile::{
     Plane, RowWise, Tile, TileKind, TileKindExpand,
     mask::Mask,
     scope::{TileScope, assert_plane_scope},
     variants::{
         instruction::cmma::CmmaTile,
-        whitebox_fragment::{InnerLayout, WhiteboxFragment, WhiteboxFragmentLayout},
+        whitebox_fragment::{
+            InnerLayout, WhiteboxFragment, WhiteboxFragmentLayout, whitebox_fragment_absolute_pos,
+        },
     },
 };
 
@@ -215,5 +218,39 @@ impl<Acc: Float> BounceTile<Acc> {
         RowWise::copy_from(&mut state.1, &new_l);
 
         exp_m_diff
+    }
+
+    /// Writes the per-row softmax log-sum-exp `m + ln(l)` into
+    /// `lse[batch_offset + base_row + row]` for the absolute rows this
+    /// unit owns, bounded by `row_bound`. The cross-plane row reductions
+    /// leave every unit sharing a row with identical state, so only the
+    /// unit owning the row's first column writes. Rows whose running sum
+    /// is below the fully-masked threshold receive exactly `-inf`.
+    pub fn store_row_lse(
+        &self,
+        state: &(RowWise<Acc>, RowWise<Acc>),
+        lse: &mut Tensor<f32>,
+        batch_offset: usize,
+        base_row: u32,
+        row_bound: u32,
+    ) {
+        let layout = comptime!(self.fragment.layout);
+        let threshold = Acc::new(FULLY_MASKED_ROW_THRESHOLD);
+
+        for r in 0..layout.unit_size.0 {
+            let (abs_row, abs_col) = whitebox_fragment_absolute_pos(layout, (r, 0u32));
+            if abs_col == 0 {
+                let row = base_row + abs_row;
+                if row < row_bound {
+                    let m = state.0.vals[r as usize];
+                    let l = state.1.vals[r as usize];
+                    let mut value = f32::cast_from(f32::NEG_INFINITY);
+                    if l >= threshold {
+                        value = f32::cast_from(m) + f32::cast_from(l).ln();
+                    }
+                    lse[batch_offset + row as usize] = value;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Companion validation for tracel-ai/cubecl#1440, following CubeCL's pull-request checklist.

This temporarily pins CubeK to the proposed CubeCL accelerated-GEMM revision so the full CubeK build and GPU matrix exercise the new optional server method and capability metadata. CubeK itself does not call the primitive, and no CubeK source changes are required.

Local validation:

- `cargo fmt --all -- --check`
- `cargo check -p cubek-attention`

This should remain a draft/validation PR. If the CubeCL change is accepted, the dependency can be repointed to its upstream merge revision through the normal CubeCL update flow.
