### PR TITLE
feat(tune): cost models for matmul, attention and reduce autotune bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.1"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "05cac67370653ef6ed6b76730b20a0cb4bede117", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "05cac67370653ef6ed6b76730b20a0cb4bede117", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "05cac67370653ef6ed6b76730b20a0cb4bede117", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "f2fc6e2b868c0c5e470616f3e03927a7db6d7fc3", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "f2fc6e2b868c0c5e470616f3e03927a7db6d7fc3", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "f2fc6e2b868c0c5e470616f3e03927a7db6d7fc3", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.1", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.1", default-features = false }

--- a/crates/cubek-attention/src/forward/definition/cost.rs
+++ b/crates/cubek-attention/src/forward/definition/cost.rs
@@ -205,4 +205,3 @@ mod tests {
         assert_eq!(causal.work().bytes, cost().work().bytes);
     }
 }
-

--- a/crates/cubek-attention/src/forward/definition/cost.rs
+++ b/crates/cubek-attention/src/forward/definition/cost.rs
@@ -16,7 +16,7 @@ pub struct AttentionCost {
     pub dims: AttentionDims,
     /// Whether a mask tensor is read.
     pub masked: bool,
-    /// Whether a causal mask skips half the score matrix calculations.
+    /// Whether a causal mask skips the score matrix above its bottom-right diagonal.
     pub causal: bool,
     /// Global element types of the operands.
     pub types: AttentionGlobalTypes,
@@ -36,17 +36,34 @@ impl AttentionCost {
             val_dim,
         } = self.dims;
 
-        let scores = batch * num_heads * seq_q;
+        let batch_heads = batch * num_heads;
 
-        // Causal masking skips roughly half of the score matrix and associated matmuls.
-        let causal_div = if self.causal { 2 } else { 1 };
+        // Causal masking drops a score when `j + seq_q > i + seq_kv`, which aligns the
+        // diagonal on the bottom right: query `i` visits `i + seq_kv - seq_q + 1` keys,
+        // the full rectangle minus the triangle above the diagonal. This is not a flat
+        // halving: a decode step (`seq_q = 1`) still visits the whole cache.
+        let diagonal = seq_q.min(seq_kv);
+        let visited = match self.causal {
+            true => diagonal * seq_kv - diagonal * diagonal.saturating_sub(1) / 2,
+            false => seq_q * seq_kv,
+        };
+        // Rows above the diagonal visit nothing, so they contract over nothing either.
+        let rows = match self.causal {
+            true => diagonal,
+            false => seq_q,
+        };
 
-        let qk_ops = scores * seq_kv * (2 * head_dim - 1) / causal_div;
-        let sv_ops = scores * val_dim * (2 * seq_kv - 1) / causal_div;
+        // `2n - 1` ops per output element: n multiplies and n - 1 adds. Saturating so a
+        // degenerate extent (an empty KV cache) yields zero instead of underflowing.
+        let qk_ops = batch_heads * visited * (2 * head_dim).saturating_sub(1);
+        // Every row contracts over the keys it visited, so summing `2 * visited_i - 1`
+        // over the rows that visited any gives the adds and multiplies per output column.
+        let sv_ops = batch_heads * val_dim * (2 * visited).saturating_sub(rows);
 
-        let elements = |seq: usize, dim: usize| batch * num_heads * seq * dim;
+        let elements = |seq: usize, dim: usize| batch_heads * seq * dim;
+        // Only the mask entries the kernel actually visits are read.
         let mask_bytes = match self.masked {
-            true => elements(seq_q, seq_kv) * self.types.mask.size() / causal_div,
+            true => batch_heads * visited * self.types.mask.size(),
             false => 0,
         };
 
@@ -135,28 +152,55 @@ mod tests {
     }
 
     #[test]
-    fn a_causal_mask_halves_the_op_count() {
+    fn a_causal_mask_skips_the_scores_above_the_diagonal() {
+        // 8 queries over 16 keys, bottom-right aligned: 8 * 16 minus the 8 * 7 / 2
+        // triangle the mask drops, so 100 of the 128 score entries are visited.
         let causal = AttentionCost {
             causal: true,
             ..cost()
         };
 
-        assert_eq!(causal.work().compute_ops, cost().work().compute_ops / 2);
+        let qk = 2 * 100 * 7;
+        // 8 rows contract over what they visited: 2 * 100 - 8 ops per val_dim column.
+        let sv = 2 * 4 * (2 * 100 - 8);
+
+        assert_eq!(causal.work().compute_ops, qk + sv);
     }
 
     #[test]
-    fn a_decode_step_costs_one_pass_over_the_cache() {
-        // seq_q = 1 represents decode; causal division must not result in zero compute ops.
-        let decode = AttentionCost {
+    fn a_decode_step_costs_a_full_pass_over_the_cache() {
+        // seq_q = 1 is decode: the single query sits on the diagonal and attends the
+        // whole cache, so a causal mask discounts nothing.
+        let decode = |causal| AttentionCost {
             dims: AttentionDims {
                 seq_q: 1,
                 ..cost().dims
             },
-            causal: true,
+            causal,
             ..cost()
         };
 
-        assert!(decode.work().compute_ops > 0);
+        assert_eq!(
+            decode(true).work().compute_ops,
+            decode(false).work().compute_ops
+        );
+    }
+
+    #[test]
+    fn an_empty_kv_cache_costs_nothing() {
+        // Degenerate extents must saturate rather than underflow the op counts.
+        let empty = |causal| AttentionCost {
+            dims: AttentionDims {
+                seq_kv: 0,
+                ..cost().dims
+            },
+            causal,
+            masked: true,
+            ..cost()
+        };
+
+        assert_eq!(empty(false).work().compute_ops, 0);
+        assert_eq!(empty(true).work().compute_ops, 0);
     }
 
     #[test]
@@ -177,7 +221,7 @@ mod tests {
 
     #[test]
     fn a_causal_run_only_reads_the_mask_it_visits() {
-        // Causal mask bytes are halved along with the visited score blocks.
+        // Only the 100 visited score entries of the 8 x 16 mask are read.
         let masked = AttentionCost {
             masked: true,
             causal: true,
@@ -188,10 +232,7 @@ mod tests {
             ..cost()
         };
 
-        assert_eq!(
-            masked.work().bytes,
-            causal.work().bytes + 2 * 8 * 16 * 4 / 2
-        );
+        assert_eq!(masked.work().bytes, causal.work().bytes + 2 * 100 * 4);
     }
 
     #[test]

--- a/crates/cubek-attention/src/forward/definition/cost.rs
+++ b/crates/cubek-attention/src/forward/definition/cost.rs
@@ -1,0 +1,208 @@
+use cubecl::{
+    client::ComputeClient,
+    ir::{ElemType, FloatKind, StorageType},
+    prelude::Runtime,
+    throughput::{ThroughputKey, compute_throughput_key, select_cmma_tile},
+    tune::Work,
+};
+
+use crate::forward::definition::{AttentionDims, AttentionGlobalTypes, AttentionProblem};
+
+/// Minimal representation of attention cost dependencies, including matrix extents,
+/// masking requirements, and element types.
+#[derive(Debug, Clone)]
+pub struct AttentionCost {
+    /// Extents of the query, key, and value tensors.
+    pub dims: AttentionDims,
+    /// Whether a mask tensor is read.
+    pub masked: bool,
+    /// Whether a causal mask skips half the score matrix calculations.
+    pub causal: bool,
+    /// Global element types of the operands.
+    pub types: AttentionGlobalTypes,
+}
+
+impl AttentionCost {
+    /// Calculates the compute operations and compulsory memory traffic for the attention pass.
+    ///
+    /// Includes both matmuls (`Q@K^T` and `S@V`) and memory traffic for compulsory input/output operands.
+    pub fn work(&self) -> Work {
+        let AttentionDims {
+            batch,
+            num_heads,
+            seq_q,
+            seq_kv,
+            head_dim,
+            val_dim,
+        } = self.dims;
+
+        let scores = batch * num_heads * seq_q;
+
+        // Causal masking skips roughly half of the score matrix and associated matmuls.
+        let causal_div = if self.causal { 2 } else { 1 };
+
+        let qk_ops = scores * seq_kv * (2 * head_dim - 1) / causal_div;
+        let sv_ops = scores * val_dim * (2 * seq_kv - 1) / causal_div;
+
+        let elements = |seq: usize, dim: usize| batch * num_heads * seq * dim;
+        let mask_bytes = match self.masked {
+            true => elements(seq_q, seq_kv) * self.types.mask.size() / causal_div,
+            false => 0,
+        };
+
+        Work {
+            compute_ops: qk_ops + sv_ops,
+            // Exclude attention bias as fast paths do not read one.
+            bytes: elements(seq_q, head_dim) * self.types.query.size()
+                + elements(seq_kv, head_dim) * self.types.key.size()
+                + elements(seq_kv, val_dim) * self.types.value.size()
+                + mask_bytes
+                + elements(seq_q, val_dim) * self.types.out.size(),
+        }
+    }
+
+    /// Generates a throughput key for compute probes representing the peak instruction throughput.
+    ///
+    /// Uses an unconstrained tile selection to accurately model peak hardware throughput
+    /// for attention matmuls.
+    pub fn compute_key<R: Runtime>(&self, client: &ComputeClient<R>) -> ThroughputKey {
+        const UNCONSTRAINED: (usize, usize, usize) = (usize::MAX, usize::MAX, usize::MAX);
+
+        // Softmax statistics accumulate in f32 regardless of operand types.
+        let acc = StorageType::Scalar(ElemType::Float(FloatKind::F32));
+
+        let cmma_tile =
+            select_cmma_tile(client, self.types.query, self.types.key, acc, UNCONSTRAINED);
+
+        compute_throughput_key(
+            cmma_tile,
+            self.types.query.elem_type(),
+            ElemType::Float(FloatKind::F32),
+        )
+    }
+}
+
+impl From<&AttentionProblem> for AttentionCost {
+    fn from(problem: &AttentionProblem) -> Self {
+        Self {
+            dims: problem.dims.clone(),
+            masked: problem.masked,
+            causal: problem.options.causal,
+            types: problem.global_dtypes.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn f32_types() -> AttentionGlobalTypes {
+        let f32 = StorageType::Scalar(ElemType::Float(FloatKind::F32));
+
+        AttentionGlobalTypes {
+            query: f32,
+            key: f32,
+            value: f32,
+            mask: f32,
+            out: f32,
+        }
+    }
+
+    fn cost() -> AttentionCost {
+        AttentionCost {
+            dims: AttentionDims {
+                batch: 2,
+                num_heads: 1,
+                seq_q: 8,
+                seq_kv: 16,
+                head_dim: 4,
+                val_dim: 4,
+            },
+            masked: false,
+            causal: false,
+            types: f32_types(),
+        }
+    }
+
+    #[test]
+    fn counts_both_matmuls() {
+        // Q@K^T ops + S@V ops
+        let qk = 2 * 8 * 16 * 7;
+        let sv = 2 * 8 * 4 * 31;
+
+        assert_eq!(cost().work().compute_ops, qk + sv);
+    }
+
+    #[test]
+    fn a_causal_mask_halves_the_op_count() {
+        let causal = AttentionCost {
+            causal: true,
+            ..cost()
+        };
+
+        assert_eq!(causal.work().compute_ops, cost().work().compute_ops / 2);
+    }
+
+    #[test]
+    fn a_decode_step_costs_one_pass_over_the_cache() {
+        // seq_q = 1 represents decode; causal division must not result in zero compute ops.
+        let decode = AttentionCost {
+            dims: AttentionDims {
+                seq_q: 1,
+                ..cost().dims
+            },
+            causal: true,
+            ..cost()
+        };
+
+        assert!(decode.work().compute_ops > 0);
+    }
+
+    #[test]
+    fn counts_the_operands_and_the_output() {
+        // (q + k + v + out) elements per batch head * 2 heads * 4 bytes
+        assert_eq!(cost().work().bytes, 2 * (32 + 64 + 64 + 32) * 4);
+    }
+
+    #[test]
+    fn a_mask_is_counted_as_bytes_read() {
+        let masked = AttentionCost {
+            masked: true,
+            ..cost()
+        };
+
+        assert_eq!(masked.work().bytes, cost().work().bytes + 2 * 8 * 16 * 4);
+    }
+
+    #[test]
+    fn a_causal_run_only_reads_the_mask_it_visits() {
+        // Causal mask bytes are halved along with the visited score blocks.
+        let masked = AttentionCost {
+            masked: true,
+            causal: true,
+            ..cost()
+        };
+        let causal = AttentionCost {
+            causal: true,
+            ..cost()
+        };
+
+        assert_eq!(
+            masked.work().bytes,
+            causal.work().bytes + 2 * 8 * 16 * 4 / 2
+        );
+    }
+
+    #[test]
+    fn a_causal_mask_does_not_change_the_operand_bytes() {
+        // Q, K, and V tensors are fully read even with causal masking.
+        let causal = AttentionCost {
+            causal: true,
+            ..cost()
+        };
+
+        assert_eq!(causal.work().bytes, cost().work().bytes);
+    }
+}
+

--- a/crates/cubek-attention/src/forward/definition/mod.rs
+++ b/crates/cubek-attention/src/forward/definition/mod.rs
@@ -1,5 +1,6 @@
 mod base;
 mod blueprint;
+mod cost;
 mod error;
 mod hypercube;
 mod spec;
@@ -7,6 +8,7 @@ mod vectorization;
 
 pub use base::*;
 pub use blueprint::*;
+pub use cost::*;
 pub use error::*;
 pub use hypercube::*;
 pub use spec::*;

--- a/crates/cubek-matmul/src/definition/cost.rs
+++ b/crates/cubek-matmul/src/definition/cost.rs
@@ -31,7 +31,7 @@ impl MatmulCost {
         let elements = |rows: usize, cols: usize| self.batches * rows * cols;
 
         Work {
-            compute_ops: elements(self.m, self.n) * (2 * self.k - 1),
+            compute_ops: elements(self.m, self.n) * (2 * self.k).saturating_sub(1),
             bytes: elements(self.m, self.k) * self.elems.lhs.size()
                 + elements(self.k, self.n) * self.elems.rhs.size()
                 + elements(self.m, self.n) * self.elems.out.size(),
@@ -141,4 +141,3 @@ mod tests {
         assert_eq!(batched.work().bytes, 8 * cost().work().bytes);
     }
 }
-

--- a/crates/cubek-matmul/src/definition/cost.rs
+++ b/crates/cubek-matmul/src/definition/cost.rs
@@ -1,0 +1,144 @@
+use cubecl::{
+    client::ComputeClient,
+    prelude::Runtime,
+    throughput::{ThroughputKey, compute_throughput_key, select_cmma_tile},
+    tune::Work,
+};
+
+use crate::definition::{MatmulElems, MatmulGlobalElems, MatmulProblem};
+
+/// Minimal representation of matmul cost dependencies, including dimensions and element types.
+#[derive(Debug, Clone)]
+pub struct MatmulCost {
+    /// Number of independent matmuls in the batch.
+    pub batches: usize,
+    /// Number of output rows (M).
+    pub m: usize,
+    /// Number of output columns (N).
+    pub n: usize,
+    /// Contracted dimension (K).
+    pub k: usize,
+    /// Global element types of the operands.
+    pub elems: MatmulGlobalElems,
+}
+
+impl MatmulCost {
+    /// Calculates the compute operations and compulsory memory traffic for the matmul.
+    ///
+    /// Computes operations as `2 * k - 1` ops per output element and compulsory byte traffic
+    /// for reading inputs and writing outputs once.
+    pub fn work(&self) -> Work {
+        let elements = |rows: usize, cols: usize| self.batches * rows * cols;
+
+        Work {
+            compute_ops: elements(self.m, self.n) * (2 * self.k - 1),
+            bytes: elements(self.m, self.k) * self.elems.lhs.size()
+                + elements(self.k, self.n) * self.elems.rhs.size()
+                + elements(self.m, self.n) * self.elems.out.size(),
+        }
+    }
+
+    /// Generates a throughput key for compute probes representing peak hardware instruction throughput.
+    ///
+    /// Selects CMMA tiles without problem-size constraints to ensure small dimensions (e.g. `m = 1`)
+    /// evaluate against peak hardware throughput, using register element types.
+    pub fn compute_key<R: Runtime>(&self, client: &ComputeClient<R>) -> ThroughputKey {
+        // Unconstrained selection allows matching hardware capability without problem-size padding limits.
+        const UNCONSTRAINED: (usize, usize, usize) = (usize::MAX, usize::MAX, usize::MAX);
+
+        let elems = MatmulElems::from_globals(&self.elems);
+
+        let cmma_tile = select_cmma_tile(
+            client,
+            elems.lhs_register,
+            elems.rhs_register,
+            elems.acc_register,
+            UNCONSTRAINED,
+        );
+
+        compute_throughput_key(
+            cmma_tile,
+            elems.lhs_register.elem_type(),
+            elems.acc_register.elem_type(),
+        )
+    }
+}
+
+impl From<&MatmulProblem> for MatmulCost {
+    fn from(problem: &MatmulProblem) -> Self {
+        Self {
+            batches: problem.out_batches.iter().product(),
+            m: problem.m,
+            n: problem.n,
+            k: problem.k,
+            elems: problem.global_dtypes.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cubecl::ir::{ElemType, FloatKind, StorageType};
+
+    fn f32_elems() -> MatmulGlobalElems {
+        let f32 = StorageType::Scalar(ElemType::Float(FloatKind::F32));
+
+        MatmulGlobalElems {
+            lhs: f32,
+            rhs: f32,
+            out: f32,
+        }
+    }
+
+    fn cost() -> MatmulCost {
+        MatmulCost {
+            batches: 1,
+            m: 2,
+            n: 3,
+            k: 4,
+            elems: f32_elems(),
+        }
+    }
+
+    #[test]
+    fn counts_a_multiply_and_an_add_per_contracted_element() {
+        // 2x3 outputs with length-4 dot product: 4 multiplies and 3 adds per element.
+        assert_eq!(cost().work().compute_ops, 6 * 7);
+    }
+
+    #[test]
+    fn scales_the_op_count_with_the_batch() {
+        let batched = MatmulCost {
+            batches: 8,
+            ..cost()
+        };
+
+        assert_eq!(batched.work().compute_ops, 8 * cost().work().compute_ops);
+    }
+
+    #[test]
+    fn a_contraction_of_one_costs_one_op_per_output() {
+        // k = 1 evaluates to 1 operation per output element.
+        let dot = MatmulCost { k: 1, ..cost() };
+
+        assert_eq!(dot.work().compute_ops, 6);
+    }
+
+    #[test]
+    fn counts_every_operand_once_in_the_byte_total() {
+        // (m*k + k*n + m*n) elements * 4 bytes
+        assert_eq!(cost().work().bytes, 26 * 4);
+    }
+
+    #[test]
+    fn counts_the_batch_in_every_operand() {
+        let batched = MatmulCost {
+            batches: 8,
+            ..cost()
+        };
+
+        assert_eq!(batched.work().bytes, 8 * cost().work().bytes);
+    }
+}
+

--- a/crates/cubek-matmul/src/definition/mod.rs
+++ b/crates/cubek-matmul/src/definition/mod.rs
@@ -1,5 +1,6 @@
 mod base;
 mod blueprint;
+mod cost;
 mod cube_mapping;
 mod error;
 mod spec;
@@ -8,6 +9,7 @@ mod vectorization;
 
 pub use base::*;
 pub use blueprint::*;
+pub use cost::*;
 pub use cube_mapping::*;
 // Internal-only — external crates import these directly from cubek-std.
 pub(crate) use cubek_std::{StageIdent, SwizzleModes};

--- a/crates/cubek-reduce/src/routines/cost.rs
+++ b/crates/cubek-reduce/src/routines/cost.rs
@@ -1,5 +1,4 @@
 use cubecl::{
-    ir::StorageType,
     throughput::{ThroughputKey, ThroughputMode},
     tune::Work,
 };
@@ -18,30 +17,27 @@ pub struct ReduceCost {
     /// The reduction operation.
     pub instruction: ReduceOperationConfig,
     /// Element types of input, output, and accumulator.
+    ///
+    /// For the instructions whose output is a coordinate (`Arg*`) or a logical flag
+    /// (`Any` / `All`), `output` already is that element type, so the write is counted
+    /// once whatever the instruction produces.
     pub dtypes: ReduceDtypes,
-    /// Element type for optional index output.
-    pub indices: Option<StorageType>,
 }
 
 impl ReduceCost {
     /// Calculates compute operations and compulsory memory traffic for the reduction.
     ///
     /// Computes operations as `(reduce_len - 1) * ops_per_step` per fold, and byte traffic
-    /// for input reads and output/index writes.
+    /// for input reads and output writes.
     pub fn work(&self) -> Work {
         let outputs = self.reduce_count * self.outputs_per_fold();
-        let indices_bytes = match self.indices {
-            Some(indices) => outputs * indices.size(),
-            None => 0,
-        };
 
         Work {
             compute_ops: self.reduce_count
                 * self.reduce_len.saturating_sub(1)
                 * self.ops_per_step(),
             bytes: self.reduce_len * self.reduce_count * self.dtypes.input.size()
-                + outputs * self.dtypes.output.size()
-                + indices_bytes,
+                + outputs * self.dtypes.output.size(),
         }
     }
 
@@ -62,23 +58,34 @@ impl ReduceCost {
         }
     }
 
-    /// Estimated minimum operations required per reduction step.
+    /// Minimum operations required per reduction step.
+    ///
+    /// Counted from the instructions the unit routine emits for one element, that
+    /// routine being the cheapest fold (the plane and cube routines add plane
+    /// reductions and accumulator fusions on top).
     fn ops_per_step(&self) -> usize {
         match self.instruction {
-            // Single binary operation (e.g. sum, product, min, max, logical).
+            // A single arithmetic operation: an add, or a multiply for `Prod`.
+            // `Mean` folds as a sum and only divides once at the end.
             ReduceOperationConfig::Sum
             | ReduceOperationConfig::Prod
-            | ReduceOperationConfig::Mean
-            | ReduceOperationConfig::Max
-            | ReduceOperationConfig::Min
-            | ReduceOperationConfig::MaxAbs
-            | ReduceOperationConfig::Any
-            | ReduceOperationConfig::All => 1,
-            // Operations tracking index/position require comparison and coordinate updates.
-            ReduceOperationConfig::ArgMax
-            | ReduceOperationConfig::ArgMin
-            | ReduceOperationConfig::ArgTopK(_)
-            | ReduceOperationConfig::TopK(_) => 2,
+            | ReduceOperationConfig::Mean => 1,
+            // A comparison and the select that keeps the winner.
+            ReduceOperationConfig::Max | ReduceOperationConfig::Min => 2,
+            // The same, over `abs` of the element.
+            ReduceOperationConfig::MaxAbs => 3,
+            // The element is first normalized to a flag, itself a comparison and a
+            // select, before the same comparison and select fold it in.
+            ReduceOperationConfig::Any | ReduceOperationConfig::All => 4,
+            // Comparing values, breaking the tie on the coordinates, then selecting
+            // the winning flag, value and coordinate.
+            ReduceOperationConfig::ArgMax | ReduceOperationConfig::ArgMin => 6,
+            // A sorted insertion walks all k slots, each a comparison and the two
+            // selects that shift the displaced value along.
+            ReduceOperationConfig::TopK(k) => 3 * k,
+            // The same walk, carrying the coordinates: the tie-break costs two more
+            // comparisons a slot, and the displaced coordinate two more selects.
+            ReduceOperationConfig::ArgTopK(k) => 8 * k,
         }
     }
 }
@@ -90,7 +97,6 @@ impl From<&ReduceProblem> for ReduceCost {
             reduce_count: problem.reduce_count,
             instruction: problem.instruction,
             dtypes: problem.dtypes,
-            indices: None,
         }
     }
 }
@@ -98,7 +104,7 @@ impl From<&ReduceProblem> for ReduceCost {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cubecl::ir::{ElemType, FloatKind, UIntKind};
+    use cubecl::ir::{ElemType, FloatKind, StorageType, UIntKind};
 
     fn f32_dtypes() -> ReduceDtypes {
         let f32 = StorageType::Scalar(ElemType::Float(FloatKind::F32));
@@ -116,7 +122,6 @@ mod tests {
             reduce_count: 12,
             instruction: ReduceOperationConfig::Sum,
             dtypes: f32_dtypes(),
-            indices: None,
         }
     }
 
@@ -147,19 +152,59 @@ mod tests {
     }
 
     #[test]
-    fn tracking_an_index_costs_two_ops_a_step() {
+    fn tracking_an_index_costs_six_ops_a_step() {
         let argmax = ReduceCost {
             instruction: ReduceOperationConfig::ArgMax,
             ..cost()
         };
 
-        assert_eq!(argmax.work().compute_ops, 2 * cost().work().compute_ops);
+        assert_eq!(argmax.work().compute_ops, 6 * cost().work().compute_ops);
+    }
+
+    #[test]
+    fn comparing_costs_an_op_more_than_accumulating() {
+        let max = ReduceCost {
+            instruction: ReduceOperationConfig::Max,
+            ..cost()
+        };
+
+        assert_eq!(max.work().compute_ops, 2 * cost().work().compute_ops);
     }
 
     #[test]
     fn counts_the_input_once_and_one_output_a_fold() {
         // 12 * 5 input elements + 12 output elements * 4 bytes
         assert_eq!(cost().work().bytes, (60 + 12) * 4);
+    }
+
+    #[test]
+    fn a_top_k_insertion_costs_three_ops_a_slot() {
+        let topk = ReduceCost {
+            instruction: ReduceOperationConfig::TopK(3),
+            ..cost()
+        };
+
+        assert_eq!(topk.work().compute_ops, 9 * cost().work().compute_ops);
+    }
+
+    #[test]
+    fn tracking_the_coordinates_costs_eight_ops_a_slot() {
+        let argtopk = ReduceCost {
+            instruction: ReduceOperationConfig::ArgTopK(3),
+            ..cost()
+        };
+
+        assert_eq!(argtopk.work().compute_ops, 24 * cost().work().compute_ops);
+    }
+
+    #[test]
+    fn normalizing_a_flag_costs_two_ops_more_than_comparing() {
+        let any = ReduceCost {
+            instruction: ReduceOperationConfig::Any,
+            ..cost()
+        };
+
+        assert_eq!(any.work().compute_ops, 4 * cost().work().compute_ops);
     }
 
     #[test]
@@ -173,14 +218,17 @@ mod tests {
     }
 
     #[test]
-    fn counts_the_indices_output_when_there_is_one() {
+    fn counts_a_coordinate_output_like_any_other_value() {
+        // `Arg*` writes one u32 coordinate a fold, which `dtypes.output` already carries.
         let argmax = ReduceCost {
             instruction: ReduceOperationConfig::ArgMax,
-            indices: Some(StorageType::Scalar(ElemType::UInt(UIntKind::U32))),
+            dtypes: ReduceDtypes {
+                output: StorageType::Scalar(ElemType::UInt(UIntKind::U32)),
+                ..f32_dtypes()
+            },
             ..cost()
         };
 
-        assert_eq!(argmax.work().bytes, cost().work().bytes + 12 * 4);
+        assert_eq!(argmax.work().bytes, (60 + 12) * 4);
     }
 }
-

--- a/crates/cubek-reduce/src/routines/cost.rs
+++ b/crates/cubek-reduce/src/routines/cost.rs
@@ -1,0 +1,186 @@
+use cubecl::{
+    ir::StorageType,
+    throughput::{ThroughputKey, ThroughputMode},
+    tune::Work,
+};
+
+use crate::{
+    components::instructions::ReduceOperationConfig, launch::ReduceDtypes, routines::ReduceProblem,
+};
+
+/// Minimal representation of reduce cost dependencies, including reduction length, operation, and element types.
+#[derive(Debug, Clone, Copy)]
+pub struct ReduceCost {
+    /// Number of elements along the reduction axis.
+    pub reduce_len: usize,
+    /// Number of reduction instances.
+    pub reduce_count: usize,
+    /// The reduction operation.
+    pub instruction: ReduceOperationConfig,
+    /// Element types of input, output, and accumulator.
+    pub dtypes: ReduceDtypes,
+    /// Element type for optional index output.
+    pub indices: Option<StorageType>,
+}
+
+impl ReduceCost {
+    /// Calculates compute operations and compulsory memory traffic for the reduction.
+    ///
+    /// Computes operations as `(reduce_len - 1) * ops_per_step` per fold, and byte traffic
+    /// for input reads and output/index writes.
+    pub fn work(&self) -> Work {
+        let outputs = self.reduce_count * self.outputs_per_fold();
+        let indices_bytes = match self.indices {
+            Some(indices) => outputs * indices.size(),
+            None => 0,
+        };
+
+        Work {
+            compute_ops: self.reduce_count
+                * self.reduce_len.saturating_sub(1)
+                * self.ops_per_step(),
+            bytes: self.reduce_len * self.reduce_count * self.dtypes.input.size()
+                + outputs * self.dtypes.output.size()
+                + indices_bytes,
+        }
+    }
+
+    /// Generates a throughput key using direct ALU throughput for the accumulation element type.
+    pub fn compute_key(&self) -> ThroughputKey {
+        ThroughputKey {
+            mode: ThroughputMode::ComputeDirect {
+                dtype: self.dtypes.accumulation.elem_type(),
+            },
+        }
+    }
+
+    /// Number of output values written per fold.
+    fn outputs_per_fold(&self) -> usize {
+        match self.instruction {
+            ReduceOperationConfig::ArgTopK(k) | ReduceOperationConfig::TopK(k) => k,
+            _ => 1,
+        }
+    }
+
+    /// Estimated minimum operations required per reduction step.
+    fn ops_per_step(&self) -> usize {
+        match self.instruction {
+            // Single binary operation (e.g. sum, product, min, max, logical).
+            ReduceOperationConfig::Sum
+            | ReduceOperationConfig::Prod
+            | ReduceOperationConfig::Mean
+            | ReduceOperationConfig::Max
+            | ReduceOperationConfig::Min
+            | ReduceOperationConfig::MaxAbs
+            | ReduceOperationConfig::Any
+            | ReduceOperationConfig::All => 1,
+            // Operations tracking index/position require comparison and coordinate updates.
+            ReduceOperationConfig::ArgMax
+            | ReduceOperationConfig::ArgMin
+            | ReduceOperationConfig::ArgTopK(_)
+            | ReduceOperationConfig::TopK(_) => 2,
+        }
+    }
+}
+
+impl From<&ReduceProblem> for ReduceCost {
+    fn from(problem: &ReduceProblem) -> Self {
+        Self {
+            reduce_len: problem.reduce_len,
+            reduce_count: problem.reduce_count,
+            instruction: problem.instruction,
+            dtypes: problem.dtypes,
+            indices: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cubecl::ir::{ElemType, FloatKind, UIntKind};
+
+    fn f32_dtypes() -> ReduceDtypes {
+        let f32 = StorageType::Scalar(ElemType::Float(FloatKind::F32));
+
+        ReduceDtypes {
+            input: f32,
+            output: f32,
+            accumulation: f32,
+        }
+    }
+
+    fn cost() -> ReduceCost {
+        ReduceCost {
+            reduce_len: 5,
+            reduce_count: 12,
+            instruction: ReduceOperationConfig::Sum,
+            dtypes: f32_dtypes(),
+            indices: None,
+        }
+    }
+
+    #[test]
+    fn folds_an_axis_with_one_op_less_than_its_length() {
+        // 12 folds of 5 elements (4 accumulations per fold).
+        assert_eq!(cost().work().compute_ops, 48);
+    }
+
+    #[test]
+    fn an_axis_of_one_costs_nothing_to_fold() {
+        let degenerate = ReduceCost {
+            reduce_len: 1,
+            ..cost()
+        };
+
+        assert_eq!(degenerate.work().compute_ops, 0);
+    }
+
+    #[test]
+    fn an_empty_axis_costs_nothing_to_fold() {
+        let empty = ReduceCost {
+            reduce_len: 0,
+            ..cost()
+        };
+
+        assert_eq!(empty.work().compute_ops, 0);
+    }
+
+    #[test]
+    fn tracking_an_index_costs_two_ops_a_step() {
+        let argmax = ReduceCost {
+            instruction: ReduceOperationConfig::ArgMax,
+            ..cost()
+        };
+
+        assert_eq!(argmax.work().compute_ops, 2 * cost().work().compute_ops);
+    }
+
+    #[test]
+    fn counts_the_input_once_and_one_output_a_fold() {
+        // 12 * 5 input elements + 12 output elements * 4 bytes
+        assert_eq!(cost().work().bytes, (60 + 12) * 4);
+    }
+
+    #[test]
+    fn top_k_writes_k_values_a_fold() {
+        let topk = ReduceCost {
+            instruction: ReduceOperationConfig::TopK(3),
+            ..cost()
+        };
+
+        assert_eq!(topk.work().bytes, (60 + 12 * 3) * 4);
+    }
+
+    #[test]
+    fn counts_the_indices_output_when_there_is_one() {
+        let argmax = ReduceCost {
+            instruction: ReduceOperationConfig::ArgMax,
+            indices: Some(StorageType::Scalar(ElemType::UInt(UIntKind::U32))),
+            ..cost()
+        };
+
+        assert_eq!(argmax.work().bytes, cost().work().bytes + 12 * 4);
+    }
+}
+

--- a/crates/cubek-reduce/src/routines/mod.rs
+++ b/crates/cubek-reduce/src/routines/mod.rs
@@ -6,6 +6,8 @@ pub mod unit;
 
 mod base;
 mod blueprint;
+mod cost;
 
 pub use base::*;
 pub use blueprint::*;
+pub use cost::*;


### PR DESCRIPTION
Adds `MatmulCost`, `AttentionCost` and `ReduceCost`: a problem reduced to what its cost depends on, with a `work()` returning the operations and bytes it demands and a `compute_key()` naming the instruction a throughput probe must be measured at. Cheap and infallible, so an autotune bounds generator can build one per launch; a caller holding a full problem gets one through `From`.

Counting here rather than in the consumer is what lets it be tested against the routines it describes. The probe tile in particular has to follow `find_instruction_size`, which selects on the hardware and the m:n aspect ratio and then pads the problem to the tile, so filtering tiles by the problem size would model a decode shape as if it ran unaccelerated.

19 unit tests, no device needed.

Depends on tracel-ai/cubecl#1462 for `Work`.