### PR TITLE
chore: update cubecl for fallible dimension indices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ version = "0.3.0-pre.1"
 # cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "870666bf46e1c370d3aae08e3dcb9d9a74ed90c8", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "870666bf46e1c370d3aae08e3dcb9d9a74ed90c8", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "7c6a9e79565c2d496fd4825649535850fdcc5006", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "7c6a9e79565c2d496fd4825649535850fdcc5006", default-features = false }
 ### For releases ###
 # cubecl = { version = "0.10.0", default-features = false }
 # cubecl-common = { version = "0.10.0", default-features = false }


### PR DESCRIPTION
## Motivation

Cubek PR #432 pins CubeCL to `870666bf`, while Burn needs the `AsIndex::try_dim_index` API merged immediately afterward in tracel-ai/cubecl#1445. Mixing those revisions in Burn creates duplicate `cubecl_core` and `cubecl_ir` types, which breaks full-workspace lint and documentation builds.

This follow-up keeps Cubek aligned with the CubeCL revision required by tracel-ai/burn#5232.

## Modifications

- Update `cubecl` and `cubecl-common` from `870666bf` to `7c6a9e79565c2d496fd4825649535850fdcc5006`.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo +nightly check --workspace`