### PR TITLE
update cubecl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.1"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "b2703c28b3e395793157f3891e8c0827cae4dbb8", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "b2703c28b3e395793157f3891e8c0827cae4dbb8", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "b2703c28b3e395793157f3891e8c0827cae4dbb8", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "c1013b1880a4639a609318847bf608f3ebd1e0eb", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "c1013b1880a4639a609318847bf608f3ebd1e0eb", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "c1013b1880a4639a609318847bf608f3ebd1e0eb", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.1", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.1", default-features = false }

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,3 @@
 [default.extend-words]
 arange = "arange"
+Cpy = "Cpy"

--- a/crates/cubek-matmul/src/components/global/memory/layout.rs
+++ b/crates/cubek-matmul/src/components/global/memory/layout.rs
@@ -268,6 +268,10 @@ impl<R: Runtime> GlobalLayoutLaunch<R> {
                         (block_row as u32, block_col as u32),
                     ))
                 }
+                QuantLevel::BlockTensor { .. } => unimplemented!(
+                    "two-level quantization is not supported by the quantized matmul, got {:?}",
+                    scheme.level
+                ),
             }
         };
 

--- a/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/benchmark.rs
@@ -131,6 +131,10 @@ fn scales_shape(scheme: &QuantScheme, shape: &[usize]) -> Vec<usize> {
                 .map(|(d, b)| d / (*b as usize))
                 .collect()
         }
+        QuantLevel::BlockTensor { .. } => unimplemented!(
+            "two-level quantization is not supported here, got {:?}",
+            scheme.level
+        ),
     }
 }
 

--- a/crates/cubek-quant/src/layout/scales.rs
+++ b/crates/cubek-quant/src/layout/scales.rs
@@ -236,6 +236,10 @@ pub fn scales_layout<R: Runtime>(
                 scales_vector_size,
             ))
         }
+        QuantLevel::BlockTensor { .. } => unimplemented!(
+            "two-level quantization is not supported here, got {:?}",
+            scheme.level
+        ),
     }
 }
 

--- a/crates/cubek-test-utils/src/stubs/quant.rs
+++ b/crates/cubek-test-utils/src/stubs/quant.rs
@@ -188,6 +188,10 @@ pub(crate) fn block_dims(scheme: &QuantScheme, shape: &[usize]) -> Vec<usize> {
             .iter()
             .map(|&b| b as usize)
             .collect(),
+        QuantLevel::BlockTensor { .. } => unimplemented!(
+            "two-level quantization is not supported here, got {:?}",
+            scheme.level
+        ),
     }
 }
 

--- a/crates/cubek-test-utils/src/test_tensor/quant.rs
+++ b/crates/cubek-test-utils/src/test_tensor/quant.rs
@@ -159,6 +159,10 @@ fn compute_input_scales(host: &HostData, scheme: &QuantScheme) -> (Shape, Vec<f3
             }
             scales
         }
+        QuantLevel::BlockTensor { .. } => unimplemented!(
+            "two-level quantization is not supported here, got {:?}",
+            scheme.level
+        ),
     };
 
     (scales_shape, scales, block_dims)

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -111,7 +111,10 @@ pub(crate) fn block_edges(scheme: QuantScheme, rank: usize) -> Vec<usize> {
         QuantLevel::Tensor => vec![1; rank],
         QuantLevel::Block(bs) => bs.to_dim_vec(rank).iter().map(|&b| b as usize).collect(),
         QuantLevel::BlockTensor { .. } => {
-            unimplemented!("two-level quantization is not supported here, got {:?}", scheme.level)
+            unimplemented!(
+                "two-level quantization is not supported here, got {:?}",
+                scheme.level
+            )
         }
     }
 }

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -110,6 +110,9 @@ pub(crate) fn block_edges(scheme: QuantScheme, rank: usize) -> Vec<usize> {
     match scheme.level {
         QuantLevel::Tensor => vec![1; rank],
         QuantLevel::Block(bs) => bs.to_dim_vec(rank).iter().map(|&b| b as usize).collect(),
+        QuantLevel::BlockTensor { .. } => {
+            unimplemented!("two-level quantization is not supported here, got {:?}", scheme.level)
+        }
     }
 }
 


### PR DESCRIPTION
Also makes sure the new QuantLevel::BlockTensor is gated behind unimplemented guards so it can compile.