### PR TITLE
update cubecl for constant bitcasts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.1"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/jcwal1516/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
-cubecl-common = { git = "https://github.com/jcwal1516/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
-cubecl-environment = { git = "https://github.com/jcwal1516/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.1", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.1"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "5d5af999d1c077d3f68211060eaa2293a47fcdeb", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "5d5af999d1c077d3f68211060eaa2293a47fcdeb", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "5d5af999d1c077d3f68211060eaa2293a47fcdeb", default-features = false }
+cubecl = { git = "https://github.com/jcwal1516/cubecl", rev = "e69fb79d65d51c24b9f35c3a0b39f94ded71c3c4", default-features = false }
+cubecl-common = { git = "https://github.com/jcwal1516/cubecl", rev = "e69fb79d65d51c24b9f35c3a0b39f94ded71c3c4", default-features = false }
+cubecl-environment = { git = "https://github.com/jcwal1516/cubecl", rev = "e69fb79d65d51c24b9f35c3a0b39f94ded71c3c4", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.1", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.1"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/jcwal1516/cubecl", rev = "e69fb79d65d51c24b9f35c3a0b39f94ded71c3c4", default-features = false }
-cubecl-common = { git = "https://github.com/jcwal1516/cubecl", rev = "e69fb79d65d51c24b9f35c3a0b39f94ded71c3c4", default-features = false }
-cubecl-environment = { git = "https://github.com/jcwal1516/cubecl", rev = "e69fb79d65d51c24b9f35c3a0b39f94ded71c3c4", default-features = false }
+cubecl = { git = "https://github.com/jcwal1516/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
+cubecl-common = { git = "https://github.com/jcwal1516/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
+cubecl-environment = { git = "https://github.com/jcwal1516/cubecl", rev = "8bf94c00903c0009981aadf83ca4f664ca968256", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.1", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.1", default-features = false }


### PR DESCRIPTION
## Summary

Update CubeCL to tracel-ai/cubecl#1477 so constant bitcasts are materialized as lvalues in the C++ dialects. This restores CUDA, HIP, and Metal source generation for the infinity reduction identities introduced by #457.

Depends on tracel-ai/cubecl#1477.
Related to #457.

## Testing

- `cargo fmt --all --check` — passed.
- `cargo xtask check lint` — passed.
- `cargo xtask doc build` — passed with the existing rustdoc link warnings.
- `cargo xtask doc tests` — passed; 6 ignored, 0 failed.
- `cargo xtask test --ci` — 8,413 passed and 24 TopK-with-indices cases failed. An exact failing case also fails on untouched `origin/main` at `de661419` with CubeCL `5d5af999`, confirming the failures are pre-existing and unrelated to this pin.
- `cargo test-cuda -p cubek-reduce --test lib nan_extrema --locked -- --nocapture --test-threads=1` — 10 passed, 0 failed on an NVIDIA GeForce RTX 4070 SUPER.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
