### PR TITLE
Read a gathered operand as a matrix through GroupedMatrix

### DIFF
--- a/crates/cubek-tile/src/fold.rs
+++ b/crates/cubek-tile/src/fold.rs
@@ -239,6 +239,21 @@ impl<C: Int> Coords<C> {
     }
 }
 
+/// Converts a comptime list of extents into constant [`Coords<u32>`].
+#[cube]
+// `#[unroll]` needs a range loop; an iterator has no expansion.
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn const_coords(#[comptime] values: Vec<usize>) -> Coords<u32> {
+    let mut out = Coords::<u32>::new();
+
+    #[unroll]
+    for p in 0..comptime!(values.len()) {
+        out.push(comptime!(values[p] as u32).runtime());
+    }
+
+    out
+}
+
 pub struct CoordsExpand<C: Int> {
     values: Vec<NativeExpand<C>>,
 }

--- a/crates/cubek-tile/src/ops/matmul/instruction/base.rs
+++ b/crates/cubek-tile/src/ops/matmul/instruction/base.rs
@@ -8,9 +8,11 @@ use cubecl::prelude::*;
 use super::register::mma_register_memory;
 use crate::*;
 
-/// What the cmma leaf's 2-D single-`K` deduction rules out.
-const PLANE_2D: &str = "mma: a cmma leaf reads one contracted axis off a directly addressed \
-                        operand; a gather-reduce runs on the manual-mma or register leaf";
+/// What a strided-window fragment's 2-D single-`K` deduction rules out.
+const STRIDED_2D: &str = "mma: a cmma or plane-register fragment reads one contracted axis off a \
+                          directly addressed operand; a gather or a wider reduce needs the \
+                          manual-mma leaf, or an unpromoted Gmem/Smem accumulator, whose software \
+                          microkernel is the `mma_register_memory` arm below";
 
 /// The leaf contraction `acc += lhs · rhs`. Dispatch is dynamic on the accumulator's comptime
 /// storage config
@@ -21,40 +23,28 @@ pub(crate) fn mma_leaf<E: Numeric, EL: Numeric, ER: Numeric>(
     rhs: &Tile<ER>,
 ) {
     let space = comptime!(acc.space.clone());
-    // A gather-reduce runs on any leaf that addresses its operands *through a view*: the register
-    // microkernel's N-D nest, and the manual-mma leaf, whose fragment load reads element by element
-    // through `Tile::fragment_matrix` and so takes both a wider reduce nest (the axes flatten into
-    // the `k` edge) and a gathered operand (the compacted stage folds underneath).
-    //
-    // Cmma cannot. It loads a raw strided window (`window_slice` + `row_stride`), which no gather
-    // is expressible in, and its fragment grid is deduced 2-D and single-contraction throughout:
-    // `PlanePartition::store` infers the A/B role from where the contracted axis sits in the
-    // trailing two, and `partition_grid` reads the grid off those same two. Both halves stay
-    // refused for that encoding rather than failing silently further down.
-    let lhs_gathered = lhs.gathered();
-    let rhs_gathered = rhs.gathered();
-    let plane_2d = comptime!(
-        matches!(acc.leaf, Leaf::Mma { .. })
-            || (!lhs_gathered
-                && !rhs_gathered
-                && Space::contracted(&[&lhs.space, &rhs.space], &space).len() == 1)
-    );
+    // Both operands flatten their contracted axes into one `k` edge by extent alone
+    // (`matrix_split`), so listing the same axes in different orders would contract mismatched
+    // positions with matching shapes. Vacuous for a single contracted axis.
+    comptime!(assert!(
+        Space::contraction_agrees(&lhs.space, &rhs.space, &space),
+        "mma: the operands list their contracted axes in different orders ({:?} against {:?}), \
+         so their `k` edges do not line up",
+        lhs.space.contracting(&space),
+        rhs.space.contracting(&space)
+    ));
     let tile_kind = &mut acc.tile_kind;
     match tile_kind {
-        TileKind::PlaneTile(t) => {
-            comptime!(assert!(plane_2d, "{}", PLANE_2D));
-            t.mma(lhs, rhs)
-        }
+        TileKind::PlaneTile(t) => t.mma(lhs, rhs, space),
         // A partition that reaches a final tile carries exactly one tile; a wider one is
         // consumed earlier, at its partition level.
         TileKind::PlanePartition(p) => {
-            comptime!(assert!(plane_2d, "{}", PLANE_2D));
             comptime!(assert!(
                 p.m_tiles == 1 && p.n_tiles == 1,
                 "mma_leaf: a multi-tile partition must be contracted at its partition level"
             ));
             let mut t = p.at(0usize, 0usize);
-            t.mma(lhs, rhs)
+            t.mma(lhs, rhs, space)
         }
         // A memory accumulator runs the software microkernel. A plane-form accumulator that was
         // never promoted lands in the arms above and meets their kind-pairing panics; there is no
@@ -68,12 +58,41 @@ pub(crate) fn mma_leaf<E: Numeric, EL: Numeric, ER: Numeric>(
 
 #[cube]
 impl<E: Numeric> PlaneTile<E> {
-    /// Contract this plane tile: the only place the two encodings' executes diverge.
-    pub(crate) fn mma<EL: Numeric, ER: Numeric>(&mut self, lhs: &Tile<EL>, rhs: &Tile<ER>) {
+    /// Contract this plane tile: the only place the encodings' executes diverge, and so the only
+    /// place that knows which of them reads a raw strided window.
+    pub(crate) fn mma<EL: Numeric, ER: Numeric>(
+        &mut self,
+        lhs: &Tile<EL>,
+        rhs: &Tile<ER>,
+        #[comptime] out: Space,
+    ) {
         match self {
-            PlaneTile::Cmma(d) => d.mma(lhs, rhs),
+            PlaneTile::Cmma(d) => {
+                strided_2d(lhs, rhs, out);
+                d.mma(lhs, rhs)
+            }
+            // Reads its operands element by element through `Tile::fragment_matrix`, so a gather
+            // folds underneath and a wider reduce flattens into the `k` edge.
             PlaneTile::Mma(d) => d.mma(lhs, rhs),
-            PlaneTile::Register(d) => d.mma(lhs, rhs),
+            PlaneTile::Register(d) => {
+                strided_2d(lhs, rhs, out);
+                d.mma(lhs, rhs)
+            }
         }
     }
+}
+
+/// Refuse what a raw strided window (`window_slice` + `row_stride`) cannot address: a gathered
+/// operand, and a contraction over more than one axis.
+#[cube]
+fn strided_2d<EL: Numeric, ER: Numeric>(lhs: &Tile<EL>, rhs: &Tile<ER>, #[comptime] out: Space) {
+    let lhs_gathered = lhs.gathered();
+    let rhs_gathered = rhs.gathered();
+    comptime!(assert!(
+        !lhs_gathered
+            && !rhs_gathered
+            && Space::contracted(&[&lhs.space, &rhs.space], &out).len() == 1,
+        "{}",
+        STRIDED_2D
+    ));
 }

--- a/crates/cubek-tile/src/ops/matmul/instruction/base.rs
+++ b/crates/cubek-tile/src/ops/matmul/instruction/base.rs
@@ -8,9 +8,9 @@ use cubecl::prelude::*;
 use super::register::mma_register_memory;
 use crate::*;
 
-/// What a plane leaf's 2-D single-`K` deduction rules out.
-const PLANE_2D: &str = "mma: a plane (cmma/mma) leaf reads one contracted axis off a directly \
-                        addressed operand; a gather-reduce runs on the register leaf";
+/// What the cmma leaf's 2-D single-`K` deduction rules out.
+const PLANE_2D: &str = "mma: a cmma leaf reads one contracted axis off a directly addressed \
+                        operand; a gather-reduce runs on the manual-mma or register leaf";
 
 /// The leaf contraction `acc += lhs · rhs`. Dispatch is dynamic on the accumulator's comptime
 /// storage config
@@ -21,19 +21,23 @@ pub(crate) fn mma_leaf<E: Numeric, EL: Numeric, ER: Numeric>(
     rhs: &Tile<ER>,
 ) {
     let space = comptime!(acc.space.clone());
-    // A gather-reduce reaches the register leaf only. The plane leaves read a fragment grid whose
-    // shape is deduced 2-D and single-contraction: `Space::contraction` asserts one contracted
-    // axis, `PlanePartition::store` infers the A/B role from where that axis sits in the trailing
-    // two, and `partition_grid` reads the grid off those same two. So both halves of the deduction
-    // are refused here rather than left to fail silently: a wider reduce nest, and an operand
-    // whose buffer a logical coordinate does not address directly. Generalizing the plane leaves
-    // is a phase of its own.
+    // A gather-reduce runs on any leaf that addresses its operands *through a view*: the register
+    // microkernel's N-D nest, and the manual-mma leaf, whose fragment load reads element by element
+    // through `Tile::fragment_matrix` and so takes both a wider reduce nest (the axes flatten into
+    // the `k` edge) and a gathered operand (the compacted stage folds underneath).
+    //
+    // Cmma cannot. It loads a raw strided window (`window_slice` + `row_stride`), which no gather
+    // is expressible in, and its fragment grid is deduced 2-D and single-contraction throughout:
+    // `PlanePartition::store` infers the A/B role from where the contracted axis sits in the
+    // trailing two, and `partition_grid` reads the grid off those same two. Both halves stay
+    // refused for that encoding rather than failing silently further down.
     let lhs_gathered = lhs.gathered();
     let rhs_gathered = rhs.gathered();
     let plane_2d = comptime!(
-        !lhs_gathered
-            && !rhs_gathered
-            && Space::contracted(&[&lhs.space, &rhs.space], &space).len() == 1
+        matches!(acc.leaf, Leaf::Mma { .. })
+            || (!lhs_gathered
+                && !rhs_gathered
+                && Space::contracted(&[&lhs.space, &rhs.space], &space).len() == 1)
     );
     let tile_kind = &mut acc.tile_kind;
     match tile_kind {

--- a/crates/cubek-tile/src/ops/matmul/instruction/base.rs
+++ b/crates/cubek-tile/src/ops/matmul/instruction/base.rs
@@ -8,12 +8,6 @@ use cubecl::prelude::*;
 use super::register::mma_register_memory;
 use crate::*;
 
-/// What a strided-window fragment's 2-D single-`K` deduction rules out.
-const STRIDED_2D: &str = "mma: a cmma or plane-register fragment reads one contracted axis off a \
-                          directly addressed operand; a gather or a wider reduce needs the \
-                          manual-mma leaf, or an unpromoted Gmem/Smem accumulator, whose software \
-                          microkernel is the `mma_register_memory` arm below";
-
 /// The leaf contraction `acc += lhs · rhs`. Dispatch is dynamic on the accumulator's comptime
 /// storage config
 #[cube]
@@ -23,16 +17,6 @@ pub(crate) fn mma_leaf<E: Numeric, EL: Numeric, ER: Numeric>(
     rhs: &Tile<ER>,
 ) {
     let space = comptime!(acc.space.clone());
-    // Both operands flatten their contracted axes into one `k` edge by extent alone
-    // (`matrix_split`), so listing the same axes in different orders would contract mismatched
-    // positions with matching shapes. Vacuous for a single contracted axis.
-    comptime!(assert!(
-        Space::contraction_agrees(&lhs.space, &rhs.space, &space),
-        "mma: the operands list their contracted axes in different orders ({:?} against {:?}), \
-         so their `k` edges do not line up",
-        lhs.space.contracting(&space),
-        rhs.space.contracting(&space)
-    ));
     let tile_kind = &mut acc.tile_kind;
     match tile_kind {
         TileKind::PlaneTile(t) => t.mma(lhs, rhs, space),
@@ -58,8 +42,7 @@ pub(crate) fn mma_leaf<E: Numeric, EL: Numeric, ER: Numeric>(
 
 #[cube]
 impl<E: Numeric> PlaneTile<E> {
-    /// Contract this plane tile: the only place the encodings' executes diverge, and so the only
-    /// place that knows which of them reads a raw strided window.
+    /// Contract this plane tile.
     pub(crate) fn mma<EL: Numeric, ER: Numeric>(
         &mut self,
         lhs: &Tile<EL>,
@@ -71,9 +54,10 @@ impl<E: Numeric> PlaneTile<E> {
                 strided_2d(lhs, rhs, out);
                 d.mma(lhs, rhs)
             }
-            // Reads its operands element by element through `Tile::fragment_matrix`, so a gather
-            // folds underneath and a wider reduce flattens into the `k` edge.
-            PlaneTile::Mma(d) => d.mma(lhs, rhs),
+            PlaneTile::Mma(d) => {
+                flattened_k(lhs, rhs, out);
+                d.mma(lhs, rhs)
+            }
             PlaneTile::Register(d) => {
                 strided_2d(lhs, rhs, out);
                 d.mma(lhs, rhs)
@@ -82,8 +66,7 @@ impl<E: Numeric> PlaneTile<E> {
     }
 }
 
-/// Refuse what a raw strided window (`window_slice` + `row_stride`) cannot address: a gathered
-/// operand, and a contraction over more than one axis.
+/// Asserts that operands are not gathered and have a single contracted axis.
 #[cube]
 fn strided_2d<EL: Numeric, ER: Numeric>(lhs: &Tile<EL>, rhs: &Tile<ER>, #[comptime] out: Space) {
     let lhs_gathered = lhs.gathered();
@@ -92,7 +75,21 @@ fn strided_2d<EL: Numeric, ER: Numeric>(lhs: &Tile<EL>, rhs: &Tile<ER>, #[compti
         !lhs_gathered
             && !rhs_gathered
             && Space::contracted(&[&lhs.space, &rhs.space], &out).len() == 1,
-        "{}",
-        STRIDED_2D
+        "mma: a cmma or plane-register fragment reads one contracted axis off a directly \
+         addressed operand; a gather or a wider reduce needs the manual-mma leaf, or an \
+         unpromoted Gmem/Smem accumulator, whose software microkernel is the \
+         `mma_register_memory` arm of `mma_leaf`"
+    ));
+}
+
+/// Asserts that operands contract their shared axes in the same order.
+#[cube]
+fn flattened_k<EL: Numeric, ER: Numeric>(lhs: &Tile<EL>, rhs: &Tile<ER>, #[comptime] out: Space) {
+    comptime!(assert!(
+        Space::contraction_agrees(&lhs.space, &rhs.space, &out),
+        "mma: the operands list their contracted axes in different orders ({:?} against {:?}), \
+         so their `k` edges do not line up",
+        lhs.space.contracting(&out),
+        rhs.space.contracting(&out)
     ));
 }

--- a/crates/cubek-tile/src/ops/matmul/instruction/mma.rs
+++ b/crates/cubek-tile/src/ops/matmul/instruction/mma.rs
@@ -1,8 +1,7 @@
 //! The manual-mma leaf: `acc += lhs · rhs` via [`MmaDefinition::execute`](cubecl::cmma::MmaDefinition),
 //! the raw-mma twin of [`cmma`](super::cmma). The accumulator is a register fragment; the operands
-//! arrive as fragments or as row-major smem windows, the latter loaded into transient `A`/`B`
-//! fragments here (a gmem window's layout is unchecked, so it must be staged first, exactly as in
-//! the cmma path).
+//! arrive as fragments or as memory windows (smem or gmem), the latter loaded into transient `A`/`B`
+//! fragments here.
 
 use cubecl::prelude::*;
 
@@ -31,7 +30,7 @@ impl<A: Numeric> MmaData<A> {
                     },
                     _ => panic!("MmaData::mma: operands must be mma fragments"),
                 },
-                (TileKind::Smem(_), TileKind::Smem(_)) => {
+                (TileKind::Smem(_) | TileKind::Gmem(_), TileKind::Smem(_) | TileKind::Gmem(_)) => {
                     let mut la = MmaData::<L>::lhs(m, n, k, layout, io);
                     la.load_window(lhs);
                     let mut rb = MmaData::<R>::rhs(m, n, k, layout, io);
@@ -43,7 +42,7 @@ impl<A: Numeric> MmaData<A> {
                         _ => panic!("MmaData::mma: transient operand fragments in the wrong roles"),
                     }
                 }
-                _ => panic!("MmaData::mma: operands must be fragments or staged smem windows"),
+                _ => panic!("MmaData::mma: operands must be fragments or memory windows"),
             },
             MmaFragment::Lhs(_) | MmaFragment::Rhs(_) => {
                 panic!("MmaData::mma: the accumulator must carry the Acc role")

--- a/crates/cubek-tile/src/ops/matmul/instruction/register.rs
+++ b/crates/cubek-tile/src/ops/matmul/instruction/register.rs
@@ -175,15 +175,8 @@ fn mma_register_direct<
     }
 }
 
-/// [`mma_register_direct`]'s N-D twin, for the two cases a batch matrix does not describe: several
-/// contracted axes, and an operand whose logical coordinate is not a physical one
-/// ([`Projection`]). The register block, the unroll rule, and the rank-1 step are the same; only
-/// the addressing differs, since each read resolves a whole coordinate ([`resolve_nd_coords`])
-/// through [`Tile::nd`] rather than a `(row, col)` pair through a matrix view.
-///
-/// The reduce nest is flattened to one runtime `kc` loop rather than nested loops: the leaf's
-/// contract is one rank-1 update per step, and a nest of comptime-known extents unravels back
-/// ([`unravel_reduce_index`]) for the cost of the div/mod the flat index already implies.
+/// N-D variant of [`mma_register_direct`] for operations with multiple contracted axes
+/// or projected operands.
 #[cube]
 fn mma_register_gather<
     E: Numeric,
@@ -222,29 +215,18 @@ fn mma_register_gather<
         &lhs.space, &rhs.space, &space, &reduce, lw
     ));
 
-    // Built once, outside the walk: the view is over the tile's whole logical box, so it does not
-    // depend on the matrix or the step, unlike the per-matrix views the 2-D kernel takes.
     let lhs_view = lhs.nd::<IL, WPL, L>();
     let rhs_view = rhs.nd::<IR, WPR, V>();
 
     for mat in 0..matrices {
-        // The batch coordinate the flat `mat` index stands for. The accumulator takes `mat` itself
-        // (`matrix_accumulate` unravels it the same way); the operands are addressed per axis, so
-        // they need the coordinates spelled out.
-        let mut batch = Coords::<u32>::new();
-        #[unroll]
-        for p in 0..comptime!(rank - 2) {
-            let stride = comptime!(
-                ((p + 1)..(rank - 2))
-                    .map(|q| space.extent_at(q))
-                    .product::<usize>()
-            );
-            batch.push(
-                mat.fcast::<u32>()
-                    .fdiv(comptime!(stride as u32))
-                    .frem(comptime!(space.extent_at(p) as u32)),
-            );
-        }
+        let batch = unravel(
+            &const_coords(comptime!(
+                (0..rank - 2)
+                    .map(|p| space.extent_at(p))
+                    .collect::<Vec<_>>()
+            )),
+            mat.fcast::<u32>(),
+        );
 
         let mut acc = acc.matrix_accumulate::<V>(mat, comptime!(space.clone()));
 
@@ -255,10 +237,11 @@ fn mma_register_gather<
         let unroll = comptime!(mr * nr <= UNROLL_BLOCK && !lhs_check && !rhs_check && !acc_check);
         let mut c = load_accumulators(&mut acc, comptime!(mr), comptime!(nr), unroll);
 
-        // One rank-1 update per reduce step, as in the 2-D kernel; `p` walks the whole flattened
-        // nest instead of a single `K`.
         for p in 0..kc {
-            let reduce_coords = unravel_reduce_index(p, comptime!(reduce_extents.clone()));
+            let reduce_coords = unravel(
+                &const_coords(comptime!(reduce_extents.clone())),
+                p.fcast::<u32>(),
+            );
             // `lhs` lines along the fastest contracted axis (`assert_operand_shapes`), so that
             // axis's coordinate splits into the line index `resolve_nd_coords` divides out and the
             // lane within it, broadcast below.
@@ -346,29 +329,6 @@ fn store_accumulators<E: Numeric, V: Size>(
             acc.commit((i as u32, n as u32), c[i * nr + n]);
         }
     }
-}
-
-/// The reduce nest's coordinate at flat step `k_step`, row-major over `reduce_extents` (the outer
-/// axis moves slowest). The outermost digit takes the bare quotient: it has no enclosing extent to
-/// wrap against, and `k_step < Π extents` by construction, so a modulo there would only cost an
-/// instruction. Every radix is comptime, so on a static nest this folds to shifts and masks.
-#[cube]
-fn unravel_reduce_index(k_step: usize, #[comptime] reduce_extents: Vec<usize>) -> Coords<u32> {
-    let n = comptime!(reduce_extents.len());
-    let mut reduce_coords = Coords::<u32>::new();
-
-    #[unroll]
-    for j in 0..n {
-        let stride = comptime!(reduce_extents[(j + 1)..].iter().product::<usize>());
-        let axis_coord = k_step.fcast::<u32>().fdiv(comptime!(stride as u32));
-        reduce_coords.push(if comptime!(j == 0) {
-            axis_coord
-        } else {
-            axis_coord.frem(comptime!(reduce_extents[j] as u32))
-        });
-    }
-
-    reduce_coords
 }
 
 /// The coordinate `operand` is read at, one entry per axis of its own space, assembled from the

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -400,7 +400,7 @@ mod tests {
     /// line and element units. Carrying it twice is what storage tiling *is*, so the tiling refusal
     /// is what rules the shape out. `A <- A*1 + B*2` over logical `[A, B]` with `B` innermost.
     #[test]
-    #[should_panic(expected = "must be untiled gmem")]
+    #[should_panic(expected = "addresses several physical axes")]
     fn innermost_axis_rides_no_coarser_physical_axis() {
         Projection::new(
             &[A, B],
@@ -426,7 +426,7 @@ mod tests {
     /// while `Ih <- A*2 + R*3` gathers, and one advance cannot be both split into digits and
     /// scaled.
     #[test]
-    #[should_panic(expected = "untiled gmem")]
+    #[should_panic(expected = "addresses several physical axes")]
     fn a_gather_rejects_tiled_storage() {
         Projection::new(
             &[A, R, B],

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -319,8 +319,7 @@ impl Projection {
         // arithmetic is only sound when it is one logical axis at coefficient 1.
         //
         // The other direction, a *coarser* physical axis also scaling that same logical axis,
-        // would mix lines into an element count. It needs no assert of its own: an axis carried by
-        // two physical axes is storage-tiled by `tiling`, which the last assert below refuses.
+        // would mix lines into an element count.
         let innermost = self.axes[self.axes.len() - 1];
         assert!(
             self.physical[self.physical.len() - 1].is_identity(innermost),
@@ -328,9 +327,14 @@ impl Projection {
              coefficient 1 (it is addressed in vector lines)"
         );
         for &axis in self.axes.iter() {
+            let count = self.physical.iter().filter(|m| m.scale(axis) != 0).count();
             assert!(
-                self.physical.iter().any(|m| m.scale(axis) != 0),
+                count > 0,
                 "Projection: logical axis {axis:?} addresses no physical axis"
+            );
+            assert!(
+                count == 1,
+                "Projection: logical axis {axis:?} addresses several physical axes"
             );
         }
         // A tiled `[grid…, tile…]` buffer splits an advance into two digits, which is not linear

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -332,18 +332,14 @@ impl Projection {
                 count > 0,
                 "Projection: logical axis {axis:?} addresses no physical axis"
             );
+            // A gathered operand must be untiled gmem, so each logical axis can map to at most one physical axis.
             assert!(
                 count == 1,
-                "Projection: logical axis {axis:?} addresses several physical axes"
+                "Projection: logical axis {axis:?} addresses several physical axes, so it is \
+                 either storage-tiled (a gathered operand must be untiled gmem) or read off two \
+                 places at once"
             );
         }
-        // A tiled `[grid…, tile…]` buffer splits an advance into two digits, which is not linear
-        // in the edge, so it cannot absorb a scaled one. Projected operands are bare gmem.
-        assert!(
-            !self.is_tiled(),
-            "Projection: a gathered operand must be untiled gmem, but an axis is split across \
-             several physical fragments"
-        );
     }
 }
 #[cfg(test)]

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -317,6 +317,10 @@ impl Projection {
         // The innermost physical axis is addressed in *lines*, not elements: `MemData::at` divides
         // its edge by the vector size and `of_impl` counts its physical shape in lines. That
         // arithmetic is only sound when it is one logical axis at coefficient 1.
+        //
+        // The other direction, a *coarser* physical axis also scaling that same logical axis,
+        // would mix lines into an element count. It needs no assert of its own: an axis carried by
+        // two physical axes is storage-tiled by `tiling`, which the last assert below refuses.
         let innermost = self.axes[self.axes.len() - 1];
         assert!(
             self.physical[self.physical.len() - 1].is_identity(innermost),
@@ -386,6 +390,22 @@ mod tests {
             ],
         );
         assert_eq!(q.span(0, |a| if a == A { 4 } else { 1 }), 4);
+    }
+
+    /// The innermost axis is addressed in lines, so a coarser physical axis scaling it would mix
+    /// line and element units. Carrying it twice is what storage tiling *is*, so the tiling refusal
+    /// is what rules the shape out. `A <- A*1 + B*2` over logical `[A, B]` with `B` innermost.
+    #[test]
+    #[should_panic(expected = "must be untiled gmem")]
+    fn innermost_axis_rides_no_coarser_physical_axis() {
+        Projection::new(
+            &[A, B],
+            &[
+                PhysicalAxisMap::affine(&[(A, 1), (B, 2)]),
+                PhysicalAxisMap::of(B),
+            ],
+        )
+        .validate();
     }
 
     #[test]

--- a/crates/cubek-tile/src/space/base.rs
+++ b/crates/cubek-tile/src/space/base.rs
@@ -516,19 +516,27 @@ impl Space {
     }
 
     /// The `k` edge this operand contracts over against `output`: the product of every
-    /// [`contracting`](Space::contracting) axis's extent, read off the operand's
-    /// [`final_space`](Space::final_space).
+    /// [`contracting`](Space::contracting) axis's extent. An instruction sees one contraction
+    /// depth, not a list of axes.
     ///
-    /// An instruction sees one contraction depth, not a list of axes. A matmul has the one axis
-    /// [`contraction`](Space::contraction) names; a convolution contracts over its taps *and* its
-    /// channels, and their product is the `k` a fragment is sized by and the edge
-    /// [`matrix_split`](crate::matrix_split) flattens those axes into.
+    /// Reads the extents off this space as it stands, like every other consumer of a tile's edges
+    /// ([`matrix_split`](crate::matrix_split)); call it on the [`final_space`](Space::final_space)
+    /// when the caller holds a level above the leaf.
     pub fn contracted_extent(&self, output: &Space) -> usize {
-        let leaf = self.final_space();
         self.contracting(output)
             .iter()
-            .map(|&axis| leaf.extent(axis))
+            .map(|&axis| self.extent(axis))
             .product()
+    }
+
+    /// Whether `lhs` and `rhs` enumerate their contracted axes in the same order.
+    ///
+    /// A fragment groups its `k` edge by extent alone ([`matrix_split`](crate::matrix_split)), so
+    /// two operands listing the same axes in different orders contract mismatched positions with
+    /// no shape mismatch to catch it. Each operand's order is its own [`TileSpec`](crate::TileSpec)
+    /// axis list, which is stated per operand, so nothing upstream forces them to agree.
+    pub fn contraction_agrees(lhs: &Space, rhs: &Space, output: &Space) -> bool {
+        lhs.contracting(output) == rhs.contracting(output)
     }
 
     /// The single axis this operand contracts against `output`:
@@ -652,6 +660,22 @@ impl<'a> IntoIterator for &'a Space {
     }
 }
 
+/// A single-level space whose every axis is one sequential cut of its extent: what the shape
+/// helpers are exercised against, since they read extents and axis order rather than the walk.
+#[cfg(test)]
+pub(crate) fn flat_space(extents: &[(Axis, usize)]) -> Space {
+    use crate::{Cut, Schedule, Tiling, WalkOrder};
+    Tiling::new()
+        .extents(extents)
+        .level(WalkOrder::RowMajor, Schedule::Direct, |mut l| {
+            for &(axis, e) in extents {
+                l = l.axis(axis, Cut::sequential(e));
+            }
+            l
+        })
+        .build()
+}
+
 #[cfg(test)]
 mod contraction_tests {
     use crate::*;
@@ -661,22 +685,11 @@ mod contraction_tests {
     const K: Axis = Axis(2);
     const R: Axis = Axis(3);
 
-    fn space(extents: &[(Axis, usize)]) -> Space {
-        let mut t = Tiling::new().extents(extents);
-        t = t.level(WalkOrder::RowMajor, Schedule::Direct, |mut l| {
-            for &(axis, e) in extents {
-                l = l.axis(axis, Cut::sequential(e));
-            }
-            l
-        });
-        t.build()
-    }
-
     /// A matmul contracts one axis, so the `k` edge is that axis's extent, as it always was.
     #[test]
     fn a_matmul_contracts_its_one_axis() {
-        let lhs = space(&[(M, 8), (K, 4)]);
-        let out = space(&[(M, 8), (N, 8)]);
+        let lhs = flat_space(&[(M, 8), (K, 4)]);
+        let out = flat_space(&[(M, 8), (N, 8)]);
         assert_eq!(lhs.contracted_extent(&out), 4);
     }
 
@@ -684,16 +697,36 @@ mod contraction_tests {
     /// which is their product.
     #[test]
     fn a_convolution_contracts_taps_times_channels() {
-        let lhs = space(&[(M, 8), (R, 3), (K, 4)]);
-        let out = space(&[(M, 8), (N, 8)]);
+        let lhs = flat_space(&[(M, 8), (R, 3), (K, 4)]);
+        let out = flat_space(&[(M, 8), (N, 8)]);
         assert_eq!(lhs.contracted_extent(&out), 12);
     }
 
     /// An operand spanning only output axes contracts nothing, and an empty product is `1`.
     #[test]
     fn contracting_nothing_is_a_unit_depth() {
-        let lhs = space(&[(M, 8), (N, 8)]);
-        let out = space(&[(M, 8), (N, 8)]);
+        let lhs = flat_space(&[(M, 8), (N, 8)]);
+        let out = flat_space(&[(M, 8), (N, 8)]);
         assert_eq!(lhs.contracted_extent(&out), 1);
+    }
+
+    /// The `A` and `B` roles of a convolution, listing taps then channels in the order each
+    /// operand's own spec states them.
+    #[test]
+    fn operands_listing_one_contraction_order_agree() {
+        let lhs = flat_space(&[(M, 8), (R, 3), (K, 4)]);
+        let rhs = flat_space(&[(R, 3), (K, 4), (N, 8)]);
+        let out = flat_space(&[(M, 8), (N, 8)]);
+        assert!(Space::contraction_agrees(&lhs, &rhs, &out));
+    }
+
+    /// The same axes and the same `k`, listed the other way round on `rhs`: nothing about the
+    /// shapes distinguishes this from the case above, so the order has to be compared.
+    #[test]
+    fn a_permuted_contraction_order_disagrees() {
+        let lhs = flat_space(&[(M, 8), (R, 3), (K, 4)]);
+        let rhs = flat_space(&[(K, 4), (R, 3), (N, 8)]);
+        let out = flat_space(&[(M, 8), (N, 8)]);
+        assert!(!Space::contraction_agrees(&lhs, &rhs, &out));
     }
 }

--- a/crates/cubek-tile/src/space/base.rs
+++ b/crates/cubek-tile/src/space/base.rs
@@ -515,6 +515,22 @@ impl Space {
         Space::merge(operands).contracting(output)
     }
 
+    /// The `k` edge this operand contracts over against `output`: the product of every
+    /// [`contracting`](Space::contracting) axis's extent, read off the operand's
+    /// [`final_space`](Space::final_space).
+    ///
+    /// An instruction sees one contraction depth, not a list of axes. A matmul has the one axis
+    /// [`contraction`](Space::contraction) names; a convolution contracts over its taps *and* its
+    /// channels, and their product is the `k` a fragment is sized by and the edge
+    /// [`matrix_split`](crate::matrix_split) flattens those axes into.
+    pub fn contracted_extent(&self, output: &Space) -> usize {
+        let leaf = self.final_space();
+        self.contracting(output)
+            .iter()
+            .map(|&axis| leaf.extent(axis))
+            .product()
+    }
+
     /// The single axis this operand contracts against `output`:
     /// [`contracting`](Space::contracting) with the one-axis contract asserted.
     pub fn contraction(&self, output: &Space) -> Axis {
@@ -633,5 +649,51 @@ impl<'a> IntoIterator for &'a Space {
 
     fn into_iter(self) -> Axes<'a> {
         self.axes()
+    }
+}
+
+#[cfg(test)]
+mod contraction_tests {
+    use crate::*;
+
+    const M: Axis = Axis(0);
+    const N: Axis = Axis(1);
+    const K: Axis = Axis(2);
+    const R: Axis = Axis(3);
+
+    fn space(extents: &[(Axis, usize)]) -> Space {
+        let mut t = Tiling::new().extents(extents);
+        t = t.level(WalkOrder::RowMajor, Schedule::Direct, |mut l| {
+            for &(axis, e) in extents {
+                l = l.axis(axis, Cut::sequential(e));
+            }
+            l
+        });
+        t.build()
+    }
+
+    /// A matmul contracts one axis, so the `k` edge is that axis's extent, as it always was.
+    #[test]
+    fn a_matmul_contracts_its_one_axis() {
+        let lhs = space(&[(M, 8), (K, 4)]);
+        let out = space(&[(M, 8), (N, 8)]);
+        assert_eq!(lhs.contracted_extent(&out), 4);
+    }
+
+    /// A convolution contracts its taps and its channels at once; the instruction sees one `k`,
+    /// which is their product.
+    #[test]
+    fn a_convolution_contracts_taps_times_channels() {
+        let lhs = space(&[(M, 8), (R, 3), (K, 4)]);
+        let out = space(&[(M, 8), (N, 8)]);
+        assert_eq!(lhs.contracted_extent(&out), 12);
+    }
+
+    /// An operand spanning only output axes contracts nothing, and an empty product is `1`.
+    #[test]
+    fn contracting_nothing_is_a_unit_depth() {
+        let lhs = space(&[(M, 8), (N, 8)]);
+        let out = space(&[(M, 8), (N, 8)]);
+        assert_eq!(lhs.contracted_extent(&out), 1);
     }
 }

--- a/crates/cubek-tile/src/staging/resident.rs
+++ b/crates/cubek-tile/src/staging/resident.rs
@@ -26,10 +26,11 @@ impl<Acc: Numeric> Tile<Acc> {
     /// contraction depth has to come from a side that has it. The `mma` call is the next line at
     /// every call site, so it is already in hand.
     pub fn promote<EA: Numeric, EL: Numeric>(&self, lhs: &Tile<EL>) -> Tile<EA> {
-        // The contracted axes are those `lhs` spans and this accumulator does not; the fragment is
-        // sized by their product, which is one axis for a matmul and taps times channels for a
-        // convolution.
-        let k = comptime!(lhs.space.contracted_extent(&self.space));
+        // The contracted axes are those `lhs` spans and this accumulator does not, and the fragment
+        // is sized by their product. Off the leaf space: a caller holds a level above it, while the
+        // fragment's own reader (`Tile::fragment_matrix`) is handed the leaf tile directly, and the
+        // two edges have to be the same number.
+        let k = comptime!(lhs.space.final_space().contracted_extent(&self.space));
         // The block's lines match the memory it drains back into; the hardware
         // encodings ignore it.
         let vector_size = self.vector_size();

--- a/crates/cubek-tile/src/staging/resident.rs
+++ b/crates/cubek-tile/src/staging/resident.rs
@@ -26,9 +26,10 @@ impl<Acc: Numeric> Tile<Acc> {
     /// contraction depth has to come from a side that has it. The `mma` call is the next line at
     /// every call site, so it is already in hand.
     pub fn promote<EA: Numeric, EL: Numeric>(&self, lhs: &Tile<EL>) -> Tile<EA> {
-        // The contracted axis is the one `lhs` spans and this accumulator does not.
-        let contracted = comptime!(lhs.space.contraction(&self.space));
-        let k = comptime!(lhs.space.final_space().extent(contracted));
+        // The contracted axes are those `lhs` spans and this accumulator does not; the fragment is
+        // sized by their product, which is one axis for a matmul and taps times channels for a
+        // convolution.
+        let k = comptime!(lhs.space.contracted_extent(&self.space));
         // The block's lines match the memory it drains back into; the hardware
         // encodings ignore it.
         let vector_size = self.vector_size();

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -1023,29 +1023,10 @@ impl<T: Numeric> MemData<T> {
     }
 
     /// The mutable twin of [`masked`](MemData::masked).
-    pub(crate) fn masked_mut<W: Size>(
+    pub(crate) fn masked_mut<W: Size, C: Coordinates, L: TileLayout<C>>(
         &mut self,
-        layout: BatchMatrix,
-    ) -> MatrixViewMut<'_, Vector<T, W>> {
-        if comptime!(self.store.quant.is_some()) {
-            panic!("Tile::matrix_mut: writing a quantized tile requires requantization")
-        }
-        let base = self.base();
-        let window = self.window();
-        let check = comptime!(self.access.overhang.masks());
-        MaskedViewMut::new(
-            self.lines_mut::<W>()
-                .view_mut(base)
-                .view_mut(window)
-                .view_mut(layout),
-            check,
-        )
-    }
-
-    pub(crate) fn masked_mut_projected<W: Size>(
-        &mut self,
-        layout: super::ProjectedBatchMatrix,
-    ) -> MatrixViewMut<'_, Vector<T, W>> {
+        layout: L,
+    ) -> MaskedViewMut<'_, Vector<T, W>, C> {
         if comptime!(self.store.quant.is_some()) {
             panic!("Tile::matrix_mut: writing a quantized tile requires requantization")
         }
@@ -1154,19 +1135,15 @@ impl<T: Numeric> MemData<T> {
         }
     }
 
-    /// [`transparent`](MemData::transparent) over one batch matrix: what the 2-D matmul leaves read.
-    pub(crate) fn matrix_transparent<I: Numeric, WP: Size, W: Size>(
+    /// [`transparent`](MemData::transparent) over one batch matrix: what the 2-D matmul leaves
+    /// read. `L` is [`BatchMatrix`] for a direct operand and
+    /// [`ProjectedBatchMatrix`](super::ProjectedBatchMatrix) for a gathered one; both answer the
+    /// same [`Coords2d`] surface.
+    pub(crate) fn matrix_transparent<I: Numeric, WP: Size, W: Size, L: TileLayout<Coords2d>>(
         &self,
-        layout: BatchMatrix,
+        layout: L,
     ) -> MatrixView<'_, Vector<T, W>> {
-        self.transparent::<I, WP, W, Coords2d, BatchMatrix>(layout)
-    }
-
-    pub(crate) fn matrix_transparent_projected<I: Numeric, WP: Size, W: Size>(
-        &self,
-        layout: super::ProjectedBatchMatrix,
-    ) -> MatrixView<'_, Vector<T, W>> {
-        self.transparent::<I, WP, W, Coords2d, super::ProjectedBatchMatrix>(layout)
+        self.transparent::<I, WP, W, Coords2d, L>(layout)
     }
 
     /// [`transparent`](MemData::transparent) over the tile's whole logical box, applying the
@@ -1209,19 +1186,16 @@ impl<T: Numeric> MemData<T> {
             self.projection.is_direct(),
             "MemData::matrix_mut: a gathered operand has no plain 2-D matrix view"
         ));
-        let rank = comptime!(space.rank());
-        let rows = comptime!(space.extent_at(rank - 2));
-        // The `Space` is scalar; `cols` counts lines, so divide the innermost extent by the width.
-        let cols = comptime!(space.extent_at(rank - 1) / self.store.vector_size);
         // Leading (batch) extents are width-invariant; the window extent is the view's shape.
-        let shape = self.extent();
-        let mut batches = CoordsDyn::new();
-        #[unroll]
-        for p in 0..rank - 2 {
-            let weight = shape.fproduct(comptime!(((p + 1)..(rank - 2)).collect::<Vec<_>>()));
-            batches.push(i.fcast::<u32>().fdiv(weight).frem(shape.at(p)));
-        }
-        self.masked_mut::<W>(BatchMatrix::new(batches, rows, cols))
+        let bound = self.extent();
+        let layout = batch_matrix(
+            &bound,
+            space,
+            comptime!(self.projection.clone()),
+            comptime!(self.store.vector_size),
+            i,
+        );
+        self.masked_mut::<W, Coords2d, BatchMatrix>(layout)
     }
 
     /// The [`AccumulateView`] over batch matrix `i`: [`matrix_mut`](MemData::matrix_mut) plus the

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -1042,6 +1042,25 @@ impl<T: Numeric> MemData<T> {
         )
     }
 
+    pub(crate) fn masked_mut_projected<W: Size>(
+        &mut self,
+        layout: super::ProjectedBatchMatrix,
+    ) -> MatrixViewMut<'_, Vector<T, W>> {
+        if comptime!(self.store.quant.is_some()) {
+            panic!("Tile::matrix_mut: writing a quantized tile requires requantization")
+        }
+        let base = self.base();
+        let window = self.window();
+        let check = comptime!(self.access.overhang.masks());
+        MaskedViewMut::new(
+            self.lines_mut::<W>()
+                .view_mut(base)
+                .view_mut(window)
+                .view_mut(layout),
+            check,
+        )
+    }
+
     /// Re-view this buffer as a flat 1-D [`FlatView`] over its [`Window`] extent,
     /// carrying the `check` flag so a flat scan masks the overhang without being asked.
     pub(crate) fn flat<W: Size>(&self) -> FlatView<'_, Vector<T, W>> {
@@ -1141,6 +1160,13 @@ impl<T: Numeric> MemData<T> {
         layout: BatchMatrix,
     ) -> MatrixView<'_, Vector<T, W>> {
         self.transparent::<I, WP, W, Coords2d, BatchMatrix>(layout)
+    }
+
+    pub(crate) fn matrix_transparent_projected<I: Numeric, WP: Size, W: Size>(
+        &self,
+        layout: super::ProjectedBatchMatrix,
+    ) -> MatrixView<'_, Vector<T, W>> {
+        self.transparent::<I, WP, W, Coords2d, super::ProjectedBatchMatrix>(layout)
     }
 
     /// [`transparent`](MemData::transparent) over the tile's whole logical box, applying the

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -1190,8 +1190,8 @@ impl<T: Numeric> MemData<T> {
         let bound = self.extent();
         let layout = batch_matrix(
             &bound,
-            space,
-            comptime!(self.projection.clone()),
+            comptime!(&space),
+            false,
             comptime!(self.store.vector_size),
             i,
         );

--- a/crates/cubek-tile/src/tile/mma.rs
+++ b/crates/cubek-tile/src/tile/mma.rs
@@ -130,17 +130,10 @@ impl<T: Numeric> MmaData<T> {
         let io = comptime!(self.io);
         let def = MmaDefinition::<T, T, T>::new(m, n, k);
         match &mut self.fragment {
-            MmaFragment::Lhs(f) => {
-                let e = comptime!(fragment_edges(MatrixIdent::A, m, n, k));
-                load_fragment(src, f, &def, MatrixIdent::A, layout, io, e)
-            }
-            MmaFragment::Rhs(f) => {
-                let e = comptime!(fragment_edges(MatrixIdent::B, m, n, k));
-                load_fragment(src, f, &def, MatrixIdent::B, layout, io, e)
-            }
+            MmaFragment::Lhs(f) => load_fragment(src, f, &def, MatrixIdent::A, layout, io, m, n, k),
+            MmaFragment::Rhs(f) => load_fragment(src, f, &def, MatrixIdent::B, layout, io, m, n, k),
             MmaFragment::Acc(f) => {
-                let e = comptime!(fragment_edges(MatrixIdent::Accumulator, m, n, k));
-                load_fragment(src, f, &def, MatrixIdent::Accumulator, layout, io, e)
+                load_fragment(src, f, &def, MatrixIdent::Accumulator, layout, io, m, n, k)
             }
         }
     }
@@ -231,13 +224,8 @@ fn fill_registers<E: Numeric, N: Size>(fragment: &mut Array<Vector<E, N>>, value
 /// Load `fragment` (role `ident`) from `mem`'s row-major window. `ldmatrix` needs a vectorized
 /// row slice, which a `MemData` window cannot serve yet, so that path is refused rather than wrong.
 ///
-/// A gathered operand never consults the config: `ldmatrix` reads a raw strided tile, which no
-/// gather is expressible in, the same objection the cmma leaf is refused a gather for. Its manual
-/// load reads element by element through [`Tile::fragment_matrix`], so the compacted stage folds
-/// underneath. That refusal is permanent rather than pending, so it selects the manual path here
-/// instead of panicking: a host-derived [`MmaIOConfig::new`] picks `LoadMatrix` on any backend
-/// advertising `ldmatrix` over the stage's element, and a convolution has no reason to be denied
-/// that config when the leaf it lands on can serve it.
+/// That refusal is permanent rather than pending, so it selects the manual path here
+/// instead of panicking.
 #[cube]
 fn load_fragment<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric>(
     src: &Tile<T>,
@@ -246,7 +234,9 @@ fn load_fragment<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric>(
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
     #[comptime] io: MmaIOConfig,
-    #[comptime] edges: (usize, usize),
+    #[comptime] m: usize,
+    #[comptime] n: usize,
+    #[comptime] k: usize,
 ) {
     let gathered = src.gathered();
     let method = comptime!(if gathered {
@@ -255,7 +245,7 @@ fn load_fragment<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric>(
         io.load_method(ident)
     });
     match method {
-        LoadMethod::Manual => load_manual_dispatch(src, fragment, def, ident, layout, edges),
+        LoadMethod::Manual => load_manual_dispatch(src, fragment, def, ident, layout, m, n, k),
         LoadMethod::LoadMatrix => {
             comptime!(panic!(
                 "MmaData::load: the ldmatrix fast path is not yet wired for MemData windows; \
@@ -275,19 +265,21 @@ fn load_manual_dispatch<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric
     def: &MmaDefinition<A, B, CD>,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
-    #[comptime] edges: (usize, usize),
+    #[comptime] m: usize,
+    #[comptime] n: usize,
+    #[comptime] k: usize,
 ) {
     let pack = src.quant_pack();
     let served = src.vector_size();
     let size!(W) = served;
     if comptime!(pack == 1) {
         let size!(WP) = served;
-        load_manual::<T, i8, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
+        load_manual::<T, i8, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, m, n, k);
     } else if comptime!(pack > 1) {
         let size!(WP) = comptime!(served / pack);
-        load_manual::<T, u32, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
+        load_manual::<T, u32, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, m, n, k);
     } else {
-        load_manual::<T, T, W, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
+        load_manual::<T, T, W, W, N, A, B, CD>(src, fragment, def, ident, layout, m, n, k);
     }
 }
 
@@ -311,7 +303,9 @@ fn load_manual<
     def: &MmaDefinition<A, B, CD>,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
-    #[comptime] edges: (usize, usize),
+    #[comptime] m: usize,
+    #[comptime] n: usize,
+    #[comptime] k: usize,
 ) {
     let num_vectors = def.vectors_per_lane(ident);
     let vector_size = def.vector_size(ident);
@@ -330,7 +324,7 @@ fn load_manual<
     // The fragment's own edges, not the stage's trailing two axes: an operand contracting over
     // several logical axes (a convolution's taps and channels) flattens them into `k`, and a
     // gathered stage folds that logical coordinate onto its compacted cells underneath.
-    let (rows, cols) = comptime!(edges);
+    let (rows, cols) = comptime!(fragment_edges(ident, m, n, k));
     let view = src.fragment_matrix::<I, WP, W>(rows, cols);
 
     #[unroll]

--- a/crates/cubek-tile/src/tile/mma.rs
+++ b/crates/cubek-tile/src/tile/mma.rs
@@ -130,10 +130,10 @@ impl<T: Numeric> MmaData<T> {
         let io = comptime!(self.io);
         let def = MmaDefinition::<T, T, T>::new(m, n, k);
         match &mut self.fragment {
-            MmaFragment::Lhs(f) => load_fragment(src, f, &def, MatrixIdent::A, layout, io, m, n, k),
-            MmaFragment::Rhs(f) => load_fragment(src, f, &def, MatrixIdent::B, layout, io, m, n, k),
+            MmaFragment::Lhs(f) => load_fragment(src, f, &def, MatrixIdent::A, layout, io, (m, k)),
+            MmaFragment::Rhs(f) => load_fragment(src, f, &def, MatrixIdent::B, layout, io, (k, n)),
             MmaFragment::Acc(f) => {
-                load_fragment(src, f, &def, MatrixIdent::Accumulator, layout, io, m, n, k)
+                load_fragment(src, f, &def, MatrixIdent::Accumulator, layout, io, (m, n))
             }
         }
     }
@@ -200,16 +200,6 @@ fn register_rhs_size<R: Numeric>(def: &MmaDefinition<R, R, R>) {
 // `MemData` window: a row-major stage addressed by `window_slice()` + scalar `row_stride()`).
 // ===========================================================================
 
-/// The `(rows, cols)` edges of the matrix a fragment of role `ident` reads out of an `m x n x k`
-/// instruction: `A` is `m x k`, `B` is `k x n`, and the accumulator `m x n`.
-fn fragment_edges(ident: MatrixIdent, m: usize, n: usize, k: usize) -> (usize, usize) {
-    match ident {
-        MatrixIdent::A => (m, k),
-        MatrixIdent::B => (k, n),
-        MatrixIdent::Accumulator => (m, n),
-    }
-}
-
 /// Fill every register slot with `value`.
 #[cube]
 fn fill_registers<E: Numeric, N: Size>(fragment: &mut Array<Vector<E, N>>, value: E) {
@@ -221,11 +211,7 @@ fn fill_registers<E: Numeric, N: Size>(fragment: &mut Array<Vector<E, N>>, value
     }
 }
 
-/// Load `fragment` (role `ident`) from `mem`'s row-major window. `ldmatrix` needs a vectorized
-/// row slice, which a `MemData` window cannot serve yet, so that path is refused rather than wrong.
-///
-/// That refusal is permanent rather than pending, so it selects the manual path here
-/// instead of panicking.
+/// Load `fragment` (role `ident`, shaped by `edges`) from a row-major window.
 #[cube]
 fn load_fragment<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric>(
     src: &Tile<T>,
@@ -234,10 +220,9 @@ fn load_fragment<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric>(
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
     #[comptime] io: MmaIOConfig,
-    #[comptime] m: usize,
-    #[comptime] n: usize,
-    #[comptime] k: usize,
+    #[comptime] edges: (usize, usize),
 ) {
+    // Fall back to manual loading for gathered operands.
     let gathered = src.gathered();
     let method = comptime!(if gathered {
         LoadMethod::Manual
@@ -245,7 +230,7 @@ fn load_fragment<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric>(
         io.load_method(ident)
     });
     match method {
-        LoadMethod::Manual => load_manual_dispatch(src, fragment, def, ident, layout, m, n, k),
+        LoadMethod::Manual => load_manual_dispatch(src, fragment, def, ident, layout, edges),
         LoadMethod::LoadMatrix => {
             comptime!(panic!(
                 "MmaData::load: the ldmatrix fast path is not yet wired for MemData windows; \
@@ -265,28 +250,23 @@ fn load_manual_dispatch<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric
     def: &MmaDefinition<A, B, CD>,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
-    #[comptime] m: usize,
-    #[comptime] n: usize,
-    #[comptime] k: usize,
+    #[comptime] edges: (usize, usize),
 ) {
     let pack = src.quant_pack();
     let served = src.vector_size();
     let size!(W) = served;
     if comptime!(pack == 1) {
         let size!(WP) = served;
-        load_manual::<T, i8, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, m, n, k);
+        load_manual::<T, i8, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
     } else if comptime!(pack > 1) {
         let size!(WP) = comptime!(served / pack);
-        load_manual::<T, u32, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, m, n, k);
+        load_manual::<T, u32, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
     } else {
-        load_manual::<T, T, W, W, N, A, B, CD>(src, fragment, def, ident, layout, m, n, k);
+        load_manual::<T, T, W, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
     }
 }
 
-/// Manual load: for each register the hardware position `(row, col)` of its element(s), read
-/// through the quant-transparent matrix view, so a stage still holding quantized values decodes
-/// here. `I`/`WP` are the storage element and physical line, `W` the served line; the view serves
-/// whole lines, so the element is lane `col % W` of line `col / W`.
+/// Manual load: reads elements for each register from `src` using the matrix view.
 #[cube]
 fn load_manual<
     T: Numeric,
@@ -303,28 +283,21 @@ fn load_manual<
     def: &MmaDefinition<A, B, CD>,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
-    #[comptime] m: usize,
-    #[comptime] n: usize,
-    #[comptime] k: usize,
+    #[comptime] edges: (usize, usize),
 ) {
     let num_vectors = def.vectors_per_lane(ident);
     let vector_size = def.vector_size(ident);
     let lane_id = UNIT_POS_PLANE;
     let served = src.vector_size();
     let width = comptime!(served as u32);
-    // The view is shaped `(rows, cols)` by the stage's own space, so a transposed read would
-    // index outside it on a non-square tile. Every `MmaData` constructor states row-major today;
-    // wiring col-major means giving the view a transposing layout, not swapping the coordinates.
+    // Only row-major layout is currently supported for manual fragment loads.
     comptime!(assert!(
         matches!(layout, MatrixLayout::RowMajor),
         "MmaData::load: a manual fragment load reads a row-major stage; \
          {layout:?} is not wired through the matrix view"
     ));
 
-    // The fragment's own edges, not the stage's trailing two axes: an operand contracting over
-    // several logical axes (a convolution's taps and channels) flattens them into `k`, and a
-    // gathered stage folds that logical coordinate onto its compacted cells underneath.
-    let (rows, cols) = comptime!(fragment_edges(ident, m, n, k));
+    let (rows, cols) = comptime!(edges);
     let view = src.fragment_matrix::<I, WP, W>(rows, cols);
 
     #[unroll]

--- a/crates/cubek-tile/src/tile/mma.rs
+++ b/crates/cubek-tile/src/tile/mma.rs
@@ -130,10 +130,17 @@ impl<T: Numeric> MmaData<T> {
         let io = comptime!(self.io);
         let def = MmaDefinition::<T, T, T>::new(m, n, k);
         match &mut self.fragment {
-            MmaFragment::Lhs(f) => load_fragment(src, f, &def, MatrixIdent::A, layout, io),
-            MmaFragment::Rhs(f) => load_fragment(src, f, &def, MatrixIdent::B, layout, io),
+            MmaFragment::Lhs(f) => {
+                let e = comptime!(fragment_edges(MatrixIdent::A, m, n, k));
+                load_fragment(src, f, &def, MatrixIdent::A, layout, io, e)
+            }
+            MmaFragment::Rhs(f) => {
+                let e = comptime!(fragment_edges(MatrixIdent::B, m, n, k));
+                load_fragment(src, f, &def, MatrixIdent::B, layout, io, e)
+            }
             MmaFragment::Acc(f) => {
-                load_fragment(src, f, &def, MatrixIdent::Accumulator, layout, io)
+                let e = comptime!(fragment_edges(MatrixIdent::Accumulator, m, n, k));
+                load_fragment(src, f, &def, MatrixIdent::Accumulator, layout, io, e)
             }
         }
     }
@@ -200,6 +207,16 @@ fn register_rhs_size<R: Numeric>(def: &MmaDefinition<R, R, R>) {
 // `MemData` window: a row-major stage addressed by `window_slice()` + scalar `row_stride()`).
 // ===========================================================================
 
+/// The `(rows, cols)` edges of the matrix a fragment of role `ident` reads out of an `m x n x k`
+/// instruction: `A` is `m x k`, `B` is `k x n`, and the accumulator `m x n`.
+fn fragment_edges(ident: MatrixIdent, m: usize, n: usize, k: usize) -> (usize, usize) {
+    match ident {
+        MatrixIdent::A => (m, k),
+        MatrixIdent::B => (k, n),
+        MatrixIdent::Accumulator => (m, n),
+    }
+}
+
 /// Fill every register slot with `value`.
 #[cube]
 fn fill_registers<E: Numeric, N: Size>(fragment: &mut Array<Vector<E, N>>, value: E) {
@@ -213,6 +230,14 @@ fn fill_registers<E: Numeric, N: Size>(fragment: &mut Array<Vector<E, N>>, value
 
 /// Load `fragment` (role `ident`) from `mem`'s row-major window. `ldmatrix` needs a vectorized
 /// row slice, which a `MemData` window cannot serve yet, so that path is refused rather than wrong.
+///
+/// A gathered operand never consults the config: `ldmatrix` reads a raw strided tile, which no
+/// gather is expressible in, the same objection the cmma leaf is refused a gather for. Its manual
+/// load reads element by element through [`Tile::fragment_matrix`], so the compacted stage folds
+/// underneath. That refusal is permanent rather than pending, so it selects the manual path here
+/// instead of panicking: a host-derived [`MmaIOConfig::new`] picks `LoadMatrix` on any backend
+/// advertising `ldmatrix` over the stage's element, and a convolution has no reason to be denied
+/// that config when the leaf it lands on can serve it.
 #[cube]
 fn load_fragment<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric>(
     src: &Tile<T>,
@@ -221,9 +246,16 @@ fn load_fragment<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric>(
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
     #[comptime] io: MmaIOConfig,
+    #[comptime] edges: (usize, usize),
 ) {
-    match io.load_method(ident) {
-        LoadMethod::Manual => load_manual_dispatch(src, fragment, def, ident, layout),
+    let gathered = src.gathered();
+    let method = comptime!(if gathered {
+        LoadMethod::Manual
+    } else {
+        io.load_method(ident)
+    });
+    match method {
+        LoadMethod::Manual => load_manual_dispatch(src, fragment, def, ident, layout, edges),
         LoadMethod::LoadMatrix => {
             comptime!(panic!(
                 "MmaData::load: the ldmatrix fast path is not yet wired for MemData windows; \
@@ -243,18 +275,19 @@ fn load_manual_dispatch<T: Numeric, N: Size, A: Numeric, B: Numeric, CD: Numeric
     def: &MmaDefinition<A, B, CD>,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
+    #[comptime] edges: (usize, usize),
 ) {
     let pack = src.quant_pack();
     let served = src.vector_size();
     let size!(W) = served;
     if comptime!(pack == 1) {
         let size!(WP) = served;
-        load_manual::<T, i8, WP, W, N, A, B, CD>(src, fragment, def, ident, layout);
+        load_manual::<T, i8, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
     } else if comptime!(pack > 1) {
         let size!(WP) = comptime!(served / pack);
-        load_manual::<T, u32, WP, W, N, A, B, CD>(src, fragment, def, ident, layout);
+        load_manual::<T, u32, WP, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
     } else {
-        load_manual::<T, T, W, W, N, A, B, CD>(src, fragment, def, ident, layout);
+        load_manual::<T, T, W, W, N, A, B, CD>(src, fragment, def, ident, layout, edges);
     }
 }
 
@@ -278,6 +311,7 @@ fn load_manual<
     def: &MmaDefinition<A, B, CD>,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
+    #[comptime] edges: (usize, usize),
 ) {
     let num_vectors = def.vectors_per_lane(ident);
     let vector_size = def.vector_size(ident);
@@ -293,8 +327,11 @@ fn load_manual<
          {layout:?} is not wired through the matrix view"
     ));
 
-    // A single matrix: an mma tile carries no batch axes.
-    let view = src.matrix_transparent::<I, WP, W>(0usize);
+    // The fragment's own edges, not the stage's trailing two axes: an operand contracting over
+    // several logical axes (a convolution's taps and channels) flattens them into `k`, and a
+    // gathered stage folds that logical coordinate onto its compacted cells underneath.
+    let (rows, cols) = comptime!(edges);
+    let view = src.fragment_matrix::<I, WP, W>(rows, cols);
 
     #[unroll]
     for i in 0..num_vectors {

--- a/crates/cubek-tile/src/tile/view/coords.rs
+++ b/crates/cubek-tile/src/tile/view/coords.rs
@@ -3,7 +3,10 @@
 //! layout answers `is_in_bounds` with. Kept apart from the layouts themselves so a reshaper and a
 //! projection reach the same `unravel` rather than each spelling one out.
 
-use cubecl::{prelude::*, std::tensor::layout::{Coords2d, CoordsDyn}};
+use cubecl::{
+    prelude::*,
+    std::tensor::layout::{Coords2d, CoordsDyn},
+};
 
 use crate::*;
 

--- a/crates/cubek-tile/src/tile/view/coords.rs
+++ b/crates/cubek-tile/src/tile/view/coords.rs
@@ -1,0 +1,69 @@
+//! The coordinate arithmetic the tile's [`Layout`](cubecl::std::tensor::layout::Layout)s share:
+//! unraveling a flat index over a group of extents, joining two groups, and the box test each
+//! layout answers `is_in_bounds` with. Kept apart from the layouts themselves so a reshaper and a
+//! projection reach the same `unravel` rather than each spelling one out.
+
+use cubecl::{prelude::*, std::tensor::layout::{Coords2d, CoordsDyn}};
+
+use crate::*;
+
+/// Unravels a flat row-major index into coordinates over the given extents: entry `p` is
+/// `i / extents[p+1..].product() % extents[p]`.
+///
+/// The leading entry skips the modulo: an index within the box never overflows it, and dropping
+/// the operation lets the divide fold when the extents are constant.
+#[cube]
+pub(crate) fn unravel(extents: &Coords<u32>, i: u32) -> Coords<u32> {
+    let n = extents.len();
+    let mut out = Coords::<u32>::new();
+
+    #[unroll]
+    for p in 0..n {
+        let digit = i.fdiv(extents.fproduct(comptime!(((p + 1)..n).collect::<Vec<_>>())));
+        if comptime!(p == 0) {
+            out.push(digit);
+        } else {
+            out.push(digit.frem(extents.at(p)));
+        }
+    }
+
+    out
+}
+
+/// Concatenates two coordinate lists into dynamic coordinates.
+#[cube]
+pub(crate) fn concat(leading: &Coords<u32>, trailing: &Coords<u32>) -> CoordsDyn {
+    let mut out = CoordsDyn::new();
+
+    #[unroll]
+    for p in 0..leading.len() {
+        out.push(leading.at(p));
+    }
+    #[unroll]
+    for p in 0..trailing.len() {
+        out.push(trailing.at(p));
+    }
+
+    out
+}
+
+/// Whether every coordinate of `pos` falls inside `shape`.
+#[cube]
+pub(crate) fn within(shape: &Coords<u32>, pos: CoordsDyn) -> bool {
+    let mut valid = true;
+
+    #[unroll]
+    for p in 0..shape.len() {
+        valid = valid && pos[p] < shape.at(p);
+    }
+
+    valid
+}
+
+/// [`within`] at rank two, where the edges are a pair rather than a list.
+#[cube]
+pub(crate) fn within_2d(pos: Coords2d, shape: Coords2d) -> bool {
+    let (row, col) = pos;
+    let (rows, cols) = shape;
+    row < rows && col < cols
+}

--- a/crates/cubek-tile/src/tile/view/flat.rs
+++ b/crates/cubek-tile/src/tile/view/flat.rs
@@ -16,7 +16,7 @@ pub type FlatView<'a, T> = MaskedView<'a, T, Coords1d>;
 /// The mutable twin of [`FlatView`].
 pub type FlatViewMut<'a, T> = MaskedViewMut<'a, T, Coords1d>;
 
-/// Maps a flat row-major index to an N-D coordinate over `shape`: the inverse of a
+/// Maps a flat row-major index to an N-D coordinate over `shape` ([`unravel`]): the inverse of a
 /// strided dot. Re-view a [`Window`]ed [`View`](cubecl::std::tensor::View) through this to walk it
 /// linearly (`shape()` is the element count) without re-deriving strides in the kernel.
 /// A static window's extents are constant handles, so the decode divides by constants.
@@ -38,21 +38,7 @@ impl Layout for FlatLayout {
     type SourceCoordinates = CoordsDyn;
 
     fn to_source_pos(&self, pos: Self::Coordinates) -> Self::SourceCoordinates {
-        let rank = self.shape.len().comptime();
-        let mut out = CoordsDyn::new();
-        let mut offs = pos as u32;
-
-        // Peel off the least-significant dim each step (row-major), carrying the quotient up.
-        #[unroll]
-        for i in 0..rank {
-            let dim = rank - i - 1;
-            let extent = self.shape.at(dim);
-            out.push(offs % extent);
-            offs /= extent;
-        }
-
-        out.reverse(); // pushed last→first; restore ascending dim order
-        out
+        unravel(&self.shape, pos as u32).to_dyn()
     }
 
     fn to_source_pos_checked(&self, pos: Self::Coordinates) -> (Self::SourceCoordinates, bool) {

--- a/crates/cubek-tile/src/tile/view/matrix.rs
+++ b/crates/cubek-tile/src/tile/view/matrix.rs
@@ -21,8 +21,7 @@ pub type MatrixViewMut<'a, T> = MaskedViewMut<'a, T, Coords2d>;
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct BatchMatrix {
-    /// [`Coords`], not [`CoordsDyn`]: a `Sequence` holder copies its elements into mutable slots,
-    /// which erases the constness the fold arithmetic downstream needs (see [`Coords`](crate::Coords)).
+    /// Leading batch coordinates.
     batches: Coords<u32>,
     tile_shape: Coords2d,
 }
@@ -44,14 +43,10 @@ impl Layout for BatchMatrix {
 
     fn to_source_pos(&self, pos: Self::Coordinates) -> Self::SourceCoordinates {
         let (t0, t1) = pos;
-        let mut out = CoordsDyn::new();
-        #[unroll]
-        for p in 0..self.batches.len() {
-            out.push(self.batches.at(p));
-        }
-        out.push(t0);
-        out.push(t1);
-        out
+        let mut exposed = Coords::<u32>::new();
+        exposed.push(t0);
+        exposed.push(t1);
+        concat(&self.batches, &exposed)
     }
 
     fn to_source_pos_checked(&self, pos: Self::Coordinates) -> (Self::SourceCoordinates, bool) {
@@ -64,13 +59,11 @@ impl Layout for BatchMatrix {
     }
 
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
-        let (t0, t1) = pos;
-        let (s0, s1) = self.tile_shape;
-        t0 < s0 && t1 < s1
+        within_2d(pos, self.tile_shape)
     }
 }
 
-/// What every 2-D reader of a tile goes through: a [`BatchMatrix`] over the operand's mapping.
+/// A 2-D matrix view over a projected tile with batch dimensions.
 pub type ProjectedBatchMatrix = Projected<BatchMatrix>;
 
 /// What an mma fragment reads its stage through: a [`GroupedMatrix`] over the operand's mapping.
@@ -117,19 +110,10 @@ impl Layout for GroupedMatrix {
 
     fn to_source_pos(&self, pos: Self::Coordinates) -> Self::SourceCoordinates {
         let (row, col) = pos;
-        let rows = unravel(&self.row_extents, row);
-        let cols = unravel(&self.col_extents, col);
-
-        let mut out = CoordsDyn::new();
-        #[unroll]
-        for p in 0..rows.len() {
-            out.push(rows.at(p));
-        }
-        #[unroll]
-        for p in 0..cols.len() {
-            out.push(cols.at(p));
-        }
-        out
+        concat(
+            &unravel(&self.row_extents, row),
+            &unravel(&self.col_extents, col),
+        )
     }
 
     fn to_source_pos_checked(&self, pos: Self::Coordinates) -> (Self::SourceCoordinates, bool) {
@@ -142,10 +126,33 @@ impl Layout for GroupedMatrix {
     }
 
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
-        let (row, col) = pos;
-        let (s0, s1) = self.tile_shape;
-        row < s0 && col < s1
+        within_2d(pos, self.tile_shape)
     }
+}
+
+/// Concatenates two coordinate lists into dynamic coordinates.
+#[cube]
+fn concat(leading: &Coords<u32>, trailing: &Coords<u32>) -> CoordsDyn {
+    let mut out = CoordsDyn::new();
+
+    #[unroll]
+    for p in 0..leading.len() {
+        out.push(leading.at(p));
+    }
+    #[unroll]
+    for p in 0..trailing.len() {
+        out.push(trailing.at(p));
+    }
+
+    out
+}
+
+/// Checks if a 2-D coordinate is within bounds.
+#[cube]
+fn within_2d(pos: Coords2d, shape: Coords2d) -> bool {
+    let (row, col) = pos;
+    let (rows, cols) = shape;
+    row < rows && col < cols
 }
 
 /// The leading (batch) extents a matrix index unravels over, in the space's axis order.
@@ -174,12 +181,9 @@ fn leading_extents(
     out
 }
 
-/// Unravel a flat index over `extents`: `out[p] = (i / Π extents[p+1..]) % extents[p]`. Folding
-/// throughout, so comptime extents and a comptime index leave no arithmetic behind. The outermost
-/// digit keeps the bare quotient, for the reason
-/// [`Projection::digit`](crate::Projection::digit)'s outermost fragment carries `None`.
+/// Unravels a flat index into coordinates over the given extents.
 #[cube]
-fn unravel(extents: &Coords<u32>, i: u32) -> Coords<u32> {
+pub(crate) fn unravel(extents: &Coords<u32>, i: u32) -> Coords<u32> {
     let n = extents.len();
     let mut out = Coords::<u32>::new();
 
@@ -226,6 +230,7 @@ pub(crate) fn matrix_split(space: &Space, rows: usize, cols: usize, vector_size:
     let rank = space.rank();
     let mut split = rank;
     let mut trailing = 1;
+    // Find the split point that matches the column count.
     while split > 0 && trailing < cols {
         split -= 1;
         trailing *= space.extent_at(split);
@@ -264,24 +269,9 @@ pub(crate) fn grouped_matrix(
     let rank = comptime!(space.rank());
     let split = comptime!(matrix_split(space, rows, cols, vector_size));
 
-    let mut row_extents = Coords::<u32>::new();
-    #[unroll]
-    for p in 0..split {
-        row_extents.push(comptime!(space.extent_at(p) as u32));
-    }
-
-    let mut col_extents = Coords::<u32>::new();
-    #[unroll]
-    for p in split..rank {
-        let e = comptime!(space.extent_at(p));
-        col_extents.push(comptime!(
-            (if p == rank - 1 { e / vector_size } else { e }) as u32
-        ));
-    }
-
     GroupedMatrix::new(
-        row_extents,
-        col_extents,
+        const_coords(comptime!(line_extents(space, vector_size, 0, split))),
+        const_coords(comptime!(line_extents(space, vector_size, split, rank))),
         rows,
         comptime!(cols / vector_size),
     )
@@ -344,10 +334,15 @@ impl<T: Numeric> Tile<T> {
         }
     }
 
+    /// Mutable version of [`matrix`](Tile::matrix). Only supported for direct projections.
     pub fn matrix_mut<W: Size>(&mut self, i: usize) -> MatrixViewMut<'_, Vector<T, W>> {
         let vector_size = self.vector_size();
         match &mut self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => {
+                comptime!(assert!(
+                    g.projection.is_direct(),
+                    "Tile::matrix_mut: a gathered operand aliases under a write"
+                ));
                 let bound = g.extent();
                 let layout = projected_batch_matrix(
                     &bound,

--- a/crates/cubek-tile/src/tile/view/matrix.rs
+++ b/crates/cubek-tile/src/tile/view/matrix.rs
@@ -3,6 +3,12 @@
 //! two exposed; [`Tile::matrix`]/[`Tile::matrix_mut`] then wrap it as a [`MatrixView`]/
 //! [`MatrixViewMut`] (a [`MaskedView`] carrying the comptime overhang-`check` flag). Used by the
 //! matmul leaves and [`copy_2d()`].
+//!
+//! [`ProjectedBatchMatrix`] is the same surface over a *gathered* operand, whose logical axes
+//! outnumber its buffer's physical ones: [`BatchMatrix`] resolves the matrix coordinate to the
+//! tile's logical one, then [`AxisProjection`] folds that onto the window's physical one. Every
+//! generalized step is gated on [`Projection::is_direct`], so a direct operand keeps its exact
+//! previous codegen.
 
 use cubecl::{
     prelude::*,
@@ -21,13 +27,16 @@ pub type MatrixViewMut<'a, T> = MaskedViewMut<'a, T, Coords2d>;
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct BatchMatrix {
-    batches: CoordsDyn,
+    /// [`Coords`], not [`CoordsDyn`]: the pinned coordinates are never reassigned, and a
+    /// `Sequence` holder copies them into mutable slots, which erases the constness the fold
+    /// arithmetic downstream needs (see [`Coords`](crate::Coords)).
+    batches: Coords<u32>,
     tile_shape: Coords2d,
 }
 
 #[cube]
 impl BatchMatrix {
-    pub fn new(batches: CoordsDyn, #[comptime] rows: usize, #[comptime] cols: usize) -> Self {
+    pub fn new(batches: Coords<u32>, #[comptime] rows: usize, #[comptime] cols: usize) -> Self {
         BatchMatrix {
             batches,
             tile_shape: (rows as u32, cols as u32).runtime(),
@@ -42,7 +51,13 @@ impl Layout for BatchMatrix {
 
     fn to_source_pos(&self, pos: Self::Coordinates) -> Self::SourceCoordinates {
         let (t0, t1) = pos;
-        let mut out = self.batches.clone();
+        // Built up rather than cloned-and-extended: an empty `Sequence` has nothing to copy into
+        // mutable slots, so each pinned coordinate reaches the source position as it was folded.
+        let mut out = CoordsDyn::new();
+        #[unroll]
+        for p in 0..self.batches.len() {
+            out.push(self.batches.at(p));
+        }
         out.push(t0);
         out.push(t1);
         out
@@ -64,61 +79,68 @@ impl Layout for BatchMatrix {
     }
 }
 
+/// [`BatchMatrix`] over a *gathered* operand.
+pub type ProjectedBatchMatrix = Projected<BatchMatrix>;
+
+/// [`GroupedMatrix`] over a *gathered* operand: what an mma fragment reads a compacted stage
+/// through.
+pub type ProjectedGroupedMatrix = Projected<GroupedMatrix>;
+
+/// A [`Layout`] presenting the tile's *whole* logical box as one `(row, col)` matrix: `row`
+/// unravels over a leading group of logical axes, `col` over the trailing group (the innermost a
+/// line count). Where [`BatchMatrix`] pins the leading axes and exposes exactly two, this
+/// flattens them into the two edges.
+///
+/// That is the difference between a tile that has a matrix face and one that *is* a matrix. An
+/// mma fragment contracts over a single `k` edge, but an operand's contraction can span several
+/// logical axes (a convolution contracts over its taps *and* its channels), and no pinning
+/// exposes that as one edge. Splitting the axes into two groups does, and the split is where the
+/// contraction starts: `[M…, K…]` for the `A` role, `[K…, N…]` for `B`.
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
-pub struct ProjectedBatchMatrix {
-    batches: CoordsDyn,
+pub struct GroupedMatrix {
+    /// Leading group, in the space's axis order.
+    row_extents: Coords<u32>,
+    /// Trailing group, the innermost a line count.
+    col_extents: Coords<u32>,
     tile_shape: Coords2d,
-    #[cube(comptime)]
-    projection: Projection,
-    #[cube(comptime)]
-    space: Space,
 }
 
 #[cube]
-impl ProjectedBatchMatrix {
+impl GroupedMatrix {
     pub fn new(
-        batches: CoordsDyn,
+        row_extents: Coords<u32>,
+        col_extents: Coords<u32>,
         #[comptime] rows: usize,
         #[comptime] cols: usize,
-        #[comptime] projection: Projection,
-        #[comptime] space: Space,
     ) -> Self {
-        ProjectedBatchMatrix {
-            batches,
+        GroupedMatrix {
+            row_extents,
+            col_extents,
             tile_shape: (rows as u32, cols as u32).runtime(),
-            projection,
-            space,
         }
     }
 }
 
 #[cube]
-impl Layout for ProjectedBatchMatrix {
+impl Layout for GroupedMatrix {
     type Coordinates = Coords2d;
     type SourceCoordinates = CoordsDyn;
 
     fn to_source_pos(&self, pos: Self::Coordinates) -> Self::SourceCoordinates {
-        let (t0, t1) = pos;
-        let mut logical = self.batches.clone();
-        logical.push(t0);
-        logical.push(t1);
+        let (row, col) = pos;
+        let rows = unravel(&self.row_extents, row);
+        let cols = unravel(&self.col_extents, col);
 
         let mut out = CoordsDyn::new();
-
         #[unroll]
-        for pa in 0..comptime!(self.projection.physical_rank()) {
-            let n = comptime!(self.projection.physical_axis(pa).terms().len());
-            let mut terms = Coords::<u32>::new();
-            #[unroll]
-            for t in 0..n {
-                let term = comptime!(self.projection.physical_axis(pa).terms()[t]);
-                let p = comptime!(self.space.position(term.axis));
-                terms.push(logical[p].fmul(comptime!(term.scale.get() as u32)));
-            }
-            out.push(terms.fsum(comptime!((0..n).collect::<Vec<_>>())));
+        for p in 0..rows.len() {
+            out.push(rows.at(p));
         }
-
+        #[unroll]
+        for p in 0..cols.len() {
+            out.push(cols.at(p));
+        }
         out
     }
 
@@ -132,70 +154,169 @@ impl Layout for ProjectedBatchMatrix {
     }
 
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
-        let (t0, t1) = pos;
+        let (row, col) = pos;
         let (s0, s1) = self.tile_shape;
-        t0 < s0 && t1 < s1
+        row < s0 && col < s1
     }
 }
 
+/// The leading (batch) extents a matrix index unravels over, in the space's axis order.
+///
+/// A direct operand reads them off the window, which is the only place a
+/// [`Dynamic`](crate::Extent::Dynamic) top-level axis carries a size. A gathered one reads them
+/// off the space: its window is boxed in *physical* axes, which are fewer than the logical ones
+/// and are combinations of them, so no entry of it sizes a logical axis. Those extents are always
+/// comptime, the same ones [`axis_projection`] shapes its logical box with.
 #[cube]
-fn batch_matrix(
-    bound: Coords<u32>,
+fn leading_extents(
+    bound: &Coords<u32>,
     #[comptime] space: Space,
+    #[comptime] gathered: bool,
+) -> Coords<u32> {
+    let mut out = Coords::<u32>::new();
+
+    #[unroll]
+    for p in 0..comptime!(space.rank() - 2) {
+        if comptime!(gathered) {
+            out.push(comptime!(space.extent_at(p) as u32));
+        } else {
+            out.push(bound.at(p));
+        }
+    }
+
+    out
+}
+
+/// Unravel a flat index over `extents`: `out[p] = (i / Π extents[p+1..]) % extents[p]`. Folding
+/// throughout, so comptime extents and a comptime index leave no arithmetic behind.
+///
+/// The outermost digit keeps the bare quotient: it has no enclosing block to be reduced against,
+/// and `i` is always within the product (a matrix index counts the matrices, a row counts the
+/// rows), so the modulo there is the identity. Same reasoning as
+/// [`Projection::digit`](crate::Projection::digit), whose outermost fragment carries `None`.
+#[cube]
+fn unravel(extents: &Coords<u32>, i: u32) -> Coords<u32> {
+    let n = extents.len();
+    let mut out = Coords::<u32>::new();
+
+    #[unroll]
+    for p in 0..n {
+        let digit = i.fdiv(extents.fproduct(comptime!(((p + 1)..n).collect::<Vec<_>>())));
+        if comptime!(p == 0) {
+            out.push(digit);
+        } else {
+            out.push(digit.frem(extents.at(p)));
+        }
+    }
+
+    out
+}
+
+/// The `i`-th batch matrix of a tile whose window is `bound`: leading axes pinned to `i`
+/// unraveled over their extents, trailing two exposed. `cols` is a line count, so the innermost
+/// extent divides by the width.
+#[cube]
+pub(crate) fn batch_matrix(
+    bound: &Coords<u32>,
+    #[comptime] space: Space,
+    #[comptime] projection: Projection,
     #[comptime] vector_size: usize,
     i: usize,
 ) -> BatchMatrix {
     let rank = comptime!(space.rank());
-    let shape = bound;
     let rows = comptime!(space.extent_at(rank - 2));
     let cols = comptime!(space.extent_at(rank - 1) / vector_size);
+    let extents = leading_extents(bound, comptime!(space), comptime!(!projection.is_direct()));
 
-    let mut batches = CoordsDyn::new();
-
-    #[unroll]
-    for p in 0..rank - 2 {
-        let weight = shape.fproduct(comptime!(((p + 1)..(rank - 2)).collect::<Vec<_>>()));
-        batches.push(i.fcast::<u32>().fdiv(weight).frem(shape.at(p)));
-    }
-
-    BatchMatrix::new(batches, rows, cols)
+    BatchMatrix::new(unravel(&extents, i.fcast::<u32>()), rows, cols)
 }
 
+/// Where the space's axes split into a leading group whose extents multiply to `rows` and a
+/// trailing group whose extents multiply to `cols`, both scalar: the position the trailing group
+/// starts at.
+///
+/// The two edges pin the split, so a caller states the matrix it wants rather than how the tile's
+/// axes are grouped into it. A `(rows, cols)` pair that is not a face of this box is a mismatched
+/// fragment, caught here rather than read out of bounds.
+pub(crate) fn matrix_split(space: &Space, rows: usize, cols: usize) -> usize {
+    let rank = space.rank();
+    let mut split = rank;
+    let mut trailing = 1;
+    while split > 0 && trailing < cols {
+        split -= 1;
+        trailing *= space.extent_at(split);
+    }
+    let leading: usize = (0..split).map(|p| space.extent_at(p)).product();
+    assert!(
+        trailing == cols && leading == rows,
+        "matrix_split: no split of this tile's axes gives a {rows}x{cols} matrix (the trailing \
+         axes multiply to {trailing}, the leading ones to {leading})"
+    );
+    // The innermost axis is the vectorized one, and the view serves lines along `col`, so it has
+    // to land in the trailing group.
+    assert!(
+        split < rank,
+        "matrix_split: the innermost (vectorized) axis must be part of the column group"
+    );
+    split
+}
+
+/// The tile's whole logical box as one `rows x cols` matrix, its axes split by
+/// [`matrix_split`]. `cols` is scalar, as a fragment states it; the view serves lines, so the
+/// column edge and the innermost extent both divide by the width.
+#[cube]
+pub(crate) fn grouped_matrix(
+    #[comptime] space: Space,
+    #[comptime] vector_size: usize,
+    #[comptime] rows: usize,
+    #[comptime] cols: usize,
+) -> GroupedMatrix {
+    let rank = comptime!(space.rank());
+    let split = comptime!(matrix_split(&space, rows, cols));
+
+    let mut row_extents = Coords::<u32>::new();
+    #[unroll]
+    for p in 0..split {
+        row_extents.push(comptime!(space.extent_at(p) as u32));
+    }
+
+    let mut col_extents = Coords::<u32>::new();
+    #[unroll]
+    for p in split..rank {
+        let e = comptime!(space.extent_at(p));
+        col_extents.push(comptime!(
+            (if p == rank - 1 { e / vector_size } else { e }) as u32
+        ));
+    }
+
+    GroupedMatrix::new(
+        row_extents,
+        col_extents,
+        rows,
+        comptime!(cols / vector_size),
+    )
+}
+
+/// [`batch_matrix`] with the operand's [`Projection`] applied under it: what a gathered operand's
+/// 2-D readers go through.
 #[cube]
 fn projected_batch_matrix(
-    bound: Coords<u32>,
+    bound: &Coords<u32>,
     #[comptime] space: Space,
     #[comptime] projection: Projection,
     #[comptime] vector_size: usize,
     i: usize,
 ) -> ProjectedBatchMatrix {
-    let rank = comptime!(space.rank());
-    let rows = comptime!(space.extent_at(rank - 2));
-    let cols = comptime!(space.extent_at(rank - 1) / vector_size);
-
-    let mut batches = CoordsDyn::new();
-
-    #[unroll]
-    for p in 0..rank - 2 {
-        let mut weight = 1u32.runtime();
-        #[unroll]
-        for q in p + 1..rank - 2 {
-            let axis_q = comptime!(space.axis_at(q));
-            let p_idx = comptime!(space.position(axis_q));
-            let raw_q = bound.at(p_idx).fcast::<u32>();
-            let w_q = comptime!(if p_idx == rank - 1 { vector_size } else { 1 });
-            weight *= comptime!(w_q as u32).runtime() * raw_q;
-        }
-        let axis_p = comptime!(space.axis_at(p));
-        let p_idx = comptime!(space.position(axis_p));
-        let raw_p = bound.at(p_idx).fcast::<u32>();
-        let w_p = comptime!(if p_idx == rank - 1 { vector_size } else { 1 });
-        let extent = comptime!(w_p as u32).runtime() * raw_p;
-
-        batches.push(i.fcast::<u32>().fdiv(weight).frem(extent));
-    }
-
-    ProjectedBatchMatrix::new(batches, rows, cols, projection, comptime!(space))
+    ProjectedBatchMatrix::new(
+        batch_matrix(
+            bound,
+            comptime!(space.clone()),
+            comptime!(projection.clone()),
+            vector_size,
+            i,
+        ),
+        axis_projection(comptime!(space), comptime!(projection), vector_size),
+    )
 }
 
 #[cube]
@@ -205,18 +326,14 @@ impl<T: Numeric> Tile<T> {
         let vector_size = self.vector_size();
         match &self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => {
-                if comptime!(g.projection.is_direct()) {
-                    let layout =
-                        batch_matrix(g.extent(), comptime!(self.space.clone()), vector_size, i);
+                let bound = g.extent();
+                let space = comptime!(self.space.clone());
+                let projection = comptime!(g.projection.clone());
+                if comptime!(projection.is_direct()) {
+                    let layout = batch_matrix(&bound, space, projection, vector_size, i);
                     g.masked::<W, Coords2d, BatchMatrix>(layout)
                 } else {
-                    let layout = projected_batch_matrix(
-                        g.extent(),
-                        comptime!(self.space.clone()),
-                        comptime!(g.projection.clone()),
-                        vector_size,
-                        i,
-                    );
+                    let layout = projected_batch_matrix(&bound, space, projection, vector_size, i);
                     g.masked::<W, Coords2d, ProjectedBatchMatrix>(layout)
                 }
             }
@@ -231,19 +348,15 @@ impl<T: Numeric> Tile<T> {
         let vector_size = self.vector_size();
         match &mut self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => {
-                if comptime!(g.projection.is_direct()) {
-                    let layout =
-                        batch_matrix(g.extent(), comptime!(self.space.clone()), vector_size, i);
-                    g.masked_mut::<W>(layout)
+                let bound = g.extent();
+                let space = comptime!(self.space.clone());
+                let projection = comptime!(g.projection.clone());
+                if comptime!(projection.is_direct()) {
+                    let layout = batch_matrix(&bound, space, projection, vector_size, i);
+                    g.masked_mut::<W, Coords2d, BatchMatrix>(layout)
                 } else {
-                    let layout = projected_batch_matrix(
-                        g.extent(),
-                        comptime!(self.space.clone()),
-                        comptime!(g.projection.clone()),
-                        vector_size,
-                        i,
-                    );
-                    g.masked_mut_projected::<W>(layout)
+                    let layout = projected_batch_matrix(&bound, space, projection, vector_size, i);
+                    g.masked_mut::<W, Coords2d, ProjectedBatchMatrix>(layout)
                 }
             }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
@@ -265,19 +378,15 @@ impl<T: Numeric> Tile<T> {
         let vector_size = self.vector_size();
         match &self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => {
-                if comptime!(g.projection.is_direct()) {
-                    let layout =
-                        batch_matrix(g.extent(), comptime!(self.space.clone()), vector_size, i);
-                    g.matrix_transparent::<I, WP, W>(layout)
+                let bound = g.extent();
+                let space = comptime!(self.space.clone());
+                let projection = comptime!(g.projection.clone());
+                if comptime!(projection.is_direct()) {
+                    let layout = batch_matrix(&bound, space, projection, vector_size, i);
+                    g.matrix_transparent::<I, WP, W, BatchMatrix>(layout)
                 } else {
-                    let layout = projected_batch_matrix(
-                        g.extent(),
-                        comptime!(self.space.clone()),
-                        comptime!(g.projection.clone()),
-                        vector_size,
-                        i,
-                    );
-                    g.matrix_transparent_projected::<I, WP, W>(layout)
+                    let layout = projected_batch_matrix(&bound, space, projection, vector_size, i);
+                    g.matrix_transparent::<I, WP, W, ProjectedBatchMatrix>(layout)
                 }
             }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
@@ -287,5 +396,110 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::matrix_transparent: a tma source has no element view")
             }
         }
+    }
+
+    /// This tile's whole logical box as the `rows x cols` matrix a fragment of that shape reads,
+    /// quantization-transparent. The [`GroupedMatrix`] twin of
+    /// [`matrix_transparent`](Tile::matrix_transparent): several logical axes may flatten into one
+    /// edge, so an operand whose contraction spans its taps *and* its channels still has a `k`
+    /// edge, and a gathered one reads it straight out of its compacted stage.
+    ///
+    /// `cols` is scalar, as an mma definition states it; the view serves lines.
+    pub fn fragment_matrix<I: Numeric, WP: Size, W: Size>(
+        &self,
+        #[comptime] rows: usize,
+        #[comptime] cols: usize,
+    ) -> MatrixView<'_, Vector<T, W>> {
+        let vector_size = self.vector_size();
+        match &self.tile_kind {
+            TileKind::Gmem(g) | TileKind::Smem(g) => {
+                let space = comptime!(self.space.clone());
+                let projection = comptime!(g.projection.clone());
+                let layout = grouped_matrix(comptime!(space.clone()), vector_size, rows, cols);
+                if comptime!(projection.is_direct()) {
+                    g.matrix_transparent::<I, WP, W, GroupedMatrix>(layout)
+                } else {
+                    let projected = ProjectedGroupedMatrix::new(
+                        layout,
+                        axis_projection(space, projection, vector_size),
+                    );
+                    g.matrix_transparent::<I, WP, W, ProjectedGroupedMatrix>(projected)
+                }
+            }
+            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
+                panic!("Tile::fragment_matrix: a plane tile has no memory view")
+            }
+            TileKind::TmaGmem(_) => {
+                panic!("Tile::fragment_matrix: a tma source has no element view")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OH: Axis = Axis(0);
+    const RH: Axis = Axis(1);
+    const CI: Axis = Axis(2);
+
+    fn space(extents: &[(Axis, usize)]) -> Space {
+        let mut t = Tiling::new().extents(extents);
+        t = t.level(WalkOrder::RowMajor, Schedule::Direct, |mut l| {
+            for &(axis, e) in extents {
+                l = l.axis(axis, Cut::sequential(e));
+            }
+            l
+        });
+        t.build()
+    }
+
+    /// A plain matmul operand: one axis per edge, the split right down the middle.
+    #[test]
+    fn a_rank_two_operand_splits_between_its_axes() {
+        let s = space(&[(OH, 8), (CI, 4)]);
+        assert_eq!(matrix_split(&s, 8, 4), 1);
+    }
+
+    /// The convolution shape: the trailing *two* axes are the contraction, so `k` is their
+    /// product and the split leaves only the output axis in the row group.
+    #[test]
+    fn a_contraction_over_two_axes_splits_before_both() {
+        let s = space(&[(OH, 8), (RH, 2), (CI, 4)]);
+        assert_eq!(matrix_split(&s, 8, 8), 1);
+    }
+
+    /// Both edges spanning several axes, which is what a 2-D convolution's input needs.
+    #[test]
+    fn both_groups_may_span_several_axes() {
+        let s = space(&[(OH, 3), (RH, 4), (CI, 2)]);
+        assert_eq!(matrix_split(&s, 12, 2), 2);
+    }
+
+    /// The smallest column group that reaches `cols` wins, so a degenerate leading axis stays in
+    /// the row group rather than being swept into the column one. Either split addresses the same
+    /// cells; taking the smaller keeps the answer deterministic.
+    #[test]
+    fn a_degenerate_leading_axis_stays_in_the_row_group() {
+        let s = space(&[(OH, 1), (RH, 2), (CI, 4)]);
+        assert_eq!(matrix_split(&s, 1, 8), 1);
+    }
+
+    /// No split gives the asked-for edges: the extents multiply to 32, and 8x8 is not a face.
+    #[test]
+    #[should_panic(expected = "no split of this tile's axes")]
+    fn a_mismatched_fragment_is_refused() {
+        let s = space(&[(OH, 8), (RH, 2), (CI, 2)]);
+        matrix_split(&s, 8, 8);
+    }
+
+    /// The column group must contain the innermost axis: the view serves lines along `col`, so a
+    /// split that leaves the vectorized axis in the row group has no line to read.
+    #[test]
+    #[should_panic(expected = "innermost (vectorized) axis")]
+    fn the_vectorized_axis_must_land_in_the_column_group() {
+        let s = space(&[(OH, 8), (CI, 4)]);
+        matrix_split(&s, 32, 1);
     }
 }

--- a/crates/cubek-tile/src/tile/view/matrix.rs
+++ b/crates/cubek-tile/src/tile/view/matrix.rs
@@ -1,14 +1,8 @@
-//! The 2-D matrix view over a [`Tile`]. [`BatchMatrix`] is a [`Layout`] that re-views the tile's
-//! N-D [`Space`] as a plain [`Coords2d`] `(row, col)` matrix: leading batch axes pinned, trailing
-//! two exposed; [`Tile::matrix`]/[`Tile::matrix_mut`] then wrap it as a [`MatrixView`]/
-//! [`MatrixViewMut`] (a [`MaskedView`] carrying the comptime overhang-`check` flag). Used by the
-//! matmul leaves and [`copy_2d()`].
-//!
-//! [`ProjectedBatchMatrix`] is the same surface over a *gathered* operand, whose logical axes
-//! outnumber its buffer's physical ones: [`BatchMatrix`] resolves the matrix coordinate to the
-//! tile's logical one, then [`AxisProjection`] folds that onto the window's physical one. Every
-//! generalized step is gated on [`Projection::is_direct`], so a direct operand keeps its exact
-//! previous codegen.
+//! The 2-D matrix views over a [`Tile`]. Two [`Layout`]s re-view the tile's N-D [`Space`] as a
+//! plain [`Coords2d`] `(row, col)` matrix: [`BatchMatrix`] pins the leading axes and exposes the
+//! trailing two, [`GroupedMatrix`] flattens every axis into the two edges. [`Tile::matrix`] and
+//! friends then wrap the result as a [`MatrixView`] (a [`MaskedView`] carrying the comptime
+//! overhang-`check` flag). Used by the matmul leaves and [`copy_2d()`].
 
 use cubecl::{
     prelude::*,
@@ -27,9 +21,8 @@ pub type MatrixViewMut<'a, T> = MaskedViewMut<'a, T, Coords2d>;
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct BatchMatrix {
-    /// [`Coords`], not [`CoordsDyn`]: the pinned coordinates are never reassigned, and a
-    /// `Sequence` holder copies them into mutable slots, which erases the constness the fold
-    /// arithmetic downstream needs (see [`Coords`](crate::Coords)).
+    /// [`Coords`], not [`CoordsDyn`]: a `Sequence` holder copies its elements into mutable slots,
+    /// which erases the constness the fold arithmetic downstream needs (see [`Coords`](crate::Coords)).
     batches: Coords<u32>,
     tile_shape: Coords2d,
 }
@@ -51,8 +44,6 @@ impl Layout for BatchMatrix {
 
     fn to_source_pos(&self, pos: Self::Coordinates) -> Self::SourceCoordinates {
         let (t0, t1) = pos;
-        // Built up rather than cloned-and-extended: an empty `Sequence` has nothing to copy into
-        // mutable slots, so each pinned coordinate reaches the source position as it was folded.
         let mut out = CoordsDyn::new();
         #[unroll]
         for p in 0..self.batches.len() {
@@ -79,23 +70,20 @@ impl Layout for BatchMatrix {
     }
 }
 
-/// [`BatchMatrix`] over a *gathered* operand.
+/// What every 2-D reader of a tile goes through: a [`BatchMatrix`] over the operand's mapping.
 pub type ProjectedBatchMatrix = Projected<BatchMatrix>;
 
-/// [`GroupedMatrix`] over a *gathered* operand: what an mma fragment reads a compacted stage
-/// through.
+/// What an mma fragment reads its stage through: a [`GroupedMatrix`] over the operand's mapping.
 pub type ProjectedGroupedMatrix = Projected<GroupedMatrix>;
 
 /// A [`Layout`] presenting the tile's *whole* logical box as one `(row, col)` matrix: `row`
 /// unravels over a leading group of logical axes, `col` over the trailing group (the innermost a
-/// line count). Where [`BatchMatrix`] pins the leading axes and exposes exactly two, this
-/// flattens them into the two edges.
+/// line count).
 ///
-/// That is the difference between a tile that has a matrix face and one that *is* a matrix. An
-/// mma fragment contracts over a single `k` edge, but an operand's contraction can span several
-/// logical axes (a convolution contracts over its taps *and* its channels), and no pinning
-/// exposes that as one edge. Splitting the axes into two groups does, and the split is where the
-/// contraction starts: `[M…, K…]` for the `A` role, `[K…, N…]` for `B`.
+/// An mma fragment contracts over a single `k` edge, but an operand's contraction can span several
+/// logical axes (a convolution contracts over its taps *and* its channels), which no pinning of
+/// trailing axes exposes as one edge. The split is where the contraction starts: `[M…, K…]` for
+/// the `A` role, `[K…, N…]` for `B`.
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct GroupedMatrix {
@@ -165,12 +153,11 @@ impl Layout for GroupedMatrix {
 /// A direct operand reads them off the window, which is the only place a
 /// [`Dynamic`](crate::Extent::Dynamic) top-level axis carries a size. A gathered one reads them
 /// off the space: its window is boxed in *physical* axes, which are fewer than the logical ones
-/// and are combinations of them, so no entry of it sizes a logical axis. Those extents are always
-/// comptime, the same ones [`axis_projection`] shapes its logical box with.
+/// and are combinations of them, so no entry of it sizes a logical axis.
 #[cube]
 fn leading_extents(
     bound: &Coords<u32>,
-    #[comptime] space: Space,
+    #[comptime] space: &Space,
     #[comptime] gathered: bool,
 ) -> Coords<u32> {
     let mut out = Coords::<u32>::new();
@@ -188,12 +175,9 @@ fn leading_extents(
 }
 
 /// Unravel a flat index over `extents`: `out[p] = (i / Π extents[p+1..]) % extents[p]`. Folding
-/// throughout, so comptime extents and a comptime index leave no arithmetic behind.
-///
-/// The outermost digit keeps the bare quotient: it has no enclosing block to be reduced against,
-/// and `i` is always within the product (a matrix index counts the matrices, a row counts the
-/// rows), so the modulo there is the identity. Same reasoning as
-/// [`Projection::digit`](crate::Projection::digit), whose outermost fragment carries `None`.
+/// throughout, so comptime extents and a comptime index leave no arithmetic behind. The outermost
+/// digit keeps the bare quotient, for the reason
+/// [`Projection::digit`](crate::Projection::digit)'s outermost fragment carries `None`.
 #[cube]
 fn unravel(extents: &Coords<u32>, i: u32) -> Coords<u32> {
     let n = extents.len();
@@ -218,15 +202,15 @@ fn unravel(extents: &Coords<u32>, i: u32) -> Coords<u32> {
 #[cube]
 pub(crate) fn batch_matrix(
     bound: &Coords<u32>,
-    #[comptime] space: Space,
-    #[comptime] projection: Projection,
+    #[comptime] space: &Space,
+    #[comptime] gathered: bool,
     #[comptime] vector_size: usize,
     i: usize,
 ) -> BatchMatrix {
     let rank = comptime!(space.rank());
     let rows = comptime!(space.extent_at(rank - 2));
     let cols = comptime!(space.extent_at(rank - 1) / vector_size);
-    let extents = leading_extents(bound, comptime!(space), comptime!(!projection.is_direct()));
+    let extents = leading_extents(bound, comptime!(space), gathered);
 
     BatchMatrix::new(unravel(&extents, i.fcast::<u32>()), rows, cols)
 }
@@ -238,7 +222,7 @@ pub(crate) fn batch_matrix(
 /// The two edges pin the split, so a caller states the matrix it wants rather than how the tile's
 /// axes are grouped into it. A `(rows, cols)` pair that is not a face of this box is a mismatched
 /// fragment, caught here rather than read out of bounds.
-pub(crate) fn matrix_split(space: &Space, rows: usize, cols: usize) -> usize {
+pub(crate) fn matrix_split(space: &Space, rows: usize, cols: usize, vector_size: usize) -> usize {
     let rank = space.rank();
     let mut split = rank;
     let mut trailing = 1;
@@ -253,10 +237,16 @@ pub(crate) fn matrix_split(space: &Space, rows: usize, cols: usize) -> usize {
          axes multiply to {trailing}, the leading ones to {leading})"
     );
     // The innermost axis is the vectorized one, and the view serves lines along `col`, so it has
-    // to land in the trailing group.
+    // to land in the trailing group, whole: the column edge and the innermost extent are both
+    // counted in lines, and a partial line would divide one of them to a different group product.
     assert!(
         split < rank,
         "matrix_split: the innermost (vectorized) axis must be part of the column group"
+    );
+    let innermost = space.extent_at(rank - 1);
+    assert!(
+        innermost.is_multiple_of(vector_size),
+        "matrix_split: the innermost extent {innermost} is not a whole number of {vector_size}-wide lines"
     );
     split
 }
@@ -266,13 +256,13 @@ pub(crate) fn matrix_split(space: &Space, rows: usize, cols: usize) -> usize {
 /// column edge and the innermost extent both divide by the width.
 #[cube]
 pub(crate) fn grouped_matrix(
-    #[comptime] space: Space,
+    #[comptime] space: &Space,
     #[comptime] vector_size: usize,
     #[comptime] rows: usize,
     #[comptime] cols: usize,
 ) -> GroupedMatrix {
     let rank = comptime!(space.rank());
-    let split = comptime!(matrix_split(&space, rows, cols));
+    let split = comptime!(matrix_split(space, rows, cols, vector_size));
 
     let mut row_extents = Coords::<u32>::new();
     #[unroll]
@@ -297,24 +287,35 @@ pub(crate) fn grouped_matrix(
     )
 }
 
-/// [`batch_matrix`] with the operand's [`Projection`] applied under it: what a gathered operand's
-/// 2-D readers go through.
+/// [`batch_matrix`] over the operand's mapping: the `i`-th batch matrix as every 2-D reader of a
+/// tile sees it.
 #[cube]
-fn projected_batch_matrix(
+pub(crate) fn projected_batch_matrix(
     bound: &Coords<u32>,
     #[comptime] space: Space,
     #[comptime] projection: Projection,
     #[comptime] vector_size: usize,
     i: usize,
 ) -> ProjectedBatchMatrix {
+    let gathered = comptime!(!projection.is_direct());
     ProjectedBatchMatrix::new(
-        batch_matrix(
-            bound,
-            comptime!(space.clone()),
-            comptime!(projection.clone()),
-            vector_size,
-            i,
-        ),
+        batch_matrix(bound, comptime!(&space), gathered, vector_size, i),
+        axis_projection(comptime!(space), comptime!(projection), vector_size),
+    )
+}
+
+/// [`grouped_matrix`] over the operand's mapping: the whole logical box as the `rows x cols`
+/// matrix an mma fragment reads.
+#[cube]
+pub(crate) fn projected_grouped_matrix(
+    #[comptime] space: Space,
+    #[comptime] projection: Projection,
+    #[comptime] vector_size: usize,
+    #[comptime] rows: usize,
+    #[comptime] cols: usize,
+) -> ProjectedGroupedMatrix {
+    ProjectedGroupedMatrix::new(
+        grouped_matrix(comptime!(&space), vector_size, rows, cols),
         axis_projection(comptime!(space), comptime!(projection), vector_size),
     )
 }
@@ -327,15 +328,14 @@ impl<T: Numeric> Tile<T> {
         match &self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => {
                 let bound = g.extent();
-                let space = comptime!(self.space.clone());
-                let projection = comptime!(g.projection.clone());
-                if comptime!(projection.is_direct()) {
-                    let layout = batch_matrix(&bound, space, projection, vector_size, i);
-                    g.masked::<W, Coords2d, BatchMatrix>(layout)
-                } else {
-                    let layout = projected_batch_matrix(&bound, space, projection, vector_size, i);
-                    g.masked::<W, Coords2d, ProjectedBatchMatrix>(layout)
-                }
+                let layout = projected_batch_matrix(
+                    &bound,
+                    comptime!(self.space.clone()),
+                    comptime!(g.projection.clone()),
+                    vector_size,
+                    i,
+                );
+                g.masked::<W, Coords2d, ProjectedBatchMatrix>(layout)
             }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::matrix: a plane tile has no memory view")
@@ -349,15 +349,14 @@ impl<T: Numeric> Tile<T> {
         match &mut self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => {
                 let bound = g.extent();
-                let space = comptime!(self.space.clone());
-                let projection = comptime!(g.projection.clone());
-                if comptime!(projection.is_direct()) {
-                    let layout = batch_matrix(&bound, space, projection, vector_size, i);
-                    g.masked_mut::<W, Coords2d, BatchMatrix>(layout)
-                } else {
-                    let layout = projected_batch_matrix(&bound, space, projection, vector_size, i);
-                    g.masked_mut::<W, Coords2d, ProjectedBatchMatrix>(layout)
-                }
+                let layout = projected_batch_matrix(
+                    &bound,
+                    comptime!(self.space.clone()),
+                    comptime!(g.projection.clone()),
+                    vector_size,
+                    i,
+                );
+                g.masked_mut::<W, Coords2d, ProjectedBatchMatrix>(layout)
             }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::matrix_mut: a plane tile has no memory view")
@@ -379,15 +378,14 @@ impl<T: Numeric> Tile<T> {
         match &self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => {
                 let bound = g.extent();
-                let space = comptime!(self.space.clone());
-                let projection = comptime!(g.projection.clone());
-                if comptime!(projection.is_direct()) {
-                    let layout = batch_matrix(&bound, space, projection, vector_size, i);
-                    g.matrix_transparent::<I, WP, W, BatchMatrix>(layout)
-                } else {
-                    let layout = projected_batch_matrix(&bound, space, projection, vector_size, i);
-                    g.matrix_transparent::<I, WP, W, ProjectedBatchMatrix>(layout)
-                }
+                let layout = projected_batch_matrix(
+                    &bound,
+                    comptime!(self.space.clone()),
+                    comptime!(g.projection.clone()),
+                    vector_size,
+                    i,
+                );
+                g.matrix_transparent::<I, WP, W, ProjectedBatchMatrix>(layout)
             }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::matrix_transparent: a plane tile has no memory view")
@@ -413,18 +411,14 @@ impl<T: Numeric> Tile<T> {
         let vector_size = self.vector_size();
         match &self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => {
-                let space = comptime!(self.space.clone());
-                let projection = comptime!(g.projection.clone());
-                let layout = grouped_matrix(comptime!(space.clone()), vector_size, rows, cols);
-                if comptime!(projection.is_direct()) {
-                    g.matrix_transparent::<I, WP, W, GroupedMatrix>(layout)
-                } else {
-                    let projected = ProjectedGroupedMatrix::new(
-                        layout,
-                        axis_projection(space, projection, vector_size),
-                    );
-                    g.matrix_transparent::<I, WP, W, ProjectedGroupedMatrix>(projected)
-                }
+                let layout = projected_grouped_matrix(
+                    comptime!(self.space.clone()),
+                    comptime!(g.projection.clone()),
+                    vector_size,
+                    rows,
+                    cols,
+                );
+                g.matrix_transparent::<I, WP, W, ProjectedGroupedMatrix>(layout)
             }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::fragment_matrix: a plane tile has no memory view")
@@ -444,37 +438,26 @@ mod tests {
     const RH: Axis = Axis(1);
     const CI: Axis = Axis(2);
 
-    fn space(extents: &[(Axis, usize)]) -> Space {
-        let mut t = Tiling::new().extents(extents);
-        t = t.level(WalkOrder::RowMajor, Schedule::Direct, |mut l| {
-            for &(axis, e) in extents {
-                l = l.axis(axis, Cut::sequential(e));
-            }
-            l
-        });
-        t.build()
-    }
-
     /// A plain matmul operand: one axis per edge, the split right down the middle.
     #[test]
     fn a_rank_two_operand_splits_between_its_axes() {
-        let s = space(&[(OH, 8), (CI, 4)]);
-        assert_eq!(matrix_split(&s, 8, 4), 1);
+        let s = flat_space(&[(OH, 8), (CI, 4)]);
+        assert_eq!(matrix_split(&s, 8, 4, 1), 1);
     }
 
     /// The convolution shape: the trailing *two* axes are the contraction, so `k` is their
     /// product and the split leaves only the output axis in the row group.
     #[test]
     fn a_contraction_over_two_axes_splits_before_both() {
-        let s = space(&[(OH, 8), (RH, 2), (CI, 4)]);
-        assert_eq!(matrix_split(&s, 8, 8), 1);
+        let s = flat_space(&[(OH, 8), (RH, 2), (CI, 4)]);
+        assert_eq!(matrix_split(&s, 8, 8, 1), 1);
     }
 
     /// Both edges spanning several axes, which is what a 2-D convolution's input needs.
     #[test]
     fn both_groups_may_span_several_axes() {
-        let s = space(&[(OH, 3), (RH, 4), (CI, 2)]);
-        assert_eq!(matrix_split(&s, 12, 2), 2);
+        let s = flat_space(&[(OH, 3), (RH, 4), (CI, 2)]);
+        assert_eq!(matrix_split(&s, 12, 2, 2), 2);
     }
 
     /// The smallest column group that reaches `cols` wins, so a degenerate leading axis stays in
@@ -482,16 +465,16 @@ mod tests {
     /// cells; taking the smaller keeps the answer deterministic.
     #[test]
     fn a_degenerate_leading_axis_stays_in_the_row_group() {
-        let s = space(&[(OH, 1), (RH, 2), (CI, 4)]);
-        assert_eq!(matrix_split(&s, 1, 8), 1);
+        let s = flat_space(&[(OH, 1), (RH, 2), (CI, 4)]);
+        assert_eq!(matrix_split(&s, 1, 8, 1), 1);
     }
 
     /// No split gives the asked-for edges: the extents multiply to 32, and 8x8 is not a face.
     #[test]
     #[should_panic(expected = "no split of this tile's axes")]
     fn a_mismatched_fragment_is_refused() {
-        let s = space(&[(OH, 8), (RH, 2), (CI, 2)]);
-        matrix_split(&s, 8, 8);
+        let s = flat_space(&[(OH, 8), (RH, 2), (CI, 2)]);
+        matrix_split(&s, 8, 8, 1);
     }
 
     /// The column group must contain the innermost axis: the view serves lines along `col`, so a
@@ -499,7 +482,16 @@ mod tests {
     #[test]
     #[should_panic(expected = "innermost (vectorized) axis")]
     fn the_vectorized_axis_must_land_in_the_column_group() {
-        let s = space(&[(OH, 8), (CI, 4)]);
-        matrix_split(&s, 32, 1);
+        let s = flat_space(&[(OH, 8), (CI, 4)]);
+        matrix_split(&s, 32, 1, 1);
+    }
+
+    /// The column edge and the innermost extent are both counted in lines, so a width that does
+    /// not divide the innermost extent would scale the two by different amounts.
+    #[test]
+    #[should_panic(expected = "whole number of 4-wide lines")]
+    fn a_partial_innermost_line_is_refused() {
+        let s = flat_space(&[(OH, 8), (CI, 6)]);
+        matrix_split(&s, 8, 6, 4);
     }
 }

--- a/crates/cubek-tile/src/tile/view/matrix.rs
+++ b/crates/cubek-tile/src/tile/view/matrix.rs
@@ -64,40 +64,162 @@ impl Layout for BatchMatrix {
     }
 }
 
-#[cube]
-impl<T: Numeric> Tile<T> {
-    /// The leading axes are pinned to `i` unraveled over their extents. Only the
-    /// (width-invariant) leading shape is read, off the window extent.
-    fn batch_matrix(&self, i: usize) -> BatchMatrix {
-        let rank = comptime!(self.space.rank());
-        let shape = match &self.tile_kind {
-            TileKind::Gmem(g) | TileKind::Smem(g) => g.extent(),
-            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
-                panic!("Tile::matrix: a plane tile has no memory view")
-            }
-            TileKind::TmaGmem(_) => panic!("Tile::matrix: a tma source has no element view"),
-        };
-        let rows = comptime!(self.space.extent_at(rank - 2));
-        // `cols` is a line count, so divide the innermost extent by the width.
-        let w = self.vector_size();
-        let cols = comptime!(self.space.extent_at(rank - 1) / w);
+#[derive(CubeType, Clone)]
+#[expand(derive(Clone))]
+pub struct ProjectedBatchMatrix {
+    batches: CoordsDyn,
+    tile_shape: Coords2d,
+    #[cube(comptime)]
+    projection: Projection,
+    #[cube(comptime)]
+    space: Space,
+}
 
-        let mut batches = CoordsDyn::new();
+#[cube]
+impl ProjectedBatchMatrix {
+    pub fn new(
+        batches: CoordsDyn,
+        #[comptime] rows: usize,
+        #[comptime] cols: usize,
+        #[comptime] projection: Projection,
+        #[comptime] space: Space,
+    ) -> Self {
+        ProjectedBatchMatrix {
+            batches,
+            tile_shape: (rows as u32, cols as u32).runtime(),
+            projection,
+            space,
+        }
+    }
+}
+
+#[cube]
+impl Layout for ProjectedBatchMatrix {
+    type Coordinates = Coords2d;
+    type SourceCoordinates = CoordsDyn;
+
+    fn to_source_pos(&self, pos: Self::Coordinates) -> Self::SourceCoordinates {
+        let (t0, t1) = pos;
+        let mut logical = self.batches.clone();
+        logical.push(t0);
+        logical.push(t1);
+
+        let mut out = CoordsDyn::new();
 
         #[unroll]
-        for p in 0..rank - 2 {
-            let weight = shape.fproduct(comptime!(((p + 1)..(rank - 2)).collect::<Vec<_>>()));
-            batches.push(i.fcast::<u32>().fdiv(weight).frem(shape.at(p)));
+        for pa in 0..comptime!(self.projection.physical_rank()) {
+            let n = comptime!(self.projection.physical_axis(pa).terms().len());
+            let mut terms = Coords::<u32>::new();
+            #[unroll]
+            for t in 0..n {
+                let term = comptime!(self.projection.physical_axis(pa).terms()[t]);
+                let p = comptime!(self.space.position(term.axis));
+                terms.push(logical[p].fmul(comptime!(term.scale.get() as u32)));
+            }
+            out.push(terms.fsum(comptime!((0..n).collect::<Vec<_>>())));
         }
 
-        BatchMatrix::new(batches, rows, cols)
+        out
     }
 
+    fn to_source_pos_checked(&self, pos: Self::Coordinates) -> (Self::SourceCoordinates, bool) {
+        let in_bounds = self.is_in_bounds(pos);
+        (self.to_source_pos(pos), in_bounds)
+    }
+
+    fn shape(&self) -> Self::Coordinates {
+        self.tile_shape
+    }
+
+    fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
+        let (t0, t1) = pos;
+        let (s0, s1) = self.tile_shape;
+        t0 < s0 && t1 < s1
+    }
+}
+
+#[cube]
+fn batch_matrix(
+    bound: Coords<u32>,
+    #[comptime] space: Space,
+    #[comptime] vector_size: usize,
+    i: usize,
+) -> BatchMatrix {
+    let rank = comptime!(space.rank());
+    let shape = bound;
+    let rows = comptime!(space.extent_at(rank - 2));
+    let cols = comptime!(space.extent_at(rank - 1) / vector_size);
+
+    let mut batches = CoordsDyn::new();
+
+    #[unroll]
+    for p in 0..rank - 2 {
+        let weight = shape.fproduct(comptime!(((p + 1)..(rank - 2)).collect::<Vec<_>>()));
+        batches.push(i.fcast::<u32>().fdiv(weight).frem(shape.at(p)));
+    }
+
+    BatchMatrix::new(batches, rows, cols)
+}
+
+#[cube]
+fn projected_batch_matrix(
+    bound: Coords<u32>,
+    #[comptime] space: Space,
+    #[comptime] projection: Projection,
+    #[comptime] vector_size: usize,
+    i: usize,
+) -> ProjectedBatchMatrix {
+    let rank = comptime!(space.rank());
+    let rows = comptime!(space.extent_at(rank - 2));
+    let cols = comptime!(space.extent_at(rank - 1) / vector_size);
+
+    let mut batches = CoordsDyn::new();
+
+    #[unroll]
+    for p in 0..rank - 2 {
+        let mut weight = 1u32.runtime();
+        #[unroll]
+        for q in p + 1..rank - 2 {
+            let axis_q = comptime!(space.axis_at(q));
+            let p_idx = comptime!(space.position(axis_q));
+            let raw_q = bound.at(p_idx).fcast::<u32>();
+            let w_q = comptime!(if p_idx == rank - 1 { vector_size } else { 1 });
+            weight *= comptime!(w_q as u32).runtime() * raw_q;
+        }
+        let axis_p = comptime!(space.axis_at(p));
+        let p_idx = comptime!(space.position(axis_p));
+        let raw_p = bound.at(p_idx).fcast::<u32>();
+        let w_p = comptime!(if p_idx == rank - 1 { vector_size } else { 1 });
+        let extent = comptime!(w_p as u32).runtime() * raw_p;
+
+        batches.push(i.fcast::<u32>().fdiv(weight).frem(extent));
+    }
+
+    ProjectedBatchMatrix::new(batches, rows, cols, projection, comptime!(space))
+}
+
+#[cube]
+impl<T: Numeric> Tile<T> {
     /// The `i`-th batch matrix over `Vector<T, W>` lines (`W` = [`width`](Tile::width)).
     pub fn matrix<W: Size>(&self, i: usize) -> MatrixView<'_, Vector<T, W>> {
-        let layout = self.batch_matrix(i);
+        let vector_size = self.vector_size();
         match &self.tile_kind {
-            TileKind::Gmem(g) | TileKind::Smem(g) => g.masked::<W, Coords2d, BatchMatrix>(layout),
+            TileKind::Gmem(g) | TileKind::Smem(g) => {
+                if comptime!(g.projection.is_direct()) {
+                    let layout =
+                        batch_matrix(g.extent(), comptime!(self.space.clone()), vector_size, i);
+                    g.masked::<W, Coords2d, BatchMatrix>(layout)
+                } else {
+                    let layout = projected_batch_matrix(
+                        g.extent(),
+                        comptime!(self.space.clone()),
+                        comptime!(g.projection.clone()),
+                        vector_size,
+                        i,
+                    );
+                    g.masked::<W, Coords2d, ProjectedBatchMatrix>(layout)
+                }
+            }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::matrix: a plane tile has no memory view")
             }
@@ -106,9 +228,24 @@ impl<T: Numeric> Tile<T> {
     }
 
     pub fn matrix_mut<W: Size>(&mut self, i: usize) -> MatrixViewMut<'_, Vector<T, W>> {
-        let layout = self.batch_matrix(i);
+        let vector_size = self.vector_size();
         match &mut self.tile_kind {
-            TileKind::Gmem(g) | TileKind::Smem(g) => g.masked_mut::<W>(layout),
+            TileKind::Gmem(g) | TileKind::Smem(g) => {
+                if comptime!(g.projection.is_direct()) {
+                    let layout =
+                        batch_matrix(g.extent(), comptime!(self.space.clone()), vector_size, i);
+                    g.masked_mut::<W>(layout)
+                } else {
+                    let layout = projected_batch_matrix(
+                        g.extent(),
+                        comptime!(self.space.clone()),
+                        comptime!(g.projection.clone()),
+                        vector_size,
+                        i,
+                    );
+                    g.masked_mut_projected::<W>(layout)
+                }
+            }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::matrix_mut: a plane tile has no memory view")
             }
@@ -125,9 +262,24 @@ impl<T: Numeric> Tile<T> {
         &self,
         i: usize,
     ) -> MatrixView<'_, Vector<T, W>> {
-        let layout = self.batch_matrix(i);
+        let vector_size = self.vector_size();
         match &self.tile_kind {
-            TileKind::Gmem(g) | TileKind::Smem(g) => g.matrix_transparent::<I, WP, W>(layout),
+            TileKind::Gmem(g) | TileKind::Smem(g) => {
+                if comptime!(g.projection.is_direct()) {
+                    let layout =
+                        batch_matrix(g.extent(), comptime!(self.space.clone()), vector_size, i);
+                    g.matrix_transparent::<I, WP, W>(layout)
+                } else {
+                    let layout = projected_batch_matrix(
+                        g.extent(),
+                        comptime!(self.space.clone()),
+                        comptime!(g.projection.clone()),
+                        vector_size,
+                        i,
+                    );
+                    g.matrix_transparent_projected::<I, WP, W>(layout)
+                }
+            }
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::matrix_transparent: a plane tile has no memory view")
             }

--- a/crates/cubek-tile/src/tile/view/matrix.rs
+++ b/crates/cubek-tile/src/tile/view/matrix.rs
@@ -130,31 +130,6 @@ impl Layout for GroupedMatrix {
     }
 }
 
-/// Concatenates two coordinate lists into dynamic coordinates.
-#[cube]
-fn concat(leading: &Coords<u32>, trailing: &Coords<u32>) -> CoordsDyn {
-    let mut out = CoordsDyn::new();
-
-    #[unroll]
-    for p in 0..leading.len() {
-        out.push(leading.at(p));
-    }
-    #[unroll]
-    for p in 0..trailing.len() {
-        out.push(trailing.at(p));
-    }
-
-    out
-}
-
-/// Checks if a 2-D coordinate is within bounds.
-#[cube]
-fn within_2d(pos: Coords2d, shape: Coords2d) -> bool {
-    let (row, col) = pos;
-    let (rows, cols) = shape;
-    row < rows && col < cols
-}
-
 /// The leading (batch) extents a matrix index unravels over, in the space's axis order.
 ///
 /// A direct operand reads them off the window, which is the only place a
@@ -175,25 +150,6 @@ fn leading_extents(
             out.push(comptime!(space.extent_at(p) as u32));
         } else {
             out.push(bound.at(p));
-        }
-    }
-
-    out
-}
-
-/// Unravels a flat index into coordinates over the given extents.
-#[cube]
-pub(crate) fn unravel(extents: &Coords<u32>, i: u32) -> Coords<u32> {
-    let n = extents.len();
-    let mut out = Coords::<u32>::new();
-
-    #[unroll]
-    for p in 0..n {
-        let digit = i.fdiv(extents.fproduct(comptime!(((p + 1)..n).collect::<Vec<_>>())));
-        if comptime!(p == 0) {
-            out.push(digit);
-        } else {
-            out.push(digit.frem(extents.at(p)));
         }
     }
 

--- a/crates/cubek-tile/src/tile/view/mod.rs
+++ b/crates/cubek-tile/src/tile/view/mod.rs
@@ -1,4 +1,5 @@
 pub mod accumulate;
+pub mod coords;
 pub mod flat;
 pub mod masked;
 pub mod matrix;
@@ -6,6 +7,8 @@ pub mod projected;
 pub mod quant;
 
 pub use accumulate::*;
+// Crate-internal helpers, so this re-export carries no public item.
+pub(crate) use coords::*;
 pub use flat::*;
 pub use masked::*;
 pub use matrix::*;

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -219,19 +219,6 @@ impl Layout for StepUp {
     }
 }
 
-/// Whether every coordinate of `pos` falls inside `shape`.
-#[cube]
-fn within(shape: &Coords<u32>, pos: CoordsDyn) -> bool {
-    let mut valid = true;
-
-    #[unroll]
-    for p in 0..shape.len() {
-        valid = valid && pos[p] < shape.at(p);
-    }
-
-    valid
-}
-
 #[cube]
 impl<T: Numeric> Tile<T> {
     /// This tile's whole logical box as a quantization-transparent read view, one coordinate per

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -39,6 +39,63 @@ impl<C: Coordinates, L> TileLayout<C> for L where
 {
 }
 
+/// [`TileLayout`] with its own coordinate left implicit, so a wrapper can name the bound without
+/// carrying that coordinate as a second parameter it would then need a `PhantomData` to hold.
+pub trait LogicalLayout:
+    Layout<SourceCoordinates = CoordsDyn> + Clone + 'static + CubeType<ExpandType: Clone>
+{
+}
+
+impl<L> LogicalLayout for L where
+    L: Layout<SourceCoordinates = CoordsDyn> + Clone + 'static + CubeType<ExpandType: Clone>
+{
+}
+
+/// Any [`LogicalLayout`] with an operand's [`Projection`] applied under it: the inner layout
+/// resolves a reader's coordinate to the tile's *logical* one, then [`AxisProjection`] folds that
+/// onto the window's *physical* one. Every gathered view is its direct view wrapped in this, so
+/// the two ranks meet in one place rather than once per reader.
+#[derive(CubeType, Clone)]
+#[expand(derive(Clone))]
+pub struct Projected<L: LogicalLayout> {
+    inner: L,
+    projection: AxisProjection,
+}
+
+#[cube]
+impl<L: LogicalLayout> Projected<L> {
+    pub fn new(inner: L, projection: AxisProjection) -> Self {
+        Projected::<L> { inner, projection }
+    }
+}
+
+#[cube]
+impl<L: LogicalLayout> Layout for Projected<L> {
+    type Coordinates = L::Coordinates;
+    type SourceCoordinates = CoordsDyn;
+
+    fn to_source_pos(&self, pos: Self::Coordinates) -> Self::SourceCoordinates {
+        self.projection.to_source_pos(self.inner.to_source_pos(pos))
+    }
+
+    fn to_source_pos_checked(&self, pos: Self::Coordinates) -> (Self::SourceCoordinates, bool) {
+        let in_bounds = self.is_in_bounds(pos.clone());
+        (self.to_source_pos(pos), in_bounds)
+    }
+
+    fn shape(&self) -> Self::Coordinates {
+        self.inner.shape()
+    }
+
+    /// The inner box alone. The logical box [`AxisProjection`] would re-check is the same one: its
+    /// extents *are* the space's, which is where the inner layout's own bounds come from. Whether
+    /// the physical cell it maps to holds valid data is the [`Window`](crate::Window)'s question,
+    /// asked one layer down.
+    fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
+        self.inner.is_in_bounds(pos)
+    }
+}
+
 /// A [`Layout`] mapping a tile's logical coordinate to its window's physical one:
 /// `phys[pa] = Σ logical[axis] * scale`. Sits between the [`Window`](crate::Window) and the
 /// element layout, so the window's `bound` still masks the read (an out-of-range stencil tap

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -23,24 +23,6 @@ use crate::*;
 /// and the scales through the same one. A blanket impl, so this bundles bounds rather than naming
 /// a new concept; [`BatchMatrix`](super::BatchMatrix) and [`AxisProjection`] are the two the leaves
 /// read through, and [`StepUp`] rides the same bounds under a fill.
-pub trait TileLayout<C: Coordinates>:
-    Layout<Coordinates = C, SourceCoordinates = CoordsDyn>
-    + Clone
-    + 'static
-    + CubeType<ExpandType: Clone>
-{
-}
-
-impl<C: Coordinates, L> TileLayout<C> for L where
-    L: Layout<Coordinates = C, SourceCoordinates = CoordsDyn>
-        + Clone
-        + 'static
-        + CubeType<ExpandType: Clone>
-{
-}
-
-/// [`TileLayout`] with its own coordinate left implicit, so a wrapper can name the bound without
-/// carrying that coordinate as a second parameter it would then need a `PhantomData` to hold.
 pub trait LogicalLayout:
     Layout<SourceCoordinates = CoordsDyn> + Clone + 'static + CubeType<ExpandType: Clone>
 {
@@ -51,10 +33,16 @@ impl<L> LogicalLayout for L where
 {
 }
 
+/// [`LogicalLayout`] answering a particular coordinate `C`, for the readers that name one.
+pub trait TileLayout<C: Coordinates>: LogicalLayout + Layout<Coordinates = C> {}
+
+impl<C: Coordinates, L> TileLayout<C> for L where L: LogicalLayout + Layout<Coordinates = C> {}
+
 /// Any [`LogicalLayout`] with an operand's [`Projection`] applied under it: the inner layout
 /// resolves a reader's coordinate to the tile's *logical* one, then [`AxisProjection`] folds that
-/// onto the window's *physical* one. Every gathered view is its direct view wrapped in this, so
-/// the two ranks meet in one place rather than once per reader.
+/// onto the window's *physical* one. Every view goes through this, so the two ranks meet in one
+/// place rather than once per reader; under the direct mapping the fold is the identity, which
+/// [`Fold`](crate::Fold) collapses to the coordinate itself.
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct Projected<L: LogicalLayout> {
@@ -87,10 +75,8 @@ impl<L: LogicalLayout> Layout for Projected<L> {
         self.inner.shape()
     }
 
-    /// The inner box alone. The logical box [`AxisProjection`] would re-check is the same one: its
-    /// extents *are* the space's, which is where the inner layout's own bounds come from. Whether
-    /// the physical cell it maps to holds valid data is the [`Window`](crate::Window)'s question,
-    /// asked one layer down.
+    /// The inner box alone: the logical box [`AxisProjection`] would re-check is the same one, its
+    /// extents being the space's, which is where the inner layout's bounds come from.
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
         self.inner.is_in_bounds(pos)
     }
@@ -171,14 +157,7 @@ impl Layout for AxisProjection {
     /// The logical box. Whether the physical coordinate it maps to is within the operand's valid
     /// data is the [`Window`](crate::Window)'s question, asked one layer down.
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
-        let mut valid = true;
-
-        #[unroll]
-        for p in 0..self.shape.len() {
-            valid = valid && pos[p] < self.shape.at(p);
-        }
-
-        valid
+        within(&self.shape, pos)
     }
 }
 
@@ -235,18 +214,24 @@ impl Layout for StepUp {
         self.shape.to_dyn()
     }
 
-    /// The compacted box. Whether the source cell it steps up to holds valid data is the
-    /// [`Window`](crate::Window)'s question, asked one layer down.
+    /// The compacted box, the source cell it steps up to being the [`Window`](crate::Window)'s
+    /// question.
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
-        let mut valid = true;
-
-        #[unroll]
-        for p in 0..self.shape.len() {
-            valid = valid && pos[p] < self.shape.at(p);
-        }
-
-        valid
+        within(&self.shape, pos)
     }
+}
+
+/// Whether every coordinate of `pos` falls inside `shape`.
+#[cube]
+fn within(shape: &Coords<u32>, pos: CoordsDyn) -> bool {
+    let mut valid = true;
+
+    #[unroll]
+    for p in 0..shape.len() {
+        valid = valid && pos[p] < shape.at(p);
+    }
+
+    valid
 }
 
 #[cube]

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -75,8 +75,6 @@ impl<L: LogicalLayout> Layout for Projected<L> {
         self.inner.shape()
     }
 
-    /// The inner box alone: the logical box [`AxisProjection`] would re-check is the same one, its
-    /// extents being the space's, which is where the inner layout's bounds come from.
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
         self.inner.is_in_bounds(pos)
     }
@@ -267,14 +265,24 @@ pub(crate) fn axis_projection(
     #[comptime] vector_size: usize,
 ) -> AxisProjection {
     let rank = comptime!(space.rank());
-    let last = comptime!(rank - 1);
-    let mut shape = Coords::<u32>::new();
-
-    #[unroll]
-    for p in 0..rank {
-        let e = comptime!(space.extent_at(p));
-        shape.push(comptime!((if p == last { e / vector_size } else { e }) as u32).runtime());
-    }
+    let shape = const_coords(comptime!(line_extents(&space, vector_size, 0, rank)));
 
     AxisProjection::new(shape, space, projection)
+}
+
+/// Returns the extents of `space` in the range `from..to`, with the innermost axis
+/// converted to line count by dividing by `vector_size`.
+pub(crate) fn line_extents(
+    space: &Space,
+    vector_size: usize,
+    from: usize,
+    to: usize,
+) -> Vec<usize> {
+    let last = space.rank() - 1;
+    (from..to)
+        .map(|p| {
+            let e = space.extent_at(p);
+            if p == last { e / vector_size } else { e }
+        })
+        .collect()
 }

--- a/crates/cubek-tile/tests/tile/conv.rs
+++ b/crates/cubek-tile/tests/tile/conv.rs
@@ -814,13 +814,24 @@ fn projected_matrix_kernel<E: Numeric>(
     }
 }
 
-/// The 2-D view over the 2-D convolution's input: logical `[OH, OW, RH, RW, CI]` over the physical
-/// `[IH, IW, CI]`, so three leading axes are pinned and the trailing `RW x CI` pair is the matrix.
-/// Three pinned axes is what makes this worth running: the unravel's weights are a product of
-/// several extents, and reading those off the window instead of the space would silently pick up
-/// the receptive field's span (`IH`, `IW`) rather than the logical edges.
-#[test]
-fn conv2d_projected_matrix_view() {
+struct Conv2dViewSetup {
+    oh: usize,
+    ow: usize,
+    rh: usize,
+    rw: usize,
+    ci: usize,
+    sh: usize,
+    sw: usize,
+    dh: usize,
+    dw: usize,
+    in_w: usize,
+    space: Space,
+    in_spec: TileSpec,
+    in_data: Vec<f32>,
+    in_handle: cubecl::std::tensor::TensorHandle<TestRuntime>,
+}
+
+fn setup_conv2d_view() -> Conv2dViewSetup {
     let (oh, ow, rh, rw, ci) = (3usize, 4usize, 2usize, 3usize, 2usize);
     let (sh, sw, dh, dw) = (2usize, 1usize, 1usize, 2usize);
     let in_h = (oh - 1) * sh + (rh - 1) * dh + 1;
@@ -846,9 +857,6 @@ fn conv2d_projected_matrix_view() {
         ],
     ));
 
-    let matrices = oh * ow * rh;
-    let (rows, cols) = (rw, ci);
-
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let f32_ty = f32::as_type_native_unchecked().storage_type();
     let in_data = ramp(in_h * in_w * ci, 7);
@@ -856,6 +864,43 @@ fn conv2d_projected_matrix_view() {
         .dtype(f32_ty)
         .custom(in_data.clone())
         .generate_with_f32_host_data();
+
+    Conv2dViewSetup {
+        oh,
+        ow,
+        rh,
+        rw,
+        ci,
+        sh,
+        sw,
+        dh,
+        dw,
+        in_w,
+        space,
+        in_spec,
+        in_data,
+        in_handle,
+    }
+}
+
+/// The 2-D view over the 2-D convolution's input: logical `[OH, OW, RH, RW, CI]` over the physical
+/// `[IH, IW, CI]`, so three leading axes are pinned and the trailing `RW x CI` pair is the matrix.
+/// Three pinned axes is what makes this worth running: the unravel's weights are a product of
+/// several extents, and reading those off the window instead of the space would silently pick up
+/// the receptive field's span (`IH`, `IW`) rather than the logical edges.
+#[test]
+fn conv2d_projected_matrix_view() {
+    let s = setup_conv2d_view();
+    let (oh, ow, rh, rw, ci) = (s.oh, s.ow, s.rh, s.rw, s.ci);
+    let (sh, sw, dh, dw) = (s.sh, s.sw, s.dh, s.dw);
+    let (in_w, in_data) = (s.in_w, s.in_data);
+    let space = s.space;
+
+    let matrices = oh * ow * rh;
+    let (rows, cols) = (rw, ci);
+
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let f32_ty = f32::as_type_native_unchecked().storage_type();
     let out_handle = TestInput::builder(client.clone(), shape![matrices, rows, cols])
         .dtype(f32_ty)
         .zeros()
@@ -865,7 +910,7 @@ fn conv2d_projected_matrix_view() {
         &client,
         space.cube_count(),
         space.cube_dim(&client),
-        TileArgLaunch::new(in_handle.binding().into_tensor_arg(), in_spec),
+        TileArgLaunch::new(s.in_handle.binding().into_tensor_arg(), s.in_spec),
         out_handle.clone().binding().into_tensor_arg(),
         space,
         matrices,
@@ -921,43 +966,19 @@ fn fragment_matrix_kernel<E: Numeric>(
 
 /// The 2-D convolution input as one `(OH·OW) x (RH·RW·CI)` matrix: five logical axes flattened
 /// into two edges over three physical ones. Neither edge is a single axis, which is the whole
-/// point — no pinning of trailing axes produces this face, and it is the one an mma contracts.
+/// point: no pinning of trailing axes produces this face, and it is the one an mma contracts.
 #[test]
 fn conv2d_fragment_matrix_view() {
-    let (oh, ow, rh, rw, ci) = (3usize, 4usize, 2usize, 3usize, 2usize);
-    let (sh, sw, dh, dw) = (2usize, 1usize, 1usize, 2usize);
-    let in_h = (oh - 1) * sh + (rh - 1) * dh + 1;
-    let in_w = (ow - 1) * sw + (rw - 1) * dw + 1;
-
-    let space = Tiling::new()
-        .extents(&[(OH, oh), (OW, ow), (RH, rh), (RW, rw), (CI, ci)])
-        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
-            l.axis(OH, Cut::sequential(oh))
-                .axis(OW, Cut::sequential(ow))
-                .axis(RH, Cut::sequential(rh))
-                .axis(RW, Cut::sequential(rw))
-                .axis(CI, Cut::sequential(ci))
-        })
-        .build();
-
-    let in_spec = TileSpec::new(Projection::new(
-        &[OH, OW, RH, RW, CI],
-        &[
-            PhysicalAxisMap::affine(&[(OH, sh), (RH, dh)]),
-            PhysicalAxisMap::affine(&[(OW, sw), (RW, dw)]),
-            PhysicalAxisMap::of(CI),
-        ],
-    ));
+    let s = setup_conv2d_view();
+    let (oh, ow, rh, rw, ci) = (s.oh, s.ow, s.rh, s.rw, s.ci);
+    let (sh, sw, dh, dw) = (s.sh, s.sw, s.dh, s.dw);
+    let (in_w, in_data) = (s.in_w, s.in_data);
+    let space = s.space;
 
     let (rows, cols) = (oh * ow, rh * rw * ci);
 
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let f32_ty = f32::as_type_native_unchecked().storage_type();
-    let in_data = ramp(in_h * in_w * ci, 7);
-    let (in_handle, _) = TestInput::builder(client.clone(), shape![in_h, in_w, ci])
-        .dtype(f32_ty)
-        .custom(in_data.clone())
-        .generate_with_f32_host_data();
     let out_handle = TestInput::builder(client.clone(), shape![rows, cols])
         .dtype(f32_ty)
         .zeros()
@@ -967,7 +988,7 @@ fn conv2d_fragment_matrix_view() {
         &client,
         space.cube_count(),
         space.cube_dim(&client),
-        TileArgLaunch::new(in_handle.binding().into_tensor_arg(), in_spec),
+        TileArgLaunch::new(s.in_handle.binding().into_tensor_arg(), s.in_spec),
         out_handle.clone().binding().into_tensor_arg(),
         space,
         rows,
@@ -1015,21 +1036,11 @@ fn conv_mma_kernel<E: Numeric>(
     out.copy_from(&acc);
 }
 
-/// A convolution contracted on the manual-mma leaf: `m x n x k` is `OH x CO x (RH·CI)`, so the
-/// `k` edge spans two logical axes and the lhs reaches the fragment through its gather. Gated on
-/// the backend advertising manual mma, like [`mma_matmul_8x8x8`]; run with `cargo test-cuda` /
-/// `test-metal`.
 #[test]
 fn conv1d_mma_leaf() {
     conv1d_mma_leaf_with(MmaIOConfig::manual());
 }
 
-/// The same contraction with `ldmatrix` selected for the lhs, which is the gathered operand. A
-/// host-derived [`MmaIOConfig::new`] picks that whenever the backend advertises `ldmatrix` over
-/// the stage's element, and no gather is expressible in a raw strided tile, so the load has to
-/// fall to the manual path on its own rather than refusing the config. The other two roles stay
-/// manual: they are direct operands, for which `ldmatrix` is genuinely unwired over a `MemData`
-/// window and still refused.
 #[test]
 fn conv1d_mma_leaf_gathered_lhs_ignores_ldmatrix() {
     conv1d_mma_leaf_with(MmaIOConfig {

--- a/crates/cubek-tile/tests/tile/conv.rs
+++ b/crates/cubek-tile/tests/tile/conv.rs
@@ -814,16 +814,13 @@ fn projected_matrix_kernel<E: Numeric>(
     }
 }
 
+/// The one 2-D convolution both view tests read, strided and dilated on both spatial axes so no
+/// two logical coordinates land on the same input cell by accident.
 struct Conv2dViewSetup {
-    oh: usize,
-    ow: usize,
-    rh: usize,
-    rw: usize,
-    ci: usize,
-    sh: usize,
-    sw: usize,
-    dh: usize,
-    dw: usize,
+    /// `(oh, ow, rh, rw, ci)`, the logical axes in the space's own order.
+    logical: (usize, usize, usize, usize, usize),
+    /// `(sh, sw, dh, dw)`, the strides then the dilations.
+    steps: (usize, usize, usize, usize),
     in_w: usize,
     space: Space,
     in_spec: TileSpec,
@@ -866,15 +863,8 @@ fn setup_conv2d_view() -> Conv2dViewSetup {
         .generate_with_f32_host_data();
 
     Conv2dViewSetup {
-        oh,
-        ow,
-        rh,
-        rw,
-        ci,
-        sh,
-        sw,
-        dh,
-        dw,
+        logical: (oh, ow, rh, rw, ci),
+        steps: (sh, sw, dh, dw),
         in_w,
         space,
         in_spec,
@@ -891,10 +881,9 @@ fn setup_conv2d_view() -> Conv2dViewSetup {
 #[test]
 fn conv2d_projected_matrix_view() {
     let s = setup_conv2d_view();
-    let (oh, ow, rh, rw, ci) = (s.oh, s.ow, s.rh, s.rw, s.ci);
-    let (sh, sw, dh, dw) = (s.sh, s.sw, s.dh, s.dw);
-    let (in_w, in_data) = (s.in_w, s.in_data);
-    let space = s.space;
+    let (oh, ow, rh, rw, ci) = s.logical;
+    let (sh, sw, dh, dw) = s.steps;
+    let (in_w, in_data, space) = (s.in_w, s.in_data, s.space);
 
     let matrices = oh * ow * rh;
     let (rows, cols) = (rw, ci);
@@ -970,10 +959,9 @@ fn fragment_matrix_kernel<E: Numeric>(
 #[test]
 fn conv2d_fragment_matrix_view() {
     let s = setup_conv2d_view();
-    let (oh, ow, rh, rw, ci) = (s.oh, s.ow, s.rh, s.rw, s.ci);
-    let (sh, sw, dh, dw) = (s.sh, s.sw, s.dh, s.dw);
-    let (in_w, in_data) = (s.in_w, s.in_data);
-    let space = s.space;
+    let (oh, ow, rh, rw, ci) = s.logical;
+    let (sh, sw, dh, dw) = s.steps;
+    let (in_w, in_data, space) = (s.in_w, s.in_data, s.space);
 
     let (rows, cols) = (oh * ow, rh * rw * ci);
 

--- a/crates/cubek-tile/tests/tile/conv.rs
+++ b/crates/cubek-tile/tests/tile/conv.rs
@@ -14,7 +14,7 @@ use cubecl::{
     prelude::*,
     zspace::{Shape, shape},
 };
-use cubek_test_utils::{HostData, HostDataType, TestInput};
+use cubek_test_utils::{HostData, HostDataType, TestInput, TestOutcome, ValidationResult};
 
 use cubek_tile::*;
 
@@ -779,4 +779,349 @@ fn conv2d_staged_mixed_steps() {
         dw: 1,
     }
     .check_at(2, 2, 4, Schedule::Staged);
+}
+
+// ---- the projected 2-D view ------------------------------------------------
+
+/// Reads a gathered operand through [`Tile::matrix`] and writes every batch matrix out flat, so
+/// the host can check the projected layout against the same gather done by hand. The 2-D door for
+/// an operand whose logical axes outnumber its buffer's physical ones: the matrix coordinate
+/// resolves through the leading axes first, then folds onto the window through the projection.
+#[cube(launch)]
+fn projected_matrix_kernel<E: Numeric>(
+    input: &TileArg<'_, E, Const<1>>,
+    out: &mut Tensor<f32>,
+    #[comptime] space: Space,
+    #[comptime] matrices: usize,
+    #[comptime] rows: usize,
+    #[comptime] cols: usize,
+    #[define(E)] _dtype: StorageType,
+) {
+    let input = input.tile(space);
+    let size!(W) = input.vector_size();
+
+    #[unroll]
+    for m in 0..matrices {
+        let view = input.matrix::<W>(m);
+        #[unroll]
+        for r in 0..rows {
+            #[unroll]
+            for c in 0..cols {
+                let value = view.read((r as u32, c as u32).runtime());
+                out[comptime!((m * rows + r) * cols + c)] = f32::cast_from(value);
+            }
+        }
+    }
+}
+
+/// The 2-D view over the 2-D convolution's input: logical `[OH, OW, RH, RW, CI]` over the physical
+/// `[IH, IW, CI]`, so three leading axes are pinned and the trailing `RW x CI` pair is the matrix.
+/// Three pinned axes is what makes this worth running: the unravel's weights are a product of
+/// several extents, and reading those off the window instead of the space would silently pick up
+/// the receptive field's span (`IH`, `IW`) rather than the logical edges.
+#[test]
+fn conv2d_projected_matrix_view() {
+    let (oh, ow, rh, rw, ci) = (3usize, 4usize, 2usize, 3usize, 2usize);
+    let (sh, sw, dh, dw) = (2usize, 1usize, 1usize, 2usize);
+    let in_h = (oh - 1) * sh + (rh - 1) * dh + 1;
+    let in_w = (ow - 1) * sw + (rw - 1) * dw + 1;
+
+    let space = Tiling::new()
+        .extents(&[(OH, oh), (OW, ow), (RH, rh), (RW, rw), (CI, ci)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(OH, Cut::sequential(oh))
+                .axis(OW, Cut::sequential(ow))
+                .axis(RH, Cut::sequential(rh))
+                .axis(RW, Cut::sequential(rw))
+                .axis(CI, Cut::sequential(ci))
+        })
+        .build();
+
+    let in_spec = TileSpec::new(Projection::new(
+        &[OH, OW, RH, RW, CI],
+        &[
+            PhysicalAxisMap::affine(&[(OH, sh), (RH, dh)]),
+            PhysicalAxisMap::affine(&[(OW, sw), (RW, dw)]),
+            PhysicalAxisMap::of(CI),
+        ],
+    ));
+
+    let matrices = oh * ow * rh;
+    let (rows, cols) = (rw, ci);
+
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let f32_ty = f32::as_type_native_unchecked().storage_type();
+    let in_data = ramp(in_h * in_w * ci, 7);
+    let (in_handle, _) = TestInput::builder(client.clone(), shape![in_h, in_w, ci])
+        .dtype(f32_ty)
+        .custom(in_data.clone())
+        .generate_with_f32_host_data();
+    let out_handle = TestInput::builder(client.clone(), shape![matrices, rows, cols])
+        .dtype(f32_ty)
+        .zeros()
+        .generate_without_host_data();
+
+    projected_matrix_kernel::launch::<TestRuntime>(
+        &client,
+        space.cube_count(),
+        space.cube_dim(&client),
+        TileArgLaunch::new(in_handle.binding().into_tensor_arg(), in_spec),
+        out_handle.clone().binding().into_tensor_arg(),
+        space,
+        matrices,
+        rows,
+        cols,
+        f32_ty,
+    );
+
+    let got = HostData::from_tensor_handle(&client, out_handle, HostDataType::F32);
+    for m in 0..matrices {
+        // The pinned axes, unraveled the way the layout unravels them: row-major over `[OH, OW, RH]`.
+        let (o_h, o_w, r_h) = (m / (ow * rh), (m / rh) % ow, m % rh);
+        for r_w in 0..rows {
+            for c_i in 0..cols {
+                let h = o_h * sh + r_h * dh;
+                let w = o_w * sw + r_w * dw;
+                assert_eq!(
+                    got.get_f32(&[m, r_w, c_i]),
+                    in_data[(h * in_w + w) * ci + c_i],
+                    "projected matrix {m} ({o_h}, {o_w}, {r_h}) at ({r_w}, {c_i})"
+                );
+            }
+        }
+    }
+}
+
+/// Reads a gathered operand through [`Tile::fragment_matrix`] and writes the whole matrix out, so
+/// the host can check it against the im2col expansion done by hand. This is the face an mma
+/// fragment reads: the output positions flattened into the row edge, the taps and channels into
+/// the column edge, resolved onto the compact window underneath.
+#[cube(launch)]
+fn fragment_matrix_kernel<E: Numeric>(
+    input: &TileArg<'_, E, Const<1>>,
+    out: &mut Tensor<f32>,
+    #[comptime] space: Space,
+    #[comptime] rows: usize,
+    #[comptime] cols: usize,
+    #[define(E)] _dtype: StorageType,
+) {
+    let input = input.tile(space);
+    let size!(W) = input.vector_size();
+    let view = input.fragment_matrix::<E, W, W>(rows, cols);
+
+    #[unroll]
+    for r in 0..rows {
+        #[unroll]
+        for c in 0..cols {
+            let value = view.read((r as u32, c as u32).runtime());
+            out[comptime!(r * cols + c)] = f32::cast_from(value);
+        }
+    }
+}
+
+/// The 2-D convolution input as one `(OH·OW) x (RH·RW·CI)` matrix: five logical axes flattened
+/// into two edges over three physical ones. Neither edge is a single axis, which is the whole
+/// point — no pinning of trailing axes produces this face, and it is the one an mma contracts.
+#[test]
+fn conv2d_fragment_matrix_view() {
+    let (oh, ow, rh, rw, ci) = (3usize, 4usize, 2usize, 3usize, 2usize);
+    let (sh, sw, dh, dw) = (2usize, 1usize, 1usize, 2usize);
+    let in_h = (oh - 1) * sh + (rh - 1) * dh + 1;
+    let in_w = (ow - 1) * sw + (rw - 1) * dw + 1;
+
+    let space = Tiling::new()
+        .extents(&[(OH, oh), (OW, ow), (RH, rh), (RW, rw), (CI, ci)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(OH, Cut::sequential(oh))
+                .axis(OW, Cut::sequential(ow))
+                .axis(RH, Cut::sequential(rh))
+                .axis(RW, Cut::sequential(rw))
+                .axis(CI, Cut::sequential(ci))
+        })
+        .build();
+
+    let in_spec = TileSpec::new(Projection::new(
+        &[OH, OW, RH, RW, CI],
+        &[
+            PhysicalAxisMap::affine(&[(OH, sh), (RH, dh)]),
+            PhysicalAxisMap::affine(&[(OW, sw), (RW, dw)]),
+            PhysicalAxisMap::of(CI),
+        ],
+    ));
+
+    let (rows, cols) = (oh * ow, rh * rw * ci);
+
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let f32_ty = f32::as_type_native_unchecked().storage_type();
+    let in_data = ramp(in_h * in_w * ci, 7);
+    let (in_handle, _) = TestInput::builder(client.clone(), shape![in_h, in_w, ci])
+        .dtype(f32_ty)
+        .custom(in_data.clone())
+        .generate_with_f32_host_data();
+    let out_handle = TestInput::builder(client.clone(), shape![rows, cols])
+        .dtype(f32_ty)
+        .zeros()
+        .generate_without_host_data();
+
+    fragment_matrix_kernel::launch::<TestRuntime>(
+        &client,
+        space.cube_count(),
+        space.cube_dim(&client),
+        TileArgLaunch::new(in_handle.binding().into_tensor_arg(), in_spec),
+        out_handle.clone().binding().into_tensor_arg(),
+        space,
+        rows,
+        cols,
+        f32_ty,
+    );
+
+    let got = HostData::from_tensor_handle(&client, out_handle, HostDataType::F32);
+    for r in 0..rows {
+        let (o_h, o_w) = (r / ow, r % ow);
+        for c in 0..cols {
+            // The column edge unravels row-major over `[RH, RW, CI]`, as the layout groups it.
+            let (r_h, r_w, c_i) = (c / (rw * ci), (c / ci) % rw, c % ci);
+            let h = o_h * sh + r_h * dh;
+            let w = o_w * sw + r_w * dw;
+            assert_eq!(
+                got.get_f32(&[r, c]),
+                in_data[(h * in_w + w) * ci + c_i],
+                "fragment matrix at ({r}, {c}) = ({o_h}, {o_w}, {r_h}, {r_w}, {c_i})"
+            );
+        }
+    }
+}
+
+// ---- the manual-mma leaf ---------------------------------------------------
+
+/// The resident promote → zero → mma → drain kernel of the matmul tests, with a *gathered* lhs.
+/// The accumulator is sized by the whole contraction (taps times channels), the input stages into
+/// its compacted smem window, and the fragment load flattens the tap and channel axes back into
+/// the `k` edge as it reads that window.
+#[cube(launch)]
+fn conv_mma_kernel<E: Numeric>(
+    input: &TileArg<'_, E, Const<1>>,
+    weight: &TileArg<'_, E, Const<1>>,
+    out: &TileArg<'_, E, Const<1>>,
+    #[comptime] space: Space,
+    #[define(E)] _dtype: StorageType,
+) {
+    let input = input.tile(comptime!(space.clone()));
+    let weight = weight.tile(comptime!(space.clone()));
+    let mut out = out.tile(space);
+    let mut acc = out.promote(&input);
+    acc.zero();
+    acc.mma(&input, &weight);
+    out.copy_from(&acc);
+}
+
+/// A convolution contracted on the manual-mma leaf: `m x n x k` is `OH x CO x (RH·CI)`, so the
+/// `k` edge spans two logical axes and the lhs reaches the fragment through its gather. Gated on
+/// the backend advertising manual mma, like [`mma_matmul_8x8x8`]; run with `cargo test-cuda` /
+/// `test-metal`.
+#[test]
+fn conv1d_mma_leaf() {
+    conv1d_mma_leaf_with(MmaIOConfig::manual());
+}
+
+/// The same contraction with `ldmatrix` selected for the lhs, which is the gathered operand. A
+/// host-derived [`MmaIOConfig::new`] picks that whenever the backend advertises `ldmatrix` over
+/// the stage's element, and no gather is expressible in a raw strided tile, so the load has to
+/// fall to the manual path on its own rather than refusing the config. The other two roles stay
+/// manual: they are direct operands, for which `ldmatrix` is genuinely unwired over a `MemData`
+/// window and still refused.
+#[test]
+fn conv1d_mma_leaf_gathered_lhs_ignores_ldmatrix() {
+    conv1d_mma_leaf_with(MmaIOConfig {
+        lhs_load_method: LoadMethod::LoadMatrix,
+        ..MmaIOConfig::manual()
+    });
+}
+
+fn conv1d_mma_leaf_with(io: MmaIOConfig) {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    if client.properties().features.matmul.mma.is_empty() {
+        TestOutcome::Validated(ValidationResult::Skipped(
+            "backend has no manual mma (features.matmul.mma) support".to_string(),
+        ))
+        .enforce();
+        return;
+    }
+
+    // `k = rh * ci = 8`, an 8x8x8 instruction, as the matmul mma test uses.
+    let (oh, co, rh, ci) = (8usize, 8usize, 2usize, 4usize);
+    let (stride, dilation) = (1usize, 1usize);
+    let in_len = (oh - 1) * stride + (rh - 1) * dilation + 1;
+    let leaf = Leaf::Mma { io };
+
+    let space = Tiling::new()
+        .extents(&[(OH, oh), (CO, co), (RH, rh), (CI, ci)])
+        .level(WalkOrder::RowMajor, Schedule::Staged, |l| {
+            l.axis(OH, Cut::sequential(oh))
+                .axis(CO, Cut::sequential(co))
+                .axis(RH, Cut::sequential(rh))
+                .axis(CI, Cut::sequential(ci))
+        })
+        .build();
+
+    let in_spec = TileSpec::new(Projection::new(
+        &[OH, RH, CI],
+        &[
+            PhysicalAxisMap::affine(&[(OH, stride), (RH, dilation)]),
+            PhysicalAxisMap::of(CI),
+        ],
+    ))
+    .leaf(leaf);
+
+    let f32_ty = f32::as_type_native_unchecked().storage_type();
+    let in_data = ramp(in_len * ci, 7);
+    let w_data = ramp(rh * ci * co, 5);
+
+    let (in_handle, _) = TestInput::builder(client.clone(), shape![in_len, ci])
+        .dtype(f32_ty)
+        .custom(in_data.clone())
+        .generate_with_f32_host_data();
+    let (w_handle, _) = TestInput::builder(client.clone(), shape![rh, ci, co])
+        .dtype(f32_ty)
+        .custom(w_data.clone())
+        .generate_with_f32_host_data();
+    let out_handle = TestInput::builder(client.clone(), shape![oh, co])
+        .dtype(f32_ty)
+        .zeros()
+        .generate_without_host_data();
+
+    conv_mma_kernel::launch::<TestRuntime>(
+        &client,
+        space.cube_count(),
+        space.cube_dim(&client),
+        TileArgLaunch::new(in_handle.binding().into_tensor_arg(), in_spec),
+        TileArgLaunch::new(
+            w_handle.binding().into_tensor_arg(),
+            TileSpec::direct(&[RH, CI, CO]).leaf(leaf),
+        ),
+        TileArgLaunch::new(
+            out_handle.clone().binding().into_tensor_arg(),
+            TileSpec::direct(&[OH, CO]).leaf(leaf),
+        ),
+        space,
+        f32_ty,
+    );
+
+    let got = HostData::from_tensor_handle(&client, out_handle, HostDataType::F32);
+    for o in 0..oh {
+        for c in 0..co {
+            let want: f32 = (0..rh)
+                .flat_map(|r| (0..ci).map(move |i| (r, i)))
+                .map(|(r, i)| {
+                    let h = o * stride + r * dilation;
+                    in_data[h * ci + i] * w_data[(r * ci + i) * co + c]
+                })
+                .sum();
+            assert_eq!(
+                got.get_f32(&[o, c]),
+                want,
+                "conv1d mma leaf: wrong at ({o}, {c})"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## What

An mma fragment contracts over a single `k` edge. A convolution contracts over its taps *and* its channels at once, and no pinning of trailing axes exposes that as one edge.

`GroupedMatrix` splits a tile's axes into two groups instead of pinning the leading ones, so several logical axes can flatten into each edge: `[M…, K…]` for the `A` role, `[K…, N…]` for `B`. `Projected<L>` then wraps any such layout with the operand's projection, so the matrix coordinate resolves to the tile's logical one and folds onto the compacted stage underneath.

This is what lets the manual mma leaf read a gathered operand straight out of its compacted smem window.

## Also in here

* **Fixes the projected 2-D view.** `projected_batch_matrix` indexed the physical ranked window with a logical axis position (`bound.at(space.position(axis))`). For any real gather the logical rank exceeds the physical one, so it read the wrong entry. Leading extents now come from the space, which is the only place a gathered operand's logical edges are sized.
* **A gathered operand always takes the manual fragment load**, whatever `MmaIOConfig` picked. `ldmatrix` reads a raw strided tile and no gather is expressible in one, so this is a permanent property rather than a missing path. `ldmatrix` over a `MemData` window remains unwired for direct operands.
* `Space::contracted_extent` gives the `k` a fragment is sized by as the product of every contracting axis, so `promote` no longer asserts a single contracted axis.
* The cmma leaf keeps its 2-D single contraction refusal. It loads a raw strided window, which a gather cannot be expressed in.

## Testing

* 50 unit tests, including new coverage for `matrix_split`, `contracted_extent`, and the projection validity rules.
* `conv2d_projected_matrix_view` and `conv2d_fragment_matrix_view` check both views on a 2-D convolution against a hand written im2col expansion, over five logical axes and three physical ones.
* Full `cubek-tile` suite green on wgpu, apart from `register_matmul_unit_split_k`, which already fails on `main`.

**`conv1d_mma_leaf` has not been run against actual mma hardware.** It gates on `features.matmul.mma`, which only the cpp backends (CUDA, HIP, Metal) populate, so it skips on wgpu and vulkan and reports green without executing. It needs one run on CUDA or Metal before this leaves draft. The same applies to `conv1d_mma_leaf_gathered_lhs_ignores_ldmatrix`.