### PR TITLE
A signed constant term in Projection

### DIFF
--- a/crates/cubek-tile/src/fold.rs
+++ b/crates/cubek-tile/src/fold.rs
@@ -46,6 +46,7 @@ pub trait Fold: Sized {
 
 impl Fold for u32 {}
 impl Fold for usize {}
+impl Fold for i32 {}
 
 /// Folding reductions over the elements at comptime `picks`: a sequence accumulates
 /// by chaining fresh values, where a `let mut` accumulator would land in a mutable

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -271,10 +271,20 @@ impl Projection {
         self.physical[pa].scale(axis)
     }
 
+    /// The signed constant offset along physical axis `pa`.
+    pub fn offset(&self, pa: usize) -> isize {
+        self.physical[pa].offset()
+    }
+
+    /// Whether any physical axis carries a negative offset.
+    pub fn may_underflow(&self) -> bool {
+        self.physical.iter().any(|m| m.offset() < 0)
+    }
+
     /// How many elements of physical axis `pa` a region covers, given each logical axis's extent:
     /// the receptive field `1 + Σ (extent - 1) * scale`. A single coefficient-`1` term collapses to
     /// `extent`, so a direct operand's window is its sub-tile edge as before; two terms give the
-    /// overlapping stencil window.
+    /// overlapping stencil window. A constant offset shifts position without changing span.
     pub fn span(&self, pa: usize, extent_of: impl Fn(Axis) -> usize) -> usize {
         1 + self.physical[pa]
             .terms()
@@ -283,15 +293,16 @@ impl Projection {
             .sum::<usize>()
     }
 
-    /// Whether every physical axis carries exactly one logical axis at coefficient `1`, so the
-    /// physical coordinates uniquely determine the logical ones and
+    /// Whether every physical axis carries exactly one logical axis at coefficient `1` with zero
+    /// offset, so the physical coordinates uniquely determine the logical ones and
     /// [`fold_physical`](crate::fold_physical) can invert `GmemLayout`'s `to_source_pos`. True for
     /// [`of_layout`](Projection::of_layout) and [`of_tiling`](Projection::of_tiling); false for an
-    /// affine (gather/stencil) map, which mixes several logical coordinates into one physical cell.
+    /// affine (gather/stencil) map, which mixes several logical coordinates into one physical cell
+    /// or applies a constant offset.
     pub fn is_invertible(&self) -> bool {
-        self.physical
-            .iter()
-            .all(|m| matches!(m.terms(), [t] if matches!(t.scale, Scale::Static(1))))
+        self.physical.iter().all(|m| {
+            m.offset() == 0 && matches!(m.terms(), [t] if matches!(t.scale, Scale::Static(1)))
+        })
     }
 
     /// The phase-1 contract for a *gathered* (affine) projection. A plain one, storage-tiled or
@@ -687,5 +698,39 @@ mod tests {
         );
         assert!(!p.is_invertible());
         assert!(Projection::direct(&[A, B]).is_invertible());
+
+        let with_offset = Projection::new(
+            &[A, B],
+            &[
+                PhysicalAxisMap::affine_with_offset(&[(A, 1)], -1),
+                PhysicalAxisMap::of(B),
+            ],
+        );
+        assert!(!with_offset.is_invertible());
+        assert_eq!(with_offset.offset(0), -1);
+        assert_eq!(with_offset.offset(1), 0);
+    }
+
+    /// Only a negative offset arms the window's underflow guard; a forward shift cannot underflow.
+    #[test]
+    fn may_underflow_tracks_negative_offsets_only() {
+        let padded = Projection::new(
+            &[A, R, B],
+            &[
+                PhysicalAxisMap::affine_with_offset(&[(A, 2), (R, 1)], -1),
+                PhysicalAxisMap::of(B),
+            ],
+        );
+        assert!(padded.may_underflow());
+
+        let shifted = Projection::new(
+            &[A, R, B],
+            &[
+                PhysicalAxisMap::affine_with_offset(&[(A, 2), (R, 1)], 1),
+                PhysicalAxisMap::of(B),
+            ],
+        );
+        assert!(!shifted.may_underflow());
+        assert!(!Projection::direct(&[A, B]).may_underflow());
     }
 }

--- a/crates/cubek-tile/src/physical/projection/compact.rs
+++ b/crates/cubek-tile/src/physical/projection/compact.rs
@@ -258,4 +258,21 @@ mod tests {
     fn a_ragged_innermost_extent_is_refused() {
         Compaction::of(&conv(1, 1), extents(8, 3, 6)).line_extents(4);
     }
+
+    /// A constant offset shifts source placement without changing compacted extents.
+    #[test]
+    fn padded_projection_compacts_identically() {
+        let p = Projection::new(
+            &[OH, RH, CI],
+            &[
+                PhysicalAxisMap::affine_with_offset(&[(OH, 2), (RH, 1)], -2),
+                PhysicalAxisMap::of(CI),
+            ],
+        );
+        let c = Compaction::of(&p, extents(8, 3, 16));
+        assert!(c.is_dense());
+        assert_eq!(c.steps(), &[1, 1]);
+        assert_eq!(c.extents(), &[17, 16]);
+        assert_eq!(c.projection().offset(0), 0);
+    }
 }

--- a/crates/cubek-tile/src/physical/projection/map.rs
+++ b/crates/cubek-tile/src/physical/projection/map.rs
@@ -45,27 +45,35 @@ pub struct AxisTerm {
     pub scale: Scale,
 }
 
-/// One [`PhysicalAxis`](crate::PhysicalAxis) as an affine combination of logical axes' digits:
-/// `physical = Σ digit(axis) * scale`.
+/// One [`PhysicalAxis`](crate::PhysicalAxis) as an affine combination of logical axes' digits
+/// plus a constant term: `physical = Σ digit(axis) * scale + offset`.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct PhysicalAxisMap {
     terms: SmallVec<[AxisTerm; MAX_AXES]>,
+    offset: isize,
 }
 
 impl PhysicalAxisMap {
-    /// The identity map: this physical axis *is* `axis`, coefficient `1`. What every operand of a
-    /// non-gather operation uses on every physical axis.
+    /// The identity map: this physical axis *is* `axis`, coefficient `1`, offset `0`. What every
+    /// operand of a non-gather operation uses on every physical axis.
     pub fn of(axis: Axis) -> Self {
         PhysicalAxisMap {
             terms: SmallVec::from_slice(&[AxisTerm {
                 axis,
                 scale: Scale::Static(1),
             }]),
+            offset: 0,
         }
     }
 
-    /// An affine combination, e.g. `affine(&[(Oh, stride), (Rh, dilation)])`.
+    /// An affine combination with zero offset, e.g. `affine(&[(Oh, stride), (Rh, dilation)])`.
     pub fn affine(terms: &[(Axis, usize)]) -> Self {
+        Self::affine_with_offset(terms, 0)
+    }
+
+    /// An affine combination with a signed constant offset, e.g.
+    /// `affine_with_offset(&[(Oh, stride), (Rh, dilation)], -padding)`.
+    pub fn affine_with_offset(terms: &[(Axis, usize)], offset: isize) -> Self {
         PhysicalAxisMap {
             terms: terms
                 .iter()
@@ -74,11 +82,17 @@ impl PhysicalAxisMap {
                     scale: Scale::Static(scale),
                 })
                 .collect(),
+            offset,
         }
     }
 
     pub fn terms(&self) -> &[AxisTerm] {
         &self.terms
+    }
+
+    /// The signed constant offset of this physical axis.
+    pub fn offset(&self) -> isize {
+        self.offset
     }
 
     /// `axis`'s coefficient, `0` when it does not address this physical axis.
@@ -89,17 +103,18 @@ impl PhysicalAxisMap {
             .map_or(0, |t| t.scale.get())
     }
 
-    /// Whether this physical axis is exactly `axis` at coefficient `1`. Says nothing about digit
-    /// extraction, which is a property of the whole [`Projection`](crate::Projection) (how many physical axes carry
-    /// `axis`), not of one map.
+    /// Whether this physical axis is exactly `axis` at coefficient `1` with zero offset.
+    /// Says nothing about digit extraction, which is a property of the whole
+    /// [`Projection`](crate::Projection) (how many physical axes carry `axis`), not of one map.
     pub fn is_identity(&self, axis: Axis) -> bool {
-        matches!(
-            self.terms.as_slice(),
-            [AxisTerm {
-                axis: a,
-                scale: Scale::Static(1)
-            }] if *a == axis
-        )
+        self.offset == 0
+            && matches!(
+                self.terms.as_slice(),
+                [AxisTerm {
+                    axis: a,
+                    scale: Scale::Static(1)
+                }] if *a == axis
+            )
     }
 }
 #[cfg(test)]
@@ -118,13 +133,20 @@ mod tests {
         assert!(!id.is_identity(B));
         assert_eq!(id.scale(A), 1);
         assert_eq!(id.scale(B), 0);
+        assert_eq!(id.offset(), 0);
 
         let affine = PhysicalAxisMap::affine(&[(A, 2), (B, 3)]);
         assert!(!affine.is_identity(A));
         assert_eq!(affine.scale(A), 2);
         assert_eq!(affine.scale(B), 3);
-        // A single term is still not the identity unless its coefficient is 1.
+        assert_eq!(affine.offset(), 0);
+        // A single term is still not the identity unless its coefficient is 1 and offset is 0.
         assert!(!PhysicalAxisMap::affine(&[(A, 2)]).is_identity(A));
         assert!(PhysicalAxisMap::affine(&[(A, 1)]).is_identity(A));
+
+        let with_offset = PhysicalAxisMap::affine_with_offset(&[(A, 1)], -2);
+        assert!(!with_offset.is_identity(A));
+        assert_eq!(with_offset.scale(A), 1);
+        assert_eq!(with_offset.offset(), -2);
     }
 }

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -1776,7 +1776,11 @@ impl Layout for Window {
             let abs = self.origin.at(i).fadd(pos[i].fcast::<i32>());
             // Clamp negative coordinates to 0 before bounds masking.
             let shifted = if comptime!(self.signed) {
-                if abs >= 0i32 { abs.fcast::<u32>() } else { 0u32 }
+                if abs >= 0i32 {
+                    abs.fcast::<u32>()
+                } else {
+                    0u32
+                }
             } else {
                 abs.fcast::<u32>()
             };

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -251,7 +251,7 @@ impl<T: Numeric> Tile<T> {
                     physical_strides,
                     projection: gmem_projection,
                 },
-                window: Window::new(origin, extent, bound),
+                window: Window::new(origin, extent, bound, comptime!(coords.may_underflow())),
                 projection: comptime!(coords),
                 window_start: 0u32,
                 access: comptime!(Access {
@@ -471,7 +471,8 @@ impl<T: Numeric> MemData<T> {
                     physical_strides,
                     projection: gmem_projection,
                 },
-                window: Window::new(origin, extent, bound),
+                // Stage origins are never negative.
+                window: Window::new(origin, extent, bound, false),
                 projection: comptime!(form.projection),
                 window_start: 0u32,
                 access: comptime!(Access {
@@ -1217,7 +1218,7 @@ impl<T: Numeric> MemData<T> {
     /// advance sums one term per contributing axis and its extent is the receptive field
     /// ([`Projection::span`]) rather than a single edge: consecutive sibling windows overlap.
     pub(crate) fn at(&self, region: &Region, #[comptime] space: Space) -> MemData<T> {
-        let mut origin = Coords::<u32>::new();
+        let mut origin = Coords::<i32>::new();
         let mut extent = Coords::<u32>::new();
         // Per-physical-axis window_start advances, summed below (chained, so constants fold).
         let mut advances = Coords::<u32>::new();
@@ -1246,7 +1247,7 @@ impl<T: Numeric> MemData<T> {
                     self.window
                         .origin
                         .at(p)
-                        .fadd(index.fmul(edge).fcast::<u32>()),
+                        .fadd(index.fmul(edge).fcast::<u32>().fcast::<i32>()),
                 );
                 extent.push(comptime!(edge as u32).runtime());
                 advances.push(index.fcast::<u32>().fmul(step_offset(
@@ -1288,7 +1289,8 @@ impl<T: Numeric> MemData<T> {
                     if pa == last { s / w } else { s }
                 });
 
-                origin.push(self.window.origin.at(pa).fadd(advance));
+                // `advance` only moves forward, so add directly to the signed origin.
+                origin.push(self.window.origin.at(pa).fadd(advance.fcast::<i32>()));
                 extent.push(comptime!(span as u32).runtime());
                 // `Projection::validate` pins a gathered operand to untiled storage (bare gmem, or
                 // the row-major compacted stage of one), so one physical axis step is one stride
@@ -1300,14 +1302,26 @@ impl<T: Numeric> MemData<T> {
             .window_start
             .fadd(advances.fsum(comptime!((0..rank).collect::<Vec<_>>())));
 
-        // Re-window the scales alongside the values (a no-op for per-tensor's zero strides).
+        // Re-window the scales alongside the values.
+        let mut origin_u32 = Coords::<u32>::new();
+        #[unroll]
+        for p in 0..rank {
+            origin_u32.push(origin.at(p).fcast::<u32>());
+        }
         let quant = #[comptime]
         match &self.store.quant {
-            ComptimeOption::Some(info) => ComptimeOption::new_Some(info.window(
-                &origin,
-                rank,
-                comptime!(self.store.vector_size),
-            )),
+            ComptimeOption::Some(info) => {
+                comptime!(assert!(
+                    !self.window.signed,
+                    "MemData::at: a quantized operand cannot carry a negative window origin, its \
+                     scale grid is addressed unsigned"
+                ));
+                ComptimeOption::new_Some(info.window(
+                    &origin_u32,
+                    rank,
+                    comptime!(self.store.vector_size),
+                ))
+            }
             ComptimeOption::None => ComptimeOption::new_None(),
         };
 
@@ -1319,7 +1333,12 @@ impl<T: Numeric> MemData<T> {
             },
             // The layout addresses the whole buffer and never narrows; only the window moves.
             layout: self.layout.clone(),
-            window: Window::new(origin, extent, self.window.bound.clone()),
+            window: Window::new(
+                origin,
+                extent,
+                self.window.bound.clone(),
+                comptime!(self.window.signed),
+            ),
             // How the logical axes address the physical ones is a fact about the buffer, invariant
             // down the descent.
             projection: comptime!(proj),
@@ -1336,8 +1355,8 @@ impl<T: Numeric> MemData<T> {
 
 /// The whole-buffer window of a stage: `origin = 0`, `extent =` its own physical extents.
 #[cube]
-fn full_window(#[comptime] form: StageForm) -> (Coords<u32>, Coords<u32>) {
-    let mut origin = Coords::<u32>::new();
+fn full_window(#[comptime] form: StageForm) -> (Coords<i32>, Coords<u32>) {
+    let mut origin = Coords::<i32>::new();
     let mut extent = Coords::<u32>::new();
 
     #[unroll]
@@ -1361,16 +1380,16 @@ fn top_window(
     bound: &Coords<u32>,
     #[comptime] vector_size: usize,
     #[comptime] projection: Projection,
-) -> (Coords<u32>, Coords<u32>) {
-    let mut origin = Coords::<u32>::new();
+) -> (Coords<i32>, Coords<u32>) {
+    let mut origin = Coords::<i32>::new();
     let mut extent = Coords::<u32>::new();
     let rank = comptime!(projection.physical_rank());
     let last = comptime!(rank - 1);
 
     #[unroll]
     for pa in 0..rank {
-        origin.push(0);
         let size = if comptime!(projection.is_direct()) {
+            origin.push(0);
             let axis = comptime!(space.axis_at(pa));
             // The innermost (vectorized) axis is a line count, `/ vector_size`. A `Dynamic` axis
             // reads its size from `bound`, already lined from the physical shape.
@@ -1381,6 +1400,8 @@ fn top_window(
                 Extent::Dynamic => bound.at(pa),
             }
         } else {
+            // Gathered axes start at their initial signed offset (e.g. negative padding).
+            origin.push((comptime!(projection.offset(pa) as i32)).runtime());
             bound.at(pa)
         };
         extent.push(size);
@@ -1714,21 +1735,30 @@ impl Layout for GmemLayout {
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct Window {
-    pub(crate) origin: Coords<u32>,
+    pub(crate) origin: Coords<i32>,
     pub(crate) extent: Coords<u32>,
     /// Absolute logical extent (the valid region). `shape()` stays `extent` (the tile
     /// cell, so loops cover the whole padded tile), but `is_in_bounds` clips against
     /// `bound` so a checked read/write zeroes / skips the overhang.
     pub(crate) bound: Coords<u32>,
+    /// Whether the origin can be negative.
+    #[cube(comptime)]
+    pub(crate) signed: bool,
 }
 
 #[cube]
 impl Window {
-    pub fn new(origin: Coords<u32>, extent: Coords<u32>, bound: Coords<u32>) -> Self {
+    pub fn new(
+        origin: Coords<i32>,
+        extent: Coords<u32>,
+        bound: Coords<u32>,
+        #[comptime] signed: bool,
+    ) -> Self {
         Window {
             origin,
             extent,
             bound,
+            signed,
         }
     }
 }
@@ -1743,7 +1773,14 @@ impl Layout for Window {
 
         #[unroll]
         for i in 0..self.origin.len() {
-            out.push(self.origin.at(i).fadd(pos[i]));
+            let abs = self.origin.at(i).fadd(pos[i].fcast::<i32>());
+            // Clamp negative coordinates to 0 before bounds masking.
+            let shifted = if comptime!(self.signed) {
+                if abs >= 0i32 { abs.fcast::<u32>() } else { 0u32 }
+            } else {
+                abs.fcast::<u32>()
+            };
+            out.push(shifted);
         }
 
         out
@@ -1761,11 +1798,16 @@ impl Layout for Window {
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
         let mut valid = true;
 
-        // The cell can overhang the matrix; a position is valid only if its absolute
-        // coordinate (`origin + pos`) is within the logical `bound`.
+        // Check if the absolute coordinate is within [0, bound).
         #[unroll]
         for i in 0..self.bound.len() {
-            valid = valid && self.origin.at(i).fadd(pos[i]) < self.bound.at(i);
+            let abs = self.origin.at(i).fadd(pos[i].fcast::<i32>());
+            let inside = if comptime!(self.signed) {
+                abs >= 0i32 && abs.fcast::<u32>() < self.bound.at(i)
+            } else {
+                abs.fcast::<u32>() < self.bound.at(i)
+            };
+            valid = valid && inside;
         }
 
         valid

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -67,8 +67,9 @@ impl<L: LogicalLayout> Layout for Projected<L> {
     }
 
     fn to_source_pos_checked(&self, pos: Self::Coordinates) -> (Self::SourceCoordinates, bool) {
-        let in_bounds = self.is_in_bounds(pos.clone());
-        (self.to_source_pos(pos), in_bounds)
+        let (inner_pos, inner_in_bounds) = self.inner.to_source_pos_checked(pos);
+        let (proj_pos, proj_in_bounds) = self.projection.to_source_pos_checked(inner_pos);
+        (proj_pos, inner_in_bounds && proj_in_bounds)
     }
 
     fn shape(&self) -> Self::Coordinates {
@@ -76,14 +77,15 @@ impl<L: LogicalLayout> Layout for Projected<L> {
     }
 
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
-        self.inner.is_in_bounds(pos)
+        let (inner_pos, inner_in_bounds) = self.inner.to_source_pos_checked(pos);
+        inner_in_bounds && self.projection.is_in_bounds(inner_pos)
     }
 }
 
 /// A [`Layout`] mapping a tile's logical coordinate to its window's physical one:
 /// `phys[pa] = Σ logical[axis] * scale`. Sits between the [`Window`](crate::Window) and the
 /// element layout, so the window's `bound` still masks the read (an out-of-range stencil tap
-/// reads zero).
+/// reads zero). Constant offsets are handled by [`Window`](crate::Window) and omitted here.
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct AxisProjection {
@@ -127,13 +129,15 @@ impl Layout for AxisProjection {
 
         #[unroll]
         for pa in 0..comptime!(self.projection.physical_rank()) {
-            let n = comptime!(self.projection.physical_axis(pa).terms().len());
+            let map = comptime!(self.projection.physical_axis(pa));
+            let n = comptime!(map.terms().len());
+
             // Per-term products, summed below (chained, so a single coefficient-1 term folds to
             // the coordinate itself).
             let mut terms = Coords::<u32>::new();
             #[unroll]
             for t in 0..n {
-                let term = comptime!(self.projection.physical_axis(pa).terms()[t]);
+                let term = comptime!(map.terms()[t]);
                 let p = comptime!(self.space.position(term.axis));
                 terms.push(pos[p].fmul(comptime!(term.scale.get() as u32)));
             }

--- a/crates/cubek-tile/tests/tile/conv.rs
+++ b/crates/cubek-tile/tests/tile/conv.rs
@@ -321,6 +321,159 @@ fn conv1d_single_tile() {
     .check(6, 4);
 }
 
+/// Padded 1-D convolution: taps that underflow physical bounds mask to 0.
+#[test]
+fn conv1d_padded_underflow_masks_to_zero() {
+    let oh = 6;
+    let co = 4;
+    let rh = 3;
+    let ci = 2;
+    let stride = 1;
+    let dilation = 1;
+    let padding = 1;
+    let in_len = 6;
+
+    let space = Tiling::new()
+        .extents(&[(OH, oh), (CO, co), (RH, rh), (CI, ci)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(OH, Cut::sequential(3))
+                .axis(CO, Cut::sequential(4))
+                .axis(RH, Cut::sequential(rh))
+                .axis(CI, Cut::sequential(ci))
+        })
+        .build();
+
+    let in_spec = TileSpec::new(Projection::new(
+        &[OH, RH, CI],
+        &[
+            PhysicalAxisMap::affine_with_offset(
+                &[(OH, stride), (RH, dilation)],
+                -(padding as isize),
+            ),
+            PhysicalAxisMap::of(CI),
+        ],
+    ))
+    .checked(true);
+
+    let (got, input, weight) = run(
+        shape![in_len, ci],
+        shape![rh, ci, co],
+        shape![oh, co],
+        in_spec,
+        &[RH, CI, CO],
+        TileSpec::direct(&[OH, CO]).checked(true),
+        space,
+        1,
+    );
+
+    // Reference with zero padding:
+    let mut want = vec![0.0f32; oh * co];
+    for o in 0..oh {
+        for c in 0..co {
+            let mut acc = 0.0f32;
+            for r in 0..rh {
+                for i in 0..ci {
+                    let h = (o * stride + r * dilation) as isize - padding as isize;
+                    let x = if h >= 0 && (h as usize) < in_len {
+                        input[(h as usize) * ci + i]
+                    } else {
+                        0.0
+                    };
+                    let w = weight[(r * ci + i) * co + c];
+                    acc += x * w;
+                }
+            }
+            want[o * co + c] = acc;
+        }
+    }
+
+    for o in 0..oh {
+        for c in 0..co {
+            assert_eq!(
+                got.get_f32(&[o, c]),
+                want[o * co + c],
+                "padded conv1d: wrong at ({o}, {c})"
+            );
+        }
+    }
+}
+
+/// The same padded convolution under a staged schedule.
+#[test]
+fn conv1d_padded_staged_underflow_masks_to_zero() {
+    let oh = 6;
+    let co = 4;
+    let rh = 3;
+    let ci = 2;
+    let stride = 1;
+    let dilation = 1;
+    let padding = 1;
+    let in_len = 6;
+
+    let space = Tiling::new()
+        .extents(&[(OH, oh), (CO, co), (RH, rh), (CI, ci)])
+        .level(WalkOrder::RowMajor, Schedule::Staged, |l| {
+            l.axis(OH, Cut::sequential(3))
+                .axis(CO, Cut::sequential(4))
+                .axis(RH, Cut::sequential(rh))
+                .axis(CI, Cut::sequential(ci))
+        })
+        .build();
+
+    let in_spec = TileSpec::new(Projection::new(
+        &[OH, RH, CI],
+        &[
+            PhysicalAxisMap::affine_with_offset(
+                &[(OH, stride), (RH, dilation)],
+                -(padding as isize),
+            ),
+            PhysicalAxisMap::of(CI),
+        ],
+    ))
+    .checked(true);
+
+    let (got, input, weight) = run(
+        shape![in_len, ci],
+        shape![rh, ci, co],
+        shape![oh, co],
+        in_spec,
+        &[RH, CI, CO],
+        TileSpec::direct(&[OH, CO]).checked(true),
+        space,
+        1,
+    );
+
+    let mut want = vec![0.0f32; oh * co];
+    for o in 0..oh {
+        for c in 0..co {
+            let mut acc = 0.0f32;
+            for r in 0..rh {
+                for i in 0..ci {
+                    let h = (o * stride + r * dilation) as isize - padding as isize;
+                    let x = if h >= 0 && (h as usize) < in_len {
+                        input[(h as usize) * ci + i]
+                    } else {
+                        0.0
+                    };
+                    let w = weight[(r * ci + i) * co + c];
+                    acc += x * w;
+                }
+            }
+            want[o * co + c] = acc;
+        }
+    }
+
+    for o in 0..oh {
+        for c in 0..co {
+            assert_eq!(
+                got.get_f32(&[o, c]),
+                want[o * co + c],
+                "padded staged conv1d: wrong at ({o}, {c})"
+            );
+        }
+    }
+}
+
 /// The gathered operand in two-wide lines. Its innermost axis is `CI`, the fastest contracted one,
 /// so the leaf splits each reduce step into the line index it reads and the lane it broadcasts:
 /// the one arithmetic on the gather path that a width of `1` leaves dead.


### PR DESCRIPTION
Stacked on #473.

A gathered operand cannot say `- padding` today: `PhysicalAxisMap` has terms but no
constant. This adds one, signed, so a windowed placement lowers to
`physical = O * step + R * dilation - padding`. Convolution wants it for the same
reason, so it lands in the tile DSL rather than in a caller.

The constant is signed, which is the actual work: a window origin was `Coords<u32>`
and an underflowing tap wrapped instead of masking.

## Changes

- `PhysicalAxisMap::affine_with_offset` and `offset()`. `is_identity` and
  `Projection::is_invertible` now require a zero offset: a shifted map is neither.
- `Window::origin` becomes `Coords<i32>`. `to_source_pos` clamps a negative
  coordinate to 0 (the read has to address something), and `is_in_bounds` checks
  `0 <= origin + pos < bound` so that read masks to zero.
- The guard is comptime. `Projection::may_underflow` feeds a `signed` flag on
  `Window`, so an operand without a negative offset emits exactly the unsigned check
  it emitted before.
- `Compaction` and `AxisProjection` deliberately drop the offset: it places the
  window, and the stage is a copy of an already-placed window.
- `Projected::to_source_pos_checked` composes both layers' checks. It was computing
  position and validity independently, and the projection's own check never ran.
- Quantized scales are still re-windowed unsigned; a comptime assert pins that no
  quantized operand gathers with a negative offset.

## Tests

Offset round-trips and the two tightened predicates; `may_underflow`; a compaction
that is unchanged by an offset. End to end, `conv1d_padded_underflow_masks_to_zero`
and its staged twin run a 1-D convolution at `padding = 1` against a zero-padded CPU
reference, the first device-side exercise of a negative origin.

`cargo clippy -p cubek-tile --all-targets` clean, `--lib` 55 passed, `--test '*'`
149 passed with `register_matmul_unit_split_k` failing identically on the base
branch.
