### PR TITLE
fix(reduce): propagate NaNs in extrema reductions

### DIFF
--- a/crates/cubek-reduce/src/components/instructions/extrema.rs
+++ b/crates/cubek-reduce/src/components/instructions/extrema.rs
@@ -1,0 +1,242 @@
+use super::lowest_coordinate_matching;
+use cubecl::{
+    ir::{Comparison, ElemType, Instruction, Type, UnaryOperands},
+    prelude::*,
+};
+
+// `E: Numeric` can't call the float-only `IsNan` trait even after a comptime type check, so emit
+// the same Cube IR operation directly. Callers keep this inside float-only comptime branches.
+#[cube]
+fn numeric_is_nan<E: Numeric, N: Size>(item: Vector<E, N>) -> Vector<bool, N> {
+    intrinsic!(|scope| {
+        let out_item = Type::scalar(ElemType::Bool).with_vector_size(item.expand.ty.vector_size());
+        let out = scope.create_value(out_item);
+        scope.register(Instruction::new(
+            Comparison::IsNan(UnaryOperands { input: item.expand }),
+            out,
+        ));
+        out.into()
+    })
+}
+
+#[cube]
+pub(crate) fn max_identity<E: Numeric>() -> E {
+    let elem_type = type_of::<E>();
+    if comptime!(elem_type.is_float()) {
+        // WGSL has no infinity literal, so construct it from its IEEE-754 bits.
+        E::cast_from(f32::reinterpret(0xff80_0000u32))
+    } else {
+        E::min_value()
+    }
+}
+
+#[cube]
+pub(crate) fn min_identity<E: Numeric>() -> E {
+    let elem_type = type_of::<E>();
+    if comptime!(elem_type.is_float()) {
+        E::cast_from(f32::reinterpret(0x7f80_0000u32))
+    } else {
+        E::max_value()
+    }
+}
+
+#[cube]
+pub(crate) fn select_max<E: Numeric, N: Size>(
+    current: Vector<E, N>,
+    candidate: Vector<E, N>,
+) -> Vector<E, N> {
+    let elem_type = type_of::<E>();
+    if comptime!(elem_type.is_float()) {
+        let current_is_nan = numeric_is_nan(current);
+        let keep_current = current_is_nan.or(current.greater_than(&candidate));
+        select_many(keep_current, current, candidate)
+    } else {
+        select_many(current.greater_than(&candidate), current, candidate)
+    }
+}
+
+#[cube]
+pub(crate) fn select_min<E: Numeric, N: Size>(
+    current: Vector<E, N>,
+    candidate: Vector<E, N>,
+) -> Vector<E, N> {
+    let elem_type = type_of::<E>();
+    if comptime!(elem_type.is_float()) {
+        let current_is_nan = numeric_is_nan(current);
+        let keep_current = current_is_nan.or(current.less_than(&candidate));
+        select_many(keep_current, current, candidate)
+    } else {
+        select_many(current.less_than(&candidate), current, candidate)
+    }
+}
+
+#[cube]
+pub(crate) fn select_argmax<E: Numeric, N: Size>(
+    current: Vector<E, N>,
+    current_coord: Vector<u32, N>,
+    candidate: Vector<E, N>,
+    candidate_coord: Vector<u32, N>,
+) -> (Vector<E, N>, Vector<u32, N>) {
+    let elem_type = type_of::<E>();
+    let keep_current = if comptime!(elem_type.is_float()) {
+        let current_is_nan = numeric_is_nan(current);
+        let candidate_is_nan = numeric_is_nan(candidate);
+        let tied = current
+            .equal(&candidate)
+            .or(current_is_nan.vec_and(candidate_is_nan));
+
+        select_many(
+            tied,
+            current_coord.less_than(&candidate_coord),
+            current_is_nan.or(current.greater_than(&candidate)),
+        )
+    } else {
+        select_many(
+            current.equal(&candidate),
+            current_coord.less_than(&candidate_coord),
+            current.greater_than(&candidate),
+        )
+    };
+
+    (
+        select_many(keep_current, current, candidate),
+        select_many(keep_current, current_coord, candidate_coord),
+    )
+}
+
+#[cube]
+pub(crate) fn select_argmin<E: Numeric, N: Size>(
+    current: Vector<E, N>,
+    current_coord: Vector<u32, N>,
+    candidate: Vector<E, N>,
+    candidate_coord: Vector<u32, N>,
+) -> (Vector<E, N>, Vector<u32, N>) {
+    let elem_type = type_of::<E>();
+    let keep_current = if comptime!(elem_type.is_float()) {
+        let current_is_nan = numeric_is_nan(current);
+        let candidate_is_nan = numeric_is_nan(candidate);
+        let tied = current
+            .equal(&candidate)
+            .or(current_is_nan.vec_and(candidate_is_nan));
+
+        select_many(
+            tied,
+            current_coord.less_than(&candidate_coord),
+            current_is_nan.or(current.less_than(&candidate)),
+        )
+    } else {
+        select_many(
+            current.equal(&candidate),
+            current_coord.less_than(&candidate_coord),
+            current.less_than(&candidate),
+        )
+    };
+
+    (
+        select_many(keep_current, current, candidate),
+        select_many(keep_current, current_coord, candidate_coord),
+    )
+}
+
+#[cube]
+pub(crate) fn plane_max_propagating_nan<E: Numeric, N: Size>(item: Vector<E, N>) -> Vector<E, N> {
+    let elem_type = type_of::<E>();
+    if comptime!(elem_type.is_float()) {
+        replace_plane_extreme_with_nan(plane_max(item), item)
+    } else {
+        plane_max(item)
+    }
+}
+
+#[cube]
+pub(crate) fn plane_min_propagating_nan<E: Numeric, N: Size>(item: Vector<E, N>) -> Vector<E, N> {
+    let elem_type = type_of::<E>();
+    if comptime!(elem_type.is_float()) {
+        replace_plane_extreme_with_nan(plane_min(item), item)
+    } else {
+        plane_min(item)
+    }
+}
+
+#[cube]
+pub(crate) fn plane_argmax_propagating_nan<E: Numeric, N: Size>(
+    item: Vector<E, N>,
+    coordinate: Vector<u32, N>,
+) -> (Vector<E, N>, Vector<u32, N>) {
+    let ordered_extreme = plane_max(item);
+    let elem_type = type_of::<E>();
+    if comptime!(elem_type.is_float()) {
+        replace_plane_arg_extreme_with_nan(ordered_extreme, item, coordinate)
+    } else {
+        let ordered_coordinate = lowest_coordinate_matching(ordered_extreme, item, coordinate);
+        (ordered_extreme, ordered_coordinate)
+    }
+}
+
+#[cube]
+pub(crate) fn plane_argmin_propagating_nan<E: Numeric, N: Size>(
+    item: Vector<E, N>,
+    coordinate: Vector<u32, N>,
+) -> (Vector<E, N>, Vector<u32, N>) {
+    let ordered_extreme = plane_min(item);
+    let elem_type = type_of::<E>();
+    if comptime!(elem_type.is_float()) {
+        replace_plane_arg_extreme_with_nan(ordered_extreme, item, coordinate)
+    } else {
+        let ordered_coordinate = lowest_coordinate_matching(ordered_extreme, item, coordinate);
+        (ordered_extreme, ordered_coordinate)
+    }
+}
+
+#[cube]
+fn replace_plane_extreme_with_nan<E: Numeric, N: Size>(
+    ordered_extreme: Vector<E, N>,
+    item: Vector<E, N>,
+) -> Vector<E, N> {
+    let is_nan = numeric_is_nan(item);
+    let no_lane = Vector::new(u32::MAX);
+    let nan_lane = plane_min(select_many(is_nan, Vector::new(UNIT_POS_X), no_lane));
+    let has_nan = nan_lane.not_equal(&no_lane);
+    let nan_lane = select_many(has_nan, nan_lane, Vector::new(0u32));
+    // Preserve an input NaN for each vector component; synthesizing one is not portable on WGPU.
+    let nan_item = shuffle_vector(item, nan_lane);
+
+    select_many(has_nan, nan_item, ordered_extreme)
+}
+
+#[cube]
+fn replace_plane_arg_extreme_with_nan<E: Numeric, N: Size>(
+    ordered_extreme: Vector<E, N>,
+    item: Vector<E, N>,
+    coordinate: Vector<u32, N>,
+) -> (Vector<E, N>, Vector<u32, N>) {
+    let ordered_coordinate = lowest_coordinate_matching(ordered_extreme, item, coordinate);
+    let is_nan = numeric_is_nan(item);
+    let no_coordinate = Vector::new(u32::MAX);
+    let nan_coordinate = plane_min(select_many(is_nan, coordinate, no_coordinate));
+    let has_nan = nan_coordinate.not_equal(&no_coordinate);
+    let is_first_nan = is_nan.vec_and(coordinate.equal(&nan_coordinate));
+    let no_lane = Vector::new(u32::MAX);
+    let nan_lane = plane_min(select_many(is_first_nan, Vector::new(UNIT_POS_X), no_lane));
+    let nan_lane = select_many(has_nan, nan_lane, Vector::new(0u32));
+    // Different vector components can choose different source lanes.
+    let nan_item = shuffle_vector(item, nan_lane);
+
+    (
+        select_many(has_nan, nan_item, ordered_extreme),
+        select_many(has_nan, nan_coordinate, ordered_coordinate),
+    )
+}
+
+#[cube]
+fn shuffle_vector<E: Numeric, N: Size>(
+    item: Vector<E, N>,
+    source_lanes: Vector<u32, N>,
+) -> Vector<E, N> {
+    let mut shuffled = Vector::empty();
+    #[unroll]
+    for k in 0..N::value() {
+        shuffled.insert(k, plane_shuffle(item.extract(k), source_lanes.extract(k)));
+    }
+    shuffled
+}

--- a/crates/cubek-reduce/src/components/instructions/max.rs
+++ b/crates/cubek-reduce/src/components/instructions/max.rs
@@ -1,4 +1,7 @@
-use super::{ArgAccumulator, ReduceFamily, ReduceInstruction, lowest_coordinate_matching};
+use super::{
+    ArgAccumulator, ReduceFamily, ReduceInstruction, max_identity, plane_argmax_propagating_nan,
+    plane_max_propagating_nan, select_argmax, select_max,
+};
 use crate::components::{
     instructions::{
         Accumulator, AccumulatorFormat, Item, ReduceOutputMode, ReduceRequirements, ReduceStep,
@@ -9,7 +12,8 @@ use crate::components::{
 use cubecl::prelude::*;
 
 /// Return the maximum item, its coordinate, or both, per [`ReduceOutputMode`].
-/// In case of equality, the lowest coordinate is selected.
+/// NaNs take precedence over non-NaN values. When indices are returned, ties
+/// and multiple NaNs select the lowest coordinate.
 #[derive(Debug, CubeType, Clone)]
 pub struct Max {
     #[cube(comptime)]
@@ -41,28 +45,14 @@ fn max_insert<T: Numeric, N: Size>(
     let acc = elements.item();
 
     match candidate_coord {
-        Value::None => {
-            elements.assign(&Value::new_single(select_many(
-                acc.greater_than(&candidate),
-                acc,
-                candidate,
-            )));
-        }
+        Value::None => elements.assign(&Value::new_single(select_max(acc, candidate))),
         Value::Single(coord) => {
             let candidate_coord = coord.unwrap();
             let acc_coord = coordinates.item();
-            let to_keep = select_many(
-                acc.equal(&candidate),
-                acc_coord.less_than(&candidate_coord),
-                acc.greater_than(&candidate),
-            );
-
-            elements.assign(&Value::new_single(select_many(to_keep, acc, candidate)));
-            coordinates.assign(&Value::new_single(select_many(
-                to_keep,
-                acc_coord,
-                candidate_coord,
-            )));
+            let (selected, selected_coord) =
+                select_argmax(acc, acc_coord, candidate, candidate_coord);
+            elements.assign(&Value::new_single(selected));
+            coordinates.assign(&Value::new_single(selected_coord));
         }
         Value::Multiple(_) => panic!("a max candidate carries at most one coordinate"),
     }
@@ -75,11 +65,10 @@ fn plane_max_candidate<T: Numeric, N: Size>(
     item: Vector<T, N>,
     coordinates: &Value<Vector<u32, N>>,
 ) -> (Vector<T, N>, Value<Vector<u32, N>>) {
-    let winning = plane_max(item);
     match coordinates {
-        Value::None => (winning, Value::new_None()),
+        Value::None => (plane_max_propagating_nan(item), Value::new_None()),
         Value::Single(coord) => {
-            let winning_coord = lowest_coordinate_matching(winning, item, coord.unwrap());
+            let (winning, winning_coord) = plane_argmax_propagating_nan(item, coord.unwrap());
             (winning, Value::new_single(winning_coord))
         }
         Value::Multiple(_) => panic!("a max candidate carries at most one coordinate"),
@@ -106,7 +95,7 @@ impl<P: ReducePrecision> ReduceInstruction<P> for Max {
     }
 
     fn null_input(_this: &Self) -> Vector<P::EI, P::SI> {
-        Vector::empty().fill(P::EI::min_value())
+        Vector::empty().fill(max_identity::<P::EI>())
     }
 
     fn null_accumulator(this: &Self) -> Accumulator<P> {
@@ -117,7 +106,7 @@ impl<P: ReducePrecision> ReduceInstruction<P> for Max {
         };
 
         Accumulator::<P> {
-            elements: Value::new_single(Vector::empty().fill(P::EA::min_value())),
+            elements: Value::new_single(Vector::empty().fill(max_identity::<P::EA>())),
             args,
         }
     }
@@ -174,11 +163,15 @@ impl<P: ReducePrecision> ReduceInstruction<P> for Max {
         match accumulator.args {
             Value::None => {
                 let acc = accumulator.elements.item();
-                let mut max = P::EA::min_value();
+                let mut max = max_identity::<P::EA>();
                 #[unroll]
                 for k in 0..acc.size() {
                     let candidate = acc.extract(k);
-                    max = select(candidate > max, candidate, max);
+                    max = select_max(
+                        Vector::<P::EA, Const<1>>::new(candidate),
+                        Vector::<P::EA, Const<1>>::new(max),
+                    )
+                    .extract(0);
                 }
                 (Value::new_single(Out::cast_from(max)), Value::new_None())
             }
@@ -220,7 +213,7 @@ fn max_finalize_with_coords<P: ReducePrecision>(accumulator: &Accumulator<P>) ->
     let vector_size = accumulator.elements.item().size().comptime();
 
     if vector_size > 1 {
-        let mut max = P::EA::min_value();
+        let mut max = max_identity::<P::EA>();
         let mut coordinate = u32::MAX.runtime();
 
         #[unroll]
@@ -228,14 +221,15 @@ fn max_finalize_with_coords<P: ReducePrecision>(accumulator: &Accumulator<P>) ->
             let acc_element = accumulator.elements.item().extract(k);
             let acc_coordinate = accumulator.args.item().extract(k);
 
-            let take = select(
-                acc_element == max,
-                acc_coordinate < coordinate,
-                acc_element > max,
+            let (selected, selected_coordinate) = select_argmax(
+                Vector::<P::EA, Const<1>>::new(max),
+                Vector::<u32, Const<1>>::new(coordinate),
+                Vector::<P::EA, Const<1>>::new(acc_element),
+                Vector::<u32, Const<1>>::new(acc_coordinate),
             );
 
-            max = select(take, acc_element, max);
-            coordinate = select(take, acc_coordinate, coordinate);
+            max = selected.extract(0);
+            coordinate = selected_coordinate.extract(0);
         }
 
         (max, coordinate)

--- a/crates/cubek-reduce/src/components/instructions/maxabs.rs
+++ b/crates/cubek-reduce/src/components/instructions/maxabs.rs
@@ -1,4 +1,4 @@
-use super::{ReduceFamily, ReduceInstruction};
+use super::{ReduceFamily, ReduceInstruction, plane_max_propagating_nan, select_max};
 use crate::components::{
     instructions::{
         Accumulator, AccumulatorFormat, Item, ReduceOutputMode, ReduceRequirements, ReduceStep,
@@ -8,8 +8,8 @@ use crate::components::{
 };
 use cubecl::prelude::*;
 
-// TODO Add to test framework.
-/// Return the item with the maximum absolute value.
+/// Return the item with the maximum absolute value. NaNs take precedence over
+/// non-NaN values.
 #[derive(Debug, CubeType, Clone)]
 pub struct MaxAbs;
 
@@ -55,20 +55,13 @@ impl<P: ReducePrecision> ReduceInstruction<P> for MaxAbs {
         let accumulator_item = accumulator.elements.item();
         let elements = match reduce_step {
             ReduceStep::Plane => {
-                let candidate_item = Vector::cast_from(plane_max(Vector::abs(item.elements)));
-                select_many(
-                    accumulator_item.greater_than(&candidate_item),
-                    accumulator_item,
-                    candidate_item,
-                )
+                let candidate_item =
+                    Vector::cast_from(plane_max_propagating_nan(Vector::abs(item.elements)));
+                select_max(accumulator_item, candidate_item)
             }
             ReduceStep::Identity => {
                 let item_abs = Vector::cast_from(Vector::abs(item.elements));
-                select_many(
-                    accumulator_item.greater_than(&item_abs),
-                    accumulator_item,
-                    item_abs,
-                )
+                select_max(accumulator_item, item_abs)
             }
         };
 
@@ -79,21 +72,14 @@ impl<P: ReducePrecision> ReduceInstruction<P> for MaxAbs {
         let accumulator_item = accumulator.elements.item();
         let other_item = other.elements.item();
 
-        accumulator.elements.assign(&Value::new_single(select_many(
-            accumulator_item.greater_than(&other_item),
-            accumulator_item,
-            other_item,
-        )));
+        let selected = select_max(accumulator_item, other_item);
+        accumulator.elements.assign(&Value::new_single(selected));
     }
 
     fn plane_reduce_inplace(_this: &Self, accumulator: &mut Accumulator<P>) {
         let acc_item = accumulator.elements.item();
-        let candidate_item = Vector::cast_from(plane_max(Vector::abs(acc_item)));
-        let max = select_many(
-            acc_item.greater_than(&candidate_item),
-            acc_item,
-            candidate_item,
-        );
+        let candidate_item = Vector::cast_from(plane_max_propagating_nan(Vector::abs(acc_item)));
+        let max = select_max(acc_item, candidate_item);
         accumulator.elements.assign(&Value::new_single(max));
     }
 
@@ -111,7 +97,11 @@ impl<P: ReducePrecision> ReduceInstruction<P> for MaxAbs {
         #[unroll]
         for k in 0..accumulator.size() {
             let candidate = accumulator.extract(k);
-            max = select(candidate > max, candidate, max);
+            max = select_max(
+                Vector::<P::EA, Const<1>>::new(candidate),
+                Vector::<P::EA, Const<1>>::new(max),
+            )
+            .extract(0);
         }
         (Value::new_single(Out::cast_from(max)), Value::new_None())
     }

--- a/crates/cubek-reduce/src/components/instructions/min.rs
+++ b/crates/cubek-reduce/src/components/instructions/min.rs
@@ -1,4 +1,7 @@
-use super::{ArgAccumulator, ReduceFamily, ReduceInstruction, lowest_coordinate_matching};
+use super::{
+    ArgAccumulator, ReduceFamily, ReduceInstruction, min_identity, plane_argmin_propagating_nan,
+    plane_min_propagating_nan, select_argmin, select_min,
+};
 use crate::components::{
     instructions::{
         Accumulator, AccumulatorFormat, Item, ReduceOutputMode, ReduceRequirements, ReduceStep,
@@ -9,7 +12,8 @@ use crate::components::{
 use cubecl::prelude::*;
 
 /// Return the minimum item, its coordinate, or both, per [`ReduceOutputMode`].
-/// In case of equality, the lowest coordinate is selected.
+/// NaNs take precedence over non-NaN values. When indices are returned, ties
+/// and multiple NaNs select the lowest coordinate.
 #[derive(Debug, CubeType, Clone)]
 pub struct Min {
     #[cube(comptime)]
@@ -41,28 +45,14 @@ fn min_insert<T: Numeric, N: Size>(
     let acc = elements.item();
 
     match candidate_coord {
-        Value::None => {
-            elements.assign(&Value::new_single(select_many(
-                acc.less_than(&candidate),
-                acc,
-                candidate,
-            )));
-        }
+        Value::None => elements.assign(&Value::new_single(select_min(acc, candidate))),
         Value::Single(coord) => {
             let candidate_coord = coord.unwrap();
             let acc_coord = coordinates.item();
-            let to_keep = select_many(
-                acc.equal(&candidate),
-                acc_coord.less_than(&candidate_coord),
-                acc.less_than(&candidate),
-            );
-
-            elements.assign(&Value::new_single(select_many(to_keep, acc, candidate)));
-            coordinates.assign(&Value::new_single(select_many(
-                to_keep,
-                acc_coord,
-                candidate_coord,
-            )));
+            let (selected, selected_coord) =
+                select_argmin(acc, acc_coord, candidate, candidate_coord);
+            elements.assign(&Value::new_single(selected));
+            coordinates.assign(&Value::new_single(selected_coord));
         }
         Value::Multiple(_) => panic!("a min candidate carries at most one coordinate"),
     }
@@ -75,11 +65,10 @@ fn plane_min_candidate<T: Numeric, N: Size>(
     item: Vector<T, N>,
     coordinates: &Value<Vector<u32, N>>,
 ) -> (Vector<T, N>, Value<Vector<u32, N>>) {
-    let winning = plane_min(item);
     match coordinates {
-        Value::None => (winning, Value::new_None()),
+        Value::None => (plane_min_propagating_nan(item), Value::new_None()),
         Value::Single(coord) => {
-            let winning_coord = lowest_coordinate_matching(winning, item, coord.unwrap());
+            let (winning, winning_coord) = plane_argmin_propagating_nan(item, coord.unwrap());
             (winning, Value::new_single(winning_coord))
         }
         Value::Multiple(_) => panic!("a min candidate carries at most one coordinate"),
@@ -106,7 +95,7 @@ impl<P: ReducePrecision> ReduceInstruction<P> for Min {
     }
 
     fn null_input(_this: &Self) -> Vector<P::EI, P::SI> {
-        Vector::empty().fill(P::EI::max_value())
+        Vector::empty().fill(min_identity::<P::EI>())
     }
 
     fn null_accumulator(this: &Self) -> Accumulator<P> {
@@ -117,7 +106,7 @@ impl<P: ReducePrecision> ReduceInstruction<P> for Min {
         };
 
         Accumulator::<P> {
-            elements: Value::new_single(Vector::empty().fill(P::EA::max_value())),
+            elements: Value::new_single(Vector::empty().fill(min_identity::<P::EA>())),
             args,
         }
     }
@@ -174,11 +163,15 @@ impl<P: ReducePrecision> ReduceInstruction<P> for Min {
         match accumulator.args {
             Value::None => {
                 let acc = accumulator.elements.item();
-                let mut min = P::EA::max_value();
+                let mut min = min_identity::<P::EA>();
                 #[unroll]
                 for k in 0..acc.size() {
                     let candidate = acc.extract(k);
-                    min = select(candidate < min, candidate, min);
+                    min = select_min(
+                        Vector::<P::EA, Const<1>>::new(candidate),
+                        Vector::<P::EA, Const<1>>::new(min),
+                    )
+                    .extract(0);
                 }
                 (Value::new_single(Out::cast_from(min)), Value::new_None())
             }
@@ -220,7 +213,7 @@ fn min_finalize_with_coords<P: ReducePrecision>(accumulator: &Accumulator<P>) ->
     let vector_size = accumulator.elements.item().size().comptime();
 
     if vector_size > 1 {
-        let mut min = P::EA::max_value();
+        let mut min = min_identity::<P::EA>();
         let mut coordinate = u32::MAX.runtime();
 
         #[unroll]
@@ -228,14 +221,15 @@ fn min_finalize_with_coords<P: ReducePrecision>(accumulator: &Accumulator<P>) ->
             let acc_element = accumulator.elements.item().extract(k);
             let acc_coordinate = accumulator.args.item().extract(k);
 
-            let take = select(
-                acc_element == min,
-                acc_coordinate < coordinate,
-                acc_element < min,
+            let (selected, selected_coordinate) = select_argmin(
+                Vector::<P::EA, Const<1>>::new(min),
+                Vector::<u32, Const<1>>::new(coordinate),
+                Vector::<P::EA, Const<1>>::new(acc_element),
+                Vector::<u32, Const<1>>::new(acc_coordinate),
             );
 
-            min = select(take, acc_element, min);
-            coordinate = select(take, acc_coordinate, coordinate);
+            min = selected.extract(0);
+            coordinate = selected_coordinate.extract(0);
         }
 
         (min, coordinate)

--- a/crates/cubek-reduce/src/components/instructions/mod.rs
+++ b/crates/cubek-reduce/src/components/instructions/mod.rs
@@ -1,6 +1,7 @@
 mod all;
 mod any;
 mod base;
+mod extrema;
 mod max;
 mod maxabs;
 mod mean;
@@ -14,6 +15,7 @@ mod utils;
 pub use all::*;
 pub use any::*;
 pub use base::*;
+pub(crate) use extrema::*;
 pub use max::*;
 pub use maxabs::*;
 pub use mean::*;

--- a/crates/cubek-reduce/src/eval/cpu_reference/argmax.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/argmax.rs
@@ -1,6 +1,6 @@
 use cubek_test_utils::{HostData, Progress};
 
-use super::{build_f32_output, for_each_output_coord, output_shape};
+use super::{build_f32_output, for_each_output_coord, output_shape, should_replace_max};
 
 pub fn reference_argmax(input: &HostData, axis: usize, progress: Option<&Progress>) -> HostData {
     let axis_len = input.shape[axis];
@@ -14,7 +14,7 @@ pub fn reference_argmax(input: &HostData, axis: usize, progress: Option<&Progres
         for i in 0..axis_len {
             coord[axis] = i;
             let v = input.get_f32(&coord);
-            if v > best {
+            if should_replace_max(best, v) {
                 best = v;
                 best_idx = i as u32;
             }

--- a/crates/cubek-reduce/src/eval/cpu_reference/argmin.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/argmin.rs
@@ -1,6 +1,6 @@
 use cubek_test_utils::{HostData, Progress};
 
-use super::{build_f32_output, for_each_output_coord, output_shape};
+use super::{build_f32_output, for_each_output_coord, output_shape, should_replace_min};
 
 pub fn reference_argmin(input: &HostData, axis: usize, progress: Option<&Progress>) -> HostData {
     let axis_len = input.shape[axis];
@@ -14,7 +14,7 @@ pub fn reference_argmin(input: &HostData, axis: usize, progress: Option<&Progres
         for i in 0..axis_len {
             coord[axis] = i;
             let v = input.get_f32(&coord);
-            if v < best {
+            if should_replace_min(best, v) {
                 best = v;
                 best_idx = i as u32;
             }

--- a/crates/cubek-reduce/src/eval/cpu_reference/max.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/max.rs
@@ -1,6 +1,6 @@
 use cubek_test_utils::{HostData, Progress};
 
-use super::{build_f32_output, for_each_output_coord, output_shape};
+use super::{build_f32_output, for_each_output_coord, output_shape, should_replace_max};
 
 pub fn reference_max(input: &HostData, axis: usize, progress: Option<&Progress>) -> HostData {
     let axis_len = input.shape[axis];
@@ -13,7 +13,7 @@ pub fn reference_max(input: &HostData, axis: usize, progress: Option<&Progress>)
         for i in 0..axis_len {
             coord[axis] = i;
             let v = input.get_f32(&coord);
-            if v > best {
+            if should_replace_max(best, v) {
                 best = v;
             }
         }

--- a/crates/cubek-reduce/src/eval/cpu_reference/max_abs.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/max_abs.rs
@@ -1,6 +1,6 @@
 use cubek_test_utils::{HostData, Progress};
 
-use super::{build_f32_output, for_each_output_coord, output_shape};
+use super::{build_f32_output, for_each_output_coord, output_shape, should_replace_max};
 
 pub fn reference_max_abs(input: &HostData, axis: usize, progress: Option<&Progress>) -> HostData {
     let axis_len = input.shape[axis];
@@ -13,7 +13,7 @@ pub fn reference_max_abs(input: &HostData, axis: usize, progress: Option<&Progre
         for i in 0..axis_len {
             coord[axis] = i;
             let v = input.get_f32(&coord).abs();
-            if v > best {
+            if should_replace_max(best, v) {
                 best = v;
             }
         }

--- a/crates/cubek-reduce/src/eval/cpu_reference/min.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/min.rs
@@ -1,6 +1,6 @@
 use cubek_test_utils::{HostData, Progress};
 
-use super::{build_f32_output, for_each_output_coord, output_shape};
+use super::{build_f32_output, for_each_output_coord, output_shape, should_replace_min};
 
 pub fn reference_min(input: &HostData, axis: usize, progress: Option<&Progress>) -> HostData {
     let axis_len = input.shape[axis];
@@ -13,7 +13,7 @@ pub fn reference_min(input: &HostData, axis: usize, progress: Option<&Progress>)
         for i in 0..axis_len {
             coord[axis] = i;
             let v = input.get_f32(&coord);
-            if v < best {
+            if should_replace_min(best, v) {
                 best = v;
             }
         }

--- a/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
@@ -258,6 +258,14 @@ pub(crate) fn output_shape(input_shape: &Shape, axis: usize) -> Vec<usize> {
     out
 }
 
+pub(super) fn should_replace_max(current: f32, candidate: f32) -> bool {
+    !current.is_nan() && (candidate.is_nan() || candidate > current)
+}
+
+pub(super) fn should_replace_min(current: f32, candidate: f32) -> bool {
+    !current.is_nan() && (candidate.is_nan() || candidate < current)
+}
+
 pub(crate) fn for_each_output_coord(output_shape: &[usize], mut f: impl FnMut(usize, &[usize])) {
     let rank = output_shape.len();
     if rank == 0 {

--- a/crates/cubek-reduce/tests/reduce/it/mod.rs
+++ b/crates/cubek-reduce/tests/reduce/it/mod.rs
@@ -2,6 +2,7 @@ mod test_case;
 
 mod argtopk_shared_memory;
 mod logical;
+mod nan_extrema;
 mod topk_with_indices_cube;
 mod with_indices_validation;
 

--- a/crates/cubek-reduce/tests/reduce/it/nan_extrema.rs
+++ b/crates/cubek-reduce/tests/reduce/it/nan_extrema.rs
@@ -1,0 +1,258 @@
+use cubecl::{
+    Runtime, TestRuntime,
+    config::autotune::AutotuneLevel,
+    features::{Plane, TypeUsage},
+    frontend::CubePrimitive,
+    zspace::{Shape, Strides},
+};
+use cubek_reduce::{
+    ReduceStrategy,
+    launch::{RoutineStrategy, VectorizationStrategy},
+    routines::{BlueprintStrategy, plane::PlaneStrategy, unit::UnitStrategy},
+};
+
+use super::test_case::TestCase;
+
+fn supports_plane() -> bool {
+    let client = TestRuntime::client(&Default::default());
+    client.properties().features.plane.contains(Plane::Ops)
+}
+
+fn supports_f16_arithmetic() -> bool {
+    let client = TestRuntime::client(&Default::default());
+    half::f16::supported_uses(&client).contains(TypeUsage::Arithmetic)
+}
+
+fn run_extrema(case: TestCase, data: Vec<f32>) {
+    let case = case.with_data(data);
+    case.test_max();
+    case.test_min();
+    case.test_max_abs();
+    case.test_argmax();
+    case.test_argmin();
+    case.test_max_with_indices();
+    case.test_min_with_indices();
+}
+
+fn run_nan_extrema(case: TestCase) {
+    let data = nan_extrema_data(&case.shape, case.axis.unwrap());
+    run_extrema(case, data);
+}
+
+fn strategy(routine: RoutineStrategy, parallel_output_vectorization: bool) -> ReduceStrategy {
+    ReduceStrategy {
+        autotune_level: AutotuneLevel::Full,
+        vectorization: VectorizationStrategy {
+            parallel_output_vectorization,
+        },
+        routine,
+    }
+}
+
+fn unit_case(shape: Shape, strides: Strides, axis: usize) -> TestCase {
+    TestCase::new::<f32>(
+        shape,
+        strides,
+        Some(axis),
+        strategy(
+            RoutineStrategy::Unit(BlueprintStrategy::Inferred(UnitStrategy)),
+            false,
+        ),
+    )
+}
+
+fn plane_case(
+    shape: Shape,
+    strides: Strides,
+    axis: usize,
+    independent: bool,
+    vectorize_output: bool,
+) -> TestCase {
+    TestCase::new::<f32>(
+        shape,
+        strides,
+        Some(axis),
+        strategy(
+            RoutineStrategy::Plane(BlueprintStrategy::Inferred(PlaneStrategy { independent })),
+            vectorize_output,
+        ),
+    )
+}
+
+#[test]
+fn unit_parallel_f32() {
+    run_nan_extrema(unit_case(Shape::new([9, 64]), Strides::new(&[64, 1]), 1));
+}
+
+#[test]
+fn plane_parallel_f32() {
+    if !supports_plane() {
+        return;
+    }
+    run_nan_extrema(plane_case(
+        Shape::new([9, 64]),
+        Strides::new(&[64, 1]),
+        1,
+        false,
+        true,
+    ));
+}
+
+#[test]
+fn plane_perpendicular_f32() {
+    if !supports_plane() {
+        return;
+    }
+    run_nan_extrema(plane_case(
+        Shape::new([64, 9]),
+        Strides::new(&[9, 1]),
+        0,
+        false,
+        true,
+    ));
+}
+
+#[test]
+fn plane_strided_f32() {
+    if !supports_plane() {
+        return;
+    }
+    run_nan_extrema(plane_case(
+        Shape::new([9, 64]),
+        Strides::new(&[128, 2]),
+        1,
+        true,
+        false,
+    ));
+}
+
+#[test]
+fn plane_parallel_f16() {
+    if !supports_plane() || !supports_f16_arithmetic() {
+        return;
+    }
+    run_nan_extrema(TestCase::new::<half::f16>(
+        Shape::new([9, 64]),
+        Strides::new(&[64, 1]),
+        Some(1),
+        strategy(
+            RoutineStrategy::Plane(BlueprintStrategy::Inferred(PlaneStrategy {
+                independent: true,
+            })),
+            true,
+        ),
+    ));
+}
+
+#[test]
+fn integer_extrema_control_i32() {
+    if !supports_plane() {
+        return;
+    }
+    let shape = Shape::new([9, 64]);
+    let data = integer_extrema_data(&shape);
+    let case = TestCase::new::<i32>(
+        shape,
+        Strides::new(&[64, 1]),
+        Some(1),
+        strategy(
+            RoutineStrategy::Plane(BlueprintStrategy::Inferred(PlaneStrategy {
+                independent: true,
+            })),
+            true,
+        ),
+    );
+    run_extrema(case, data);
+}
+
+#[test]
+fn unit_singleton_f32() {
+    run_nan_extrema(unit_case(Shape::new([9, 1]), Strides::new(&[1, 1]), 1));
+}
+
+#[test]
+fn unit_infinite_identities_f32() {
+    let case = |value| {
+        unit_case(Shape::new([2, 64]), Strides::new(&[64, 1]), 1).with_data(vec![value; 128])
+    };
+
+    let max = case(f32::NEG_INFINITY);
+    max.test_max();
+    max.test_argmax();
+    max.test_max_with_indices();
+
+    let min = case(f32::INFINITY);
+    min.test_min();
+    min.test_argmin();
+    min.test_min_with_indices();
+}
+
+#[cfg(feature = "heavy")]
+mod heavy {
+    use cubek_reduce::routines::cube::CubeStrategy;
+
+    use super::*;
+
+    fn case(use_planes: bool) -> TestCase {
+        TestCase::new::<f32>(
+            Shape::new([9, 256]),
+            Strides::new(&[256, 1]),
+            Some(1),
+            strategy(
+                RoutineStrategy::Cube(BlueprintStrategy::Inferred(CubeStrategy { use_planes })),
+                true,
+            ),
+        )
+    }
+
+    #[test]
+    fn cube_f32() {
+        run_nan_extrema(case(false));
+    }
+
+    #[test]
+    fn cube_with_planes_f32() {
+        if !supports_plane() {
+            return;
+        }
+        run_nan_extrema(case(true));
+    }
+}
+
+fn nan_extrema_data(shape: &Shape, axis: usize) -> Vec<f32> {
+    let axis_len = shape[axis];
+    let inner_len = shape.iter().skip(axis + 1).product::<usize>();
+    let num_elements = shape.iter().product::<usize>();
+
+    (0..num_elements)
+        .map(|linear| {
+            let axis_coordinate = (linear / inner_len) % axis_len;
+            let outer = linear / (inner_len * axis_len);
+            let inner = linear % inner_len;
+            let slice = outer * inner_len + inner;
+            let base = (axis_coordinate % 7) as f32 - 3.0 + (slice % 3) as f32 * 0.125;
+
+            match slice % 9 {
+                0 if axis_coordinate == axis_len / 2 => f32::NAN,
+                1 if axis_coordinate == 0 => f32::NAN,
+                2 if axis_coordinate + 1 == axis_len => f32::NAN,
+                3 if axis_coordinate == axis_len / 3 || axis_coordinate == (2 * axis_len) / 3 => {
+                    f32::NAN
+                }
+                4 => f32::NAN,
+                5 if axis_coordinate == 0 || axis_coordinate + 1 == axis_len => 9.0,
+                6 if axis_coordinate == 0 || axis_coordinate + 1 == axis_len => -9.0,
+                7 if axis_coordinate == 0 => f32::NEG_INFINITY,
+                7 if axis_coordinate + 1 == axis_len => f32::INFINITY,
+                7 if axis_coordinate == axis_len / 2 => f32::NAN,
+                _ => base,
+            }
+        })
+        .collect()
+}
+
+fn integer_extrema_data(shape: &Shape) -> Vec<f32> {
+    (0..shape.iter().product())
+        .map(|linear| ((linear * 17) % 31) as f32 - 15.0)
+        .collect()
+}

--- a/crates/cubek-reduce/tests/reduce/it/test_case.rs
+++ b/crates/cubek-reduce/tests/reduce/it/test_case.rs
@@ -27,6 +27,7 @@ pub struct TestCase {
     pub strategy: ReduceStrategy,
     pub input_dtype: StorageType,
     pub accumulation_dtype: StorageType,
+    custom_input: Option<Vec<f32>>,
 }
 
 impl core::fmt::Debug for TestCase {
@@ -60,7 +61,15 @@ impl TestCase {
             strategy,
             input_dtype: <P::EI as CubePrimitive>::as_type_native_unchecked().storage_type(),
             accumulation_dtype: <P::EA as CubePrimitive>::as_type_native_unchecked().storage_type(),
+            custom_input: None,
         }
+    }
+
+    /// Use explicit regression data. Custom cases must execute even when the default matrix-test
+    /// policy permits unsupported generated configurations to fail compilation.
+    pub fn with_data(mut self, data: Vec<f32>) -> Self {
+        self.custom_input = Some(data);
+        self
     }
 
     pub fn test_sum(&self) {
@@ -235,13 +244,16 @@ impl TestCase {
         let axis = self.axis.unwrap();
         let u32_dtype = u32::as_type_native_unchecked().storage_type();
 
-        let (input_handle, input_host) = TestInput::builder(client.clone(), self.shape.clone())
+        let input = TestInput::builder(client.clone(), self.shape.clone())
             .dtype(self.input_dtype)
             .layout(StridedLayout::Explicit(
                 self.stride.iter().copied().collect(),
-            ))
-            .random(1234, Distribution::Uniform(-1., 1.))
-            .generate_with_f32_host_data();
+            ));
+        let input = match &self.custom_input {
+            Some(data) => input.custom(data.clone()),
+            None => input.random(1234, Distribution::Uniform(-1., 1.)),
+        };
+        let (input_handle, input_host) = input.generate_with_f32_host_data();
 
         let expected_values =
             cast_host_through_dtype(values_reference(&input_host, axis), self.input_dtype);
@@ -297,7 +309,7 @@ impl TestCase {
             }
             ExecutionOutcome::CompileError(e) => TestOutcome::CompileError(e),
         };
-        outcome.enforce();
+        self.enforce_outcome(outcome);
     }
 
     fn run_reduce_test(
@@ -327,13 +339,16 @@ impl TestCase {
         let client = TestRuntime::client(&Default::default());
         let axis = self.axis.unwrap();
 
-        let (input_handle, input_host) = TestInput::builder(client.clone(), self.shape.clone())
+        let input = TestInput::builder(client.clone(), self.shape.clone())
             .dtype(self.input_dtype)
             .layout(StridedLayout::Explicit(
                 self.stride.iter().copied().collect(),
-            ))
-            .random(1234, distribution)
-            .generate_with_f32_host_data();
+            ));
+        let input = match &self.custom_input {
+            Some(data) => input.custom(data.clone()),
+            None => input.random(1234, distribution),
+        };
+        let (input_handle, input_host) = input.generate_with_f32_host_data();
 
         let expected = cast_host_through_dtype(reference(&input_host, axis), output_dtype);
 
@@ -369,6 +384,20 @@ impl TestCase {
             }
             ExecutionOutcome::CompileError(e) => TestOutcome::CompileError(e),
         };
+        self.enforce_outcome(outcome);
+    }
+
+    fn enforce_outcome(&self, outcome: TestOutcome) {
+        if self.custom_input.is_some() {
+            assert!(
+                !matches!(
+                    &outcome,
+                    TestOutcome::CompileError(_)
+                        | TestOutcome::Validated(ValidationResult::Skipped(_))
+                ),
+                "expected custom reduction case to execute and validate, got {outcome:?}"
+            );
+        }
         outcome.enforce();
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #430 for the extrema behavior tracked in tracel-ai/burn#4814.

This makes `max`, `min`, `argmax`, `argmin`, and `max_abs` propagate NaNs consistently across Cubek reduction strategies. Indexed reductions select the lowest coordinate when multiple NaNs are present, preserving the existing lowest-index tie behavior.

## Root cause

Ordered comparisons with NaN are always false, so the previous comparison helpers could keep or discard a NaN depending on operand order. Plane reductions could also lose NaNs through subgroup extrema operations. Floating-point reduction identities used finite values, which made real infinities tie with the identity sentinel in indexed reductions.

## Changes

- Centralize float extrema selection and indexed tie behavior in a private `extrema` module shared by Max, Min, and MaxAbs.
- Propagate an actual input NaN through plane reductions and select the lowest NaN coordinate for indexed reductions.
- Use positive and negative infinity as floating-point extrema identities while preserving the existing integer identities and comparison paths behind compile-time branches.
- Update the independent CPU references and add focused coverage for unit, plane, Cube, fused, vectorized, all-NaN, mixed-NaN, infinity, and finite-tie cases.

This does not change the public API or TopK behavior. No benchmark result is claimed by this PR.

## Validation

Cubek:

- `cargo fmt --all --check`
- `cargo xtask check lint`
- `cargo xtask doc build`
- `cargo xtask doc tests`
- `cargo xtask test --ci`
- `cargo test-wgpu -p cubek-reduce --test reduce nan_extrema -- --nocapture` — 10 passed, 0 failed

Burn was also validated locally against this Cubek commit:

- `cargo run-checks`
- WGPU with fusion on macOS
- WGPU with fusion on an NVIDIA RTX 4070 SUPER Linux host — 24 NaN tests, 6 whole-extrema tests, and the lowest-index tie test passed

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here.

Burn PR: tracel-ai/burn#5290.
