### PR TITLE
Carry a projection's Dynamic coefficients and offsets at runtime

### DIFF
--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -118,6 +118,18 @@ impl<'a, E: Numeric, V: Size> TileArg<'a, E, V> {
     pub fn tile(&self, #[comptime] space: Space) -> Tile<E> {
         Tile::<E>::of(self.tensor, space, comptime!(self.spec.clone()))
     }
+
+    /// [`tile`](Self::tile) for a gather whose coefficients are not all comptime: one value per
+    /// [`Scale::Dynamic`](crate::Scale) term of the spec's projection, in
+    /// [`Projection::dynamic_index`] order. See [`Tile::of_gathered`].
+    pub fn tile_gathered(&self, #[comptime] space: Space, coefficients: Coords<u32>) -> Tile<E> {
+        Tile::<E>::of_gathered(
+            self.tensor,
+            space,
+            comptime!(self.spec.clone()),
+            coefficients,
+        )
+    }
 }
 
 /// One quantized operand as a single launch argument: the storage-typed values tensor

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -119,15 +119,22 @@ impl<'a, E: Numeric, V: Size> TileArg<'a, E, V> {
         Tile::<E>::of(self.tensor, space, comptime!(self.spec.clone()))
     }
 
-    /// [`tile`](Self::tile) for a gather whose coefficients are not all comptime: one value per
-    /// [`Scale::Dynamic`](crate::Scale) term of the spec's projection, in
-    /// [`Projection::dynamic_index`] order. See [`Tile::of_gathered`].
-    pub fn tile_gathered(&self, #[comptime] space: Space, coefficients: Coords<u32>) -> Tile<E> {
+    /// [`tile`](Self::tile) for a gather whose affine map is not all comptime: one value per
+    /// [`Scale::Dynamic`](crate::Scale) term and one signed value per
+    /// [`Offset::Dynamic`](crate::Offset) axis of the spec's projection. See
+    /// [`Tile::of_gathered`].
+    pub fn tile_gathered(
+        &self,
+        #[comptime] space: Space,
+        coefficients: Coords<u32>,
+        offsets: Coords<i32>,
+    ) -> Tile<E> {
         Tile::<E>::of_gathered(
             self.tensor,
             space,
             comptime!(self.spec.clone()),
             coefficients,
+            offsets,
         )
     }
 }

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -3,7 +3,7 @@
 
 use cubecl::zspace::SmallVec;
 
-use crate::{Axis, ConcreteLayout, MAX_AXES, PhysicalAxisMap, Scale, StorageTiling};
+use crate::{Axis, ConcreteLayout, MAX_AXES, Offset, PhysicalAxisMap, Scale, StorageTiling};
 
 /// An operand's logical axes mapped onto its buffer's physical axes.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
@@ -271,24 +271,31 @@ impl Projection {
         self.physical[pa].scale(axis)
     }
 
-    /// The signed constant offset along physical axis `pa`.
-    pub fn offset(&self, pa: usize) -> isize {
+    /// The signed constant or dynamic offset along physical axis `pa`.
+    pub fn offset(&self, pa: usize) -> Offset {
         self.physical[pa].offset()
     }
 
-    /// Whether any physical axis carries a negative offset.
+    /// Whether any physical axis carries a negative offset or a dynamic offset (whose sign
+    /// cannot be proven non-negative at comptime).
     pub fn may_underflow(&self) -> bool {
-        self.physical.iter().any(|m| m.offset() < 0)
+        self.physical.iter().any(|m| match m.offset() {
+            Offset::Static(o) => o < 0,
+            Offset::Dynamic => true,
+        })
     }
 
     /// Where physical axis `pa`'s term `t` sits in the runtime coefficient carrier, or `None` when
     /// it is [`Static`](Scale::Static). The order is the projection's own, physical axis major and
     /// term order within, so a caller fills the carrier by walking the maps in order.
-    pub fn dynamic_index(&self, pa: usize, t: usize) -> Option<usize> {
+    pub fn dynamic_scale_index(&self, pa: usize, t: usize) -> Option<usize> {
         if !self.physical[pa].terms()[t].scale.is_dynamic() {
             return None;
         }
-        let before: usize = self.physical[..pa].iter().map(|m| m.dynamic_count()).sum();
+        let before: usize = self.physical[..pa]
+            .iter()
+            .map(|m| m.dynamic_scale_count())
+            .sum();
         let within = self.physical[pa].terms()[..t]
             .iter()
             .filter(|term| term.scale.is_dynamic())
@@ -296,14 +303,42 @@ impl Projection {
         Some(before + within)
     }
 
-    /// How many coefficients are [`Dynamic`](Scale::Dynamic): the length of the runtime carrier.
-    pub fn dynamic_count(&self) -> usize {
-        self.physical.iter().map(|m| m.dynamic_count()).sum()
+    /// Where physical axis `pa`'s offset sits in the runtime offset carrier, or `None` when it is
+    /// [`Static`](Offset::Static). Offsets ride their own signed carrier, so this order is
+    /// independent of [`dynamic_scale_index`](Self::dynamic_scale_index)'s.
+    pub fn dynamic_offset_index(&self, pa: usize) -> Option<usize> {
+        if !self.physical[pa].offset().is_dynamic() {
+            return None;
+        }
+        Some(
+            self.physical[..pa]
+                .iter()
+                .filter(|m| m.offset().is_dynamic())
+                .count(),
+        )
+    }
+
+    /// How many coefficients are [`Dynamic`](Scale::Dynamic): the length of the coefficient carrier.
+    pub fn dynamic_scale_count(&self) -> usize {
+        self.physical.iter().map(|m| m.dynamic_scale_count()).sum()
+    }
+
+    /// How many offsets are [`Dynamic`](Offset::Dynamic): the length of the offset carrier.
+    pub fn dynamic_offset_count(&self) -> usize {
+        self.physical
+            .iter()
+            .filter(|m| m.offset().is_dynamic())
+            .count()
+    }
+
+    /// Whether any coefficient or offset is only known at runtime.
+    pub fn has_dynamic(&self) -> bool {
+        self.has_dynamic_scales() || self.dynamic_offset_count() > 0
     }
 
     /// Whether any coefficient is only known at runtime.
-    pub fn has_dynamic(&self) -> bool {
-        self.dynamic_count() > 0
+    pub fn has_dynamic_scales(&self) -> bool {
+        self.physical.iter().any(|m| m.has_dynamic_scale())
     }
 
     /// How many elements of physical axis `pa` a region covers, given each logical axis's extent:
@@ -326,7 +361,8 @@ impl Projection {
     /// or applies a constant offset.
     pub fn is_invertible(&self) -> bool {
         self.physical.iter().all(|m| {
-            m.offset() == 0 && matches!(m.terms(), [t] if matches!(t.scale, Scale::Static(1)))
+            m.offset() == Offset::Static(0)
+                && matches!(m.terms(), [t] if matches!(t.scale, Scale::Static(1)))
         })
     }
 
@@ -724,11 +760,12 @@ mod tests {
             ],
         );
         assert!(!with_offset.is_invertible());
-        assert_eq!(with_offset.offset(0), -1);
-        assert_eq!(with_offset.offset(1), 0);
+        assert_eq!(with_offset.offset(0), Offset::Static(-1));
+        assert_eq!(with_offset.offset(1), Offset::Static(0));
     }
 
     /// Only a negative offset arms the window's underflow guard; a forward shift cannot underflow.
+    /// A dynamic offset conservatively arms it since its sign is only known at runtime.
     #[test]
     fn may_underflow_tracks_negative_offsets_only() {
         let padded = Projection::new(
@@ -749,9 +786,19 @@ mod tests {
         );
         assert!(!shifted.may_underflow());
         assert!(!Projection::direct(&[A, B]).may_underflow());
+
+        let dynamic_offset = Projection::new(
+            &[A, R, B],
+            &[
+                PhysicalAxisMap::affine_with_offset(&[(A, 2), (R, 1)], Offset::Dynamic),
+                PhysicalAxisMap::of(B),
+            ],
+        );
+        assert!(dynamic_offset.may_underflow());
     }
 
-    /// The runtime carrier's order: physical axis major, term order within, `Static` terms skipped.
+    /// Each carrier's order: physical axis major, term order within, `Static` skipped. Offsets are
+    /// indexed apart from coefficients, so one does not shift the other.
     #[test]
     fn dynamic_terms_index_in_projection_order() {
         let p = Projection::new(
@@ -762,10 +809,12 @@ mod tests {
             ],
         );
         assert!(p.has_dynamic());
-        assert_eq!(p.dynamic_count(), 2);
-        assert_eq!(p.dynamic_index(0, 0), Some(0));
-        assert_eq!(p.dynamic_index(0, 1), Some(1));
-        assert_eq!(p.dynamic_index(1, 0), None);
+        assert_eq!(p.dynamic_scale_count(), 2);
+        assert_eq!(p.dynamic_offset_count(), 0);
+        assert_eq!(p.dynamic_scale_index(0, 0), Some(0));
+        assert_eq!(p.dynamic_scale_index(0, 1), Some(1));
+        assert_eq!(p.dynamic_offset_index(0), None);
+        assert_eq!(p.dynamic_scale_index(1, 0), None);
 
         let mixed = Projection::new(
             &[A, R, B],
@@ -774,10 +823,39 @@ mod tests {
                 PhysicalAxisMap::of(B),
             ],
         );
-        assert_eq!(mixed.dynamic_count(), 1);
-        assert_eq!(mixed.dynamic_index(0, 0), None);
-        assert_eq!(mixed.dynamic_index(0, 1), Some(0));
+        assert_eq!(mixed.dynamic_scale_count(), 1);
+        assert_eq!(mixed.dynamic_scale_index(0, 0), None);
+        assert_eq!(mixed.dynamic_scale_index(0, 1), Some(0));
+        assert_eq!(mixed.dynamic_offset_index(0), None);
         assert!(!Projection::direct(&[A, B]).has_dynamic());
+
+        let with_dynamic_offset = Projection::new(
+            &[A, R, B],
+            &[
+                PhysicalAxisMap::scaled_with_offset(
+                    &[(A, Scale::Dynamic), (R, Scale::Static(1))],
+                    Offset::Dynamic,
+                ),
+                PhysicalAxisMap::of(B),
+            ],
+        );
+        assert_eq!(with_dynamic_offset.dynamic_scale_count(), 1);
+        assert_eq!(with_dynamic_offset.dynamic_offset_count(), 1);
+        assert_eq!(with_dynamic_offset.dynamic_scale_index(0, 0), Some(0));
+        assert_eq!(with_dynamic_offset.dynamic_scale_index(0, 1), None);
+        assert_eq!(with_dynamic_offset.dynamic_offset_index(0), Some(0));
+        assert_eq!(with_dynamic_offset.dynamic_offset_index(1), None);
+
+        let two_offsets = Projection::new(
+            &[A, R, B],
+            &[
+                PhysicalAxisMap::affine_with_offset(&[(A, 2), (R, 1)], Offset::Dynamic),
+                PhysicalAxisMap::scaled_with_offset(&[(B, Scale::Dynamic)], Offset::Dynamic),
+            ],
+        );
+        assert_eq!(two_offsets.dynamic_offset_index(0), Some(0));
+        assert_eq!(two_offsets.dynamic_offset_index(1), Some(1));
+        assert_eq!(two_offsets.dynamic_scale_index(1, 0), Some(0));
     }
 
     /// A runtime coefficient is a gather by construction, so it can never be inverted back into

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -281,6 +281,31 @@ impl Projection {
         self.physical.iter().any(|m| m.offset() < 0)
     }
 
+    /// Where physical axis `pa`'s term `t` sits in the runtime coefficient carrier, or `None` when
+    /// it is [`Static`](Scale::Static). The order is the projection's own, physical axis major and
+    /// term order within, so a caller fills the carrier by walking the maps in order.
+    pub fn dynamic_index(&self, pa: usize, t: usize) -> Option<usize> {
+        if !self.physical[pa].terms()[t].scale.is_dynamic() {
+            return None;
+        }
+        let before: usize = self.physical[..pa].iter().map(|m| m.dynamic_count()).sum();
+        let within = self.physical[pa].terms()[..t]
+            .iter()
+            .filter(|term| term.scale.is_dynamic())
+            .count();
+        Some(before + within)
+    }
+
+    /// How many coefficients are [`Dynamic`](Scale::Dynamic): the length of the runtime carrier.
+    pub fn dynamic_count(&self) -> usize {
+        self.physical.iter().map(|m| m.dynamic_count()).sum()
+    }
+
+    /// Whether any coefficient is only known at runtime.
+    pub fn has_dynamic(&self) -> bool {
+        self.dynamic_count() > 0
+    }
+
     /// How many elements of physical axis `pa` a region covers, given each logical axis's extent:
     /// the receptive field `1 + Σ (extent - 1) * scale`. A single coefficient-`1` term collapses to
     /// `extent`, so a direct operand's window is its sub-tile edge as before; two terms give the
@@ -308,14 +333,6 @@ impl Projection {
     /// The phase-1 contract for a *gathered* (affine) projection. A plain one, storage-tiled or
     /// not, is unconstrained: it is what the engine has always done.
     pub fn validate(&self) {
-        assert!(
-            !self
-                .physical
-                .iter()
-                .any(|m| m.terms().iter().any(|t| t.scale.is_dynamic())),
-            "Projection: Dynamic scales are reserved for a runtime stride/dilation and are not \
-             implemented yet"
-        );
         // Every physical axis carrying one logical axis at coefficient 1 is exactly "no gather",
         // whatever the ranks: `direct`, and `tiled`, which repeats a label rather than scaling it.
         if self.is_invertible() {
@@ -338,7 +355,7 @@ impl Projection {
              coefficient 1 (it is addressed in vector lines)"
         );
         for &axis in self.axes.iter() {
-            let count = self.physical.iter().filter(|m| m.scale(axis) != 0).count();
+            let count = self.physical.iter().filter(|m| m.addresses(axis)).count();
             assert!(
                 count > 0,
                 "Projection: logical axis {axis:?} addresses no physical axis"
@@ -732,5 +749,49 @@ mod tests {
         );
         assert!(!shifted.may_underflow());
         assert!(!Projection::direct(&[A, B]).may_underflow());
+    }
+
+    /// The runtime carrier's order: physical axis major, term order within, `Static` terms skipped.
+    #[test]
+    fn dynamic_terms_index_in_projection_order() {
+        let p = Projection::new(
+            &[A, R, B],
+            &[
+                PhysicalAxisMap::scaled(&[(A, Scale::Dynamic), (R, Scale::Dynamic)]),
+                PhysicalAxisMap::of(B),
+            ],
+        );
+        assert!(p.has_dynamic());
+        assert_eq!(p.dynamic_count(), 2);
+        assert_eq!(p.dynamic_index(0, 0), Some(0));
+        assert_eq!(p.dynamic_index(0, 1), Some(1));
+        assert_eq!(p.dynamic_index(1, 0), None);
+
+        let mixed = Projection::new(
+            &[A, R, B],
+            &[
+                PhysicalAxisMap::scaled(&[(A, Scale::Static(2)), (R, Scale::Dynamic)]),
+                PhysicalAxisMap::of(B),
+            ],
+        );
+        assert_eq!(mixed.dynamic_count(), 1);
+        assert_eq!(mixed.dynamic_index(0, 0), None);
+        assert_eq!(mixed.dynamic_index(0, 1), Some(0));
+        assert!(!Projection::direct(&[A, B]).has_dynamic());
+    }
+
+    /// A runtime coefficient is a gather by construction, so it can never be inverted back into
+    /// logical digits.
+    #[test]
+    fn a_dynamic_coefficient_is_not_invertible() {
+        let p = Projection::new(
+            &[A, B],
+            &[
+                PhysicalAxisMap::scaled(&[(A, Scale::Dynamic)]),
+                PhysicalAxisMap::of(B),
+            ],
+        );
+        assert!(!p.is_invertible());
+        p.validate();
     }
 }

--- a/crates/cubek-tile/src/physical/projection/compact.rs
+++ b/crates/cubek-tile/src/physical/projection/compact.rs
@@ -54,7 +54,7 @@ impl Compaction {
         // The box below is the smem allocation: both its step (a gcd of coefficients) and its
         // extent are comptime by construction, which a runtime coefficient cannot be.
         assert!(
-            !projection.has_dynamic(),
+            !projection.has_dynamic_scales(),
             "Compaction: a Dynamic coefficient has no comptime window extent, so the operand \
              carrying it cannot be staged (use Schedule::Direct)"
         );
@@ -167,7 +167,7 @@ fn gcd(a: usize, b: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Scale;
+    use crate::{Offset, Scale};
 
     const OH: Axis = Axis(0);
     const RH: Axis = Axis(1);
@@ -281,7 +281,24 @@ mod tests {
         assert!(c.is_dense());
         assert_eq!(c.steps(), &[1, 1]);
         assert_eq!(c.extents(), &[17, 16]);
-        assert_eq!(c.projection().offset(0), 0);
+        assert_eq!(c.projection().offset(0), Offset::Static(0));
+    }
+
+    /// A dynamic offset shifts source placement without changing compacted extents.
+    #[test]
+    fn dynamic_offset_projection_compacts_identically() {
+        let p = Projection::new(
+            &[OH, RH, CI],
+            &[
+                PhysicalAxisMap::affine_with_offset(&[(OH, 2), (RH, 1)], Offset::Dynamic),
+                PhysicalAxisMap::of(CI),
+            ],
+        );
+        let c = Compaction::of(&p, extents(8, 3, 16));
+        assert!(c.is_dense());
+        assert_eq!(c.steps(), &[1, 1]);
+        assert_eq!(c.extents(), &[17, 16]);
+        assert_eq!(c.projection().offset(0), Offset::Static(0));
     }
 
     /// A stage is sized at comptime, which a runtime coefficient cannot be.

--- a/crates/cubek-tile/src/physical/projection/compact.rs
+++ b/crates/cubek-tile/src/physical/projection/compact.rs
@@ -51,6 +51,13 @@ impl Compaction {
     /// step is `1` and every extent is the axis's own, so a plain operand's stage is the tile it
     /// always was.
     pub fn of(projection: &Projection, extent_of: impl Fn(Axis) -> usize) -> Compaction {
+        // The box below is the smem allocation: both its step (a gcd of coefficients) and its
+        // extent are comptime by construction, which a runtime coefficient cannot be.
+        assert!(
+            !projection.has_dynamic(),
+            "Compaction: a Dynamic coefficient has no comptime window extent, so the operand \
+             carrying it cannot be staged (use Schedule::Direct)"
+        );
         let rank = projection.physical_rank();
         let mut steps = SmallVec::new();
         let mut extents = SmallVec::new();
@@ -160,6 +167,7 @@ fn gcd(a: usize, b: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Scale;
 
     const OH: Axis = Axis(0);
     const RH: Axis = Axis(1);
@@ -274,5 +282,19 @@ mod tests {
         assert_eq!(c.steps(), &[1, 1]);
         assert_eq!(c.extents(), &[17, 16]);
         assert_eq!(c.projection().offset(0), 0);
+    }
+
+    /// A stage is sized at comptime, which a runtime coefficient cannot be.
+    #[test]
+    #[should_panic(expected = "cannot be staged")]
+    fn a_dynamic_coefficient_is_refused() {
+        let p = Projection::new(
+            &[OH, RH, CI],
+            &[
+                PhysicalAxisMap::scaled(&[(OH, Scale::Dynamic), (RH, Scale::Static(1))]),
+                PhysicalAxisMap::of(CI),
+            ],
+        );
+        Compaction::of(&p, extents(8, 3, 16));
     }
 }

--- a/crates/cubek-tile/src/physical/projection/map.rs
+++ b/crates/cubek-tile/src/physical/projection/map.rs
@@ -8,9 +8,11 @@ use crate::{Axis, MAX_AXES};
 
 /// How far one unit of a logical axis's coordinate moves along one physical axis. Mirrors
 /// [`Extent`](crate::Extent): `Static` is a comptime constant so the advance folds the way
-/// [`window_start`](crate::MemData) needs, `Dynamic` is reserved for a runtime stride/dilation
-/// and is rejected by [`Projection::validate`](crate::Projection::validate) until the runtime
-/// half exists.
+/// [`window_start`](crate::MemData) needs, `Dynamic` is a runtime stride or dilation whose value
+/// rides the tile ([`Tile::of_gathered`](crate::Tile::of_gathered)) instead of the kernel.
+///
+/// A `Dynamic` coefficient costs the comptime window geometry: the receptive field it spans is a
+/// runtime value, so the operand cannot be staged.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Scale {
     Static(usize),
@@ -74,13 +76,25 @@ impl PhysicalAxisMap {
     /// An affine combination with a signed constant offset, e.g.
     /// `affine_with_offset(&[(Oh, stride), (Rh, dilation)], -padding)`.
     pub fn affine_with_offset(terms: &[(Axis, usize)], offset: isize) -> Self {
+        let terms: SmallVec<[(Axis, Scale); MAX_AXES]> = terms
+            .iter()
+            .map(|&(axis, scale)| (axis, Scale::Static(scale)))
+            .collect();
+        Self::scaled_with_offset(&terms, offset)
+    }
+
+    /// [`affine`](Self::affine) over explicit [`Scale`]s, which is how a coefficient only known at
+    /// runtime is spelled: `scaled(&[(Oh, Scale::Dynamic), (Rh, Scale::Static(1))])`.
+    pub fn scaled(terms: &[(Axis, Scale)]) -> Self {
+        Self::scaled_with_offset(terms, 0)
+    }
+
+    /// [`scaled`](Self::scaled) with a signed constant offset.
+    pub fn scaled_with_offset(terms: &[(Axis, Scale)], offset: isize) -> Self {
         PhysicalAxisMap {
             terms: terms
                 .iter()
-                .map(|&(axis, scale)| AxisTerm {
-                    axis,
-                    scale: Scale::Static(scale),
-                })
+                .map(|&(axis, scale)| AxisTerm { axis, scale })
                 .collect(),
             offset,
         }
@@ -95,7 +109,20 @@ impl PhysicalAxisMap {
         self.offset
     }
 
-    /// `axis`'s coefficient, `0` when it does not address this physical axis.
+    /// How many of this axis's coefficients are [`Dynamic`](Scale::Dynamic).
+    pub fn dynamic_count(&self) -> usize {
+        self.terms.iter().filter(|t| t.scale.is_dynamic()).count()
+    }
+
+    /// Whether `axis` addresses this physical axis at all, whatever its coefficient is and whether
+    /// or not it is comptime. [`scale`](Self::scale)'s question minus the value.
+    pub fn addresses(&self, axis: Axis) -> bool {
+        self.terms.iter().any(|t| t.axis == axis)
+    }
+
+    /// `axis`'s coefficient, `0` when it does not address this physical axis. Panics when the
+    /// coefficient is [`Dynamic`](Scale::Dynamic); [`addresses`](Self::addresses) is the question
+    /// that survives one.
     pub fn scale(&self, axis: Axis) -> usize {
         self.terms
             .iter()

--- a/crates/cubek-tile/src/physical/projection/map.rs
+++ b/crates/cubek-tile/src/physical/projection/map.rs
@@ -37,6 +37,44 @@ impl Scale {
     }
 }
 
+/// The constant term of one physical axis's affine combination. Mirrors [`Scale`]: `Static` is a
+/// comptime constant so [`may_underflow`](crate::Projection::may_underflow) can track whether it
+/// is negative, `Dynamic` is a runtime padding or placement whose value rides the tile's signed
+/// offset carrier instead of the kernel.
+///
+/// Unlike [`Scale::Dynamic`], an `Offset::Dynamic` costs no comptime window geometry: `span` is
+/// offset-invariant, and [`Compaction`](crate::Compaction) drops the offset entirely, so an
+/// operand carrying one can still be staged. The only cost is that
+/// [`may_underflow`](crate::Projection::may_underflow) cannot prove non-negativity and
+/// conservatively arms the signed guard.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum Offset {
+    Static(isize),
+    Dynamic,
+}
+
+impl Offset {
+    /// The comptime offset; panics on `Dynamic`.
+    pub fn get(self) -> isize {
+        match self {
+            Offset::Static(n) => n,
+            Offset::Dynamic => {
+                panic!("Offset::get: this offset is Dynamic; its value is only known at runtime")
+            }
+        }
+    }
+
+    pub fn is_dynamic(self) -> bool {
+        matches!(self, Offset::Dynamic)
+    }
+}
+
+impl From<isize> for Offset {
+    fn from(n: isize) -> Self {
+        Offset::Static(n)
+    }
+}
+
 /// One logical axis's contribution to one physical axis: `digit * scale`, where the digit is the
 /// whole coordinate unless the axis is spread over several physical axes, which
 /// [`Projection::digit`](crate::Projection::digit) reads off the map's own shape rather than off a
@@ -52,7 +90,7 @@ pub struct AxisTerm {
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct PhysicalAxisMap {
     terms: SmallVec<[AxisTerm; MAX_AXES]>,
-    offset: isize,
+    offset: Offset,
 }
 
 impl PhysicalAxisMap {
@@ -64,7 +102,7 @@ impl PhysicalAxisMap {
                 axis,
                 scale: Scale::Static(1),
             }]),
-            offset: 0,
+            offset: Offset::Static(0),
         }
     }
 
@@ -73,9 +111,10 @@ impl PhysicalAxisMap {
         Self::affine_with_offset(terms, 0)
     }
 
-    /// An affine combination with a signed constant offset, e.g.
-    /// `affine_with_offset(&[(Oh, stride), (Rh, dilation)], -padding)`.
-    pub fn affine_with_offset(terms: &[(Axis, usize)], offset: isize) -> Self {
+    /// An affine combination with a signed constant or dynamic offset, e.g.
+    /// `affine_with_offset(&[(Oh, stride), (Rh, dilation)], -padding)` or
+    /// `affine_with_offset(&[(Oh, stride), (Rh, dilation)], Offset::Dynamic)`.
+    pub fn affine_with_offset(terms: &[(Axis, usize)], offset: impl Into<Offset>) -> Self {
         let terms: SmallVec<[(Axis, Scale); MAX_AXES]> = terms
             .iter()
             .map(|&(axis, scale)| (axis, Scale::Static(scale)))
@@ -89,14 +128,14 @@ impl PhysicalAxisMap {
         Self::scaled_with_offset(terms, 0)
     }
 
-    /// [`scaled`](Self::scaled) with a signed constant offset.
-    pub fn scaled_with_offset(terms: &[(Axis, Scale)], offset: isize) -> Self {
+    /// [`scaled`](Self::scaled) with a signed constant or dynamic offset.
+    pub fn scaled_with_offset(terms: &[(Axis, Scale)], offset: impl Into<Offset>) -> Self {
         PhysicalAxisMap {
             terms: terms
                 .iter()
                 .map(|&(axis, scale)| AxisTerm { axis, scale })
                 .collect(),
-            offset,
+            offset: offset.into(),
         }
     }
 
@@ -104,14 +143,19 @@ impl PhysicalAxisMap {
         &self.terms
     }
 
-    /// The signed constant offset of this physical axis.
-    pub fn offset(&self) -> isize {
+    /// The signed constant or dynamic offset of this physical axis.
+    pub fn offset(&self) -> Offset {
         self.offset
     }
 
     /// How many of this axis's coefficients are [`Dynamic`](Scale::Dynamic).
-    pub fn dynamic_count(&self) -> usize {
+    pub fn dynamic_scale_count(&self) -> usize {
         self.terms.iter().filter(|t| t.scale.is_dynamic()).count()
+    }
+
+    /// Whether any of this axis's coefficients are [`Dynamic`](Scale::Dynamic).
+    pub fn has_dynamic_scale(&self) -> bool {
+        self.terms.iter().any(|t| t.scale.is_dynamic())
     }
 
     /// Whether `axis` addresses this physical axis at all, whatever its coefficient is and whether
@@ -134,7 +178,7 @@ impl PhysicalAxisMap {
     /// Says nothing about digit extraction, which is a property of the whole
     /// [`Projection`](crate::Projection) (how many physical axes carry `axis`), not of one map.
     pub fn is_identity(&self, axis: Axis) -> bool {
-        self.offset == 0
+        self.offset == Offset::Static(0)
             && matches!(
                 self.terms.as_slice(),
                 [AxisTerm {
@@ -144,6 +188,7 @@ impl PhysicalAxisMap {
             )
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,13 +205,13 @@ mod tests {
         assert!(!id.is_identity(B));
         assert_eq!(id.scale(A), 1);
         assert_eq!(id.scale(B), 0);
-        assert_eq!(id.offset(), 0);
+        assert_eq!(id.offset(), Offset::Static(0));
 
         let affine = PhysicalAxisMap::affine(&[(A, 2), (B, 3)]);
         assert!(!affine.is_identity(A));
         assert_eq!(affine.scale(A), 2);
         assert_eq!(affine.scale(B), 3);
-        assert_eq!(affine.offset(), 0);
+        assert_eq!(affine.offset(), Offset::Static(0));
         // A single term is still not the identity unless its coefficient is 1 and offset is 0.
         assert!(!PhysicalAxisMap::affine(&[(A, 2)]).is_identity(A));
         assert!(PhysicalAxisMap::affine(&[(A, 1)]).is_identity(A));
@@ -174,6 +219,13 @@ mod tests {
         let with_offset = PhysicalAxisMap::affine_with_offset(&[(A, 1)], -2);
         assert!(!with_offset.is_identity(A));
         assert_eq!(with_offset.scale(A), 1);
-        assert_eq!(with_offset.offset(), -2);
+        assert_eq!(with_offset.offset(), Offset::Static(-2));
+
+        let with_dynamic_offset = PhysicalAxisMap::affine_with_offset(&[(A, 1)], Offset::Dynamic);
+        assert!(!with_dynamic_offset.is_identity(A));
+        assert_eq!(with_dynamic_offset.offset(), Offset::Dynamic);
+        assert!(with_dynamic_offset.offset().is_dynamic());
+        assert!(!with_dynamic_offset.has_dynamic_scale());
+        assert_eq!(with_dynamic_offset.dynamic_scale_count(), 0);
     }
 }

--- a/crates/cubek-tile/src/space/partition/partitioner.rs
+++ b/crates/cubek-tile/src/space/partition/partitioner.rs
@@ -107,6 +107,17 @@ impl Partitioner {
         self.level().schedule
     }
 
+    /// Whether any level from here down stages its operands into smem, so their window geometry
+    /// has to be comptime (an allocation size is).
+    pub fn stages(&self) -> bool {
+        match self {
+            Partitioner::Final => false,
+            Partitioner::Level(level) => {
+                !matches!(level.schedule, Schedule::Direct) || level.next.stages()
+            }
+        }
+    }
+
     /// Resolve every level's deferred [`PlaneLanes`](super::Coverage::PlaneLanes) count to
     /// `Instances(plane_size)`. The launch's single stamping pass, so geometry and the walk
     /// only ever see concrete instance counts.

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -33,10 +33,14 @@ pub struct MemData<T: Numeric> {
     #[cube(comptime)]
     pub(crate) projection: Projection,
     /// The runtime half of [`projection`](Self::projection): one value per
-    /// [`Scale::Dynamic`](crate::Scale) coefficient, in [`Projection::dynamic_index`] order. Empty
-    /// for every fully-`Static` mapping, which is every operand but a runtime-strided gather.
+    /// [`Scale::Dynamic`](crate::Scale) coefficient, in [`Projection::dynamic_scale_index`] order.
+    /// Empty for every fully-`Static` mapping, which is every operand but a runtime-strided gather.
     /// Named apart from the quantization scales in [`Store`], which are a different thing entirely.
     pub(crate) coefficients: Coords<u32>,
+    /// The runtime half of the projection's constant terms: one value per
+    /// [`Offset::Dynamic`](crate::Offset) axis, in [`Projection::dynamic_offset_index`] order.
+    /// Signed, since a padding places the window before the buffer's origin.
+    pub(crate) offsets: Coords<i32>,
     /// The window origin's offset through the layout, accumulated across [`at`](Tile::at)s rather
     /// than re-derived: each descent shifts by a *comptime* edge, so [`step_offset`] folds
     /// and this stays a multiply-add. Addressing it from the origin instead would decompose a
@@ -123,19 +127,22 @@ impl<T: Numeric> Tile<T> {
             spec,
             ComptimeOption::new_None(),
             Coords::<u32>::new(),
+            Coords::<i32>::new(),
         )
     }
 
-    /// [`of`](Tile::of) for a gather whose coefficients are not all comptime: `coefficients` holds
-    /// one value per [`Scale::Dynamic`](crate::Scale) term of the spec's projection, in
-    /// [`Projection::dynamic_index`] order (physical axis major, term order within). A runtime
-    /// stride or dilation is exactly this, and the kernel builds the carrier from its own scalar
-    /// arguments, so nothing about it reaches the launch.
+    /// [`of`](Tile::of) for a gather whose affine map is not all comptime: `coefficients` holds one
+    /// value per [`Scale::Dynamic`](crate::Scale) term in [`Projection::dynamic_scale_index`] order,
+    /// `offsets` one signed value per [`Offset::Dynamic`](crate::Offset) axis in
+    /// [`Projection::dynamic_offset_index`] order. A runtime stride, dilation or padding is exactly
+    /// this, and the kernel builds the carriers from its own scalar arguments, so nothing about
+    /// them reaches the launch.
     pub fn of_gathered<E: CubePrimitive<Scalar = T>>(
         tensor: &Tensor<E>,
         #[comptime] space: Space,
         #[comptime] spec: TileSpec,
         coefficients: Coords<u32>,
+        offsets: Coords<i32>,
     ) -> Tile<T> {
         Tile::<T>::of_impl::<E>(
             tensor,
@@ -143,6 +150,7 @@ impl<T: Numeric> Tile<T> {
             spec,
             ComptimeOption::new_None(),
             coefficients,
+            offsets,
         )
     }
 
@@ -188,6 +196,7 @@ impl<T: Numeric> Tile<T> {
             spec,
             ComptimeOption::new_Some(info),
             Coords::<u32>::new(),
+            Coords::<i32>::new(),
         )
     }
 
@@ -200,6 +209,7 @@ impl<T: Numeric> Tile<T> {
         #[comptime] spec: TileSpec,
         quant: ComptimeOption<QuantInfo>,
         coefficients: Coords<u32>,
+        offsets: Coords<i32>,
     ) -> Tile<T> {
         // The one projection: the kernel's space narrowed to this operand's axes.
         let space = comptime!(space.project(spec.axes()));
@@ -216,17 +226,23 @@ impl<T: Numeric> Tile<T> {
             "Tile::of: a gathered operand cannot be quantized; its scale grid is shaped over its \
              logical axes, which its buffer's physical axes no longer match"
         ));
-        let given = coefficients.len();
+        let scales_given = coefficients.len();
         comptime!(assert!(
-            given == coords.dynamic_count(),
-            "Tile::of: the projection has {} Dynamic coefficients but {given} were given",
-            coords.dynamic_count()
+            scales_given == coords.dynamic_scale_count(),
+            "Tile::of: the projection has {} Dynamic coefficients but {scales_given} were given",
+            coords.dynamic_scale_count()
+        ));
+        let offsets_given = offsets.len();
+        comptime!(assert!(
+            offsets_given == coords.dynamic_offset_count(),
+            "Tile::of: the projection has {} Dynamic offsets but {offsets_given} were given",
+            coords.dynamic_offset_count()
         ));
         // A staged operand's smem is allocated from its compacted window, whose extent a runtime
         // coefficient makes runtime. `Compaction::of` refuses it too; this is the earlier, clearer
         // report, at the operand rather than at the stage.
         comptime!(assert!(
-            !coords.has_dynamic() || !space.partitioner().stages(),
+            !coords.has_dynamic_scales() || !space.partitioner().stages(),
             "Tile::of: a Dynamic coefficient cannot be staged, its window has no comptime extent; \
              the schedule must be Direct"
         ));
@@ -288,6 +304,7 @@ impl<T: Numeric> Tile<T> {
         let (origin, extent) = top_window(
             comptime!(space.clone()),
             &bound,
+            &offsets,
             vector_size,
             comptime!(coords.clone()),
         );
@@ -306,6 +323,7 @@ impl<T: Numeric> Tile<T> {
                 window: Window::new(origin, extent, bound, comptime!(coords.may_underflow())),
                 projection: comptime!(coords),
                 coefficients,
+                offsets,
                 window_start: 0u32,
                 access: comptime!(Access {
                     whole: true,
@@ -528,8 +546,10 @@ impl<T: Numeric> MemData<T> {
                 window: Window::new(origin, extent, bound, false),
                 projection: comptime!(form.projection),
                 // A stage's own mapping is the compacted one, which is fully `Static`: a Dynamic
-                // coefficient never reaches a stage ([`Compaction::of`] refuses it).
+                // coefficient never reaches a stage ([`Compaction::of`] refuses it), and the
+                // compaction drops the offset, the gmem window having already been placed.
                 coefficients: Coords::<u32>::new(),
+                offsets: Coords::<i32>::new(),
                 window_start: 0u32,
                 access: comptime!(Access {
                     whole: true,
@@ -1347,7 +1367,7 @@ impl<T: Numeric> MemData<T> {
                         Scale::Dynamic => {
                             let coefficient = self
                                 .coefficients
-                                .at(comptime!(proj.dynamic_index(pa, t).unwrap()));
+                                .at(comptime!(proj.dynamic_scale_index(pa, t).unwrap()));
                             terms.push(
                                 region
                                     .coord(term.axis)
@@ -1363,7 +1383,7 @@ impl<T: Numeric> MemData<T> {
 
                 // The receptive field of the child edges: `1 + Σ (edge - 1) * scale`, which stays
                 // comptime for the mapping that is.
-                let span = if comptime!(proj.physical_axis(pa).dynamic_count() == 0) {
+                let span = if comptime!(proj.physical_axis(pa).dynamic_scale_count() == 0) {
                     comptime!({
                         let s = proj.span(pa, |a| space.partitioner().edge(a));
                         (if pa == last { s / w } else { s }) as u32
@@ -1424,9 +1444,11 @@ impl<T: Numeric> MemData<T> {
                 comptime!(self.window.signed),
             ),
             // How the logical axes address the physical ones is a fact about the buffer, invariant
-            // down the descent, and so are its runtime coefficients.
+            // down the descent, and so are its runtime coefficients. The offsets only placed the
+            // top window, which `origin` above already carries.
             projection: comptime!(proj),
             coefficients: self.coefficients.clone(),
+            offsets: self.offsets.clone(),
             window_start: start,
             // The window no longer covers the buffer, so the straight-through fill is off.
             access: comptime!(Access {
@@ -1463,6 +1485,7 @@ fn full_window(#[comptime] form: StageForm) -> (Coords<i32>, Coords<u32>) {
 fn top_window(
     #[comptime] space: Space,
     bound: &Coords<u32>,
+    offsets: &Coords<i32>,
     #[comptime] vector_size: usize,
     #[comptime] projection: Projection,
 ) -> (Coords<i32>, Coords<u32>) {
@@ -1486,7 +1509,12 @@ fn top_window(
             }
         } else {
             // Gathered axes start at their initial signed offset (e.g. negative padding).
-            origin.push((comptime!(projection.offset(pa) as i32)).runtime());
+            match comptime!(projection.offset(pa)) {
+                Offset::Static(o) => origin.push((comptime!(o as i32)).runtime()),
+                Offset::Dynamic => {
+                    origin.push(offsets.at(comptime!(projection.dynamic_offset_index(pa).unwrap())))
+                }
+            }
             bound.at(pa)
         };
         extent.push(size);

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -32,6 +32,11 @@ pub struct MemData<T: Numeric> {
     /// like the layout: `at` moves the window, never the mapping.
     #[cube(comptime)]
     pub(crate) projection: Projection,
+    /// The runtime half of [`projection`](Self::projection): one value per
+    /// [`Scale::Dynamic`](crate::Scale) coefficient, in [`Projection::dynamic_index`] order. Empty
+    /// for every fully-`Static` mapping, which is every operand but a runtime-strided gather.
+    /// Named apart from the quantization scales in [`Store`], which are a different thing entirely.
+    pub(crate) coefficients: Coords<u32>,
     /// The window origin's offset through the layout, accumulated across [`at`](Tile::at)s rather
     /// than re-derived: each descent shifts by a *comptime* edge, so [`step_offset`] folds
     /// and this stays a multiply-add. Addressing it from the origin instead would decompose a
@@ -112,7 +117,33 @@ impl<T: Numeric> Tile<T> {
         #[comptime] space: Space,
         #[comptime] spec: TileSpec,
     ) -> Tile<T> {
-        Tile::<T>::of_impl::<E>(tensor, space, spec, ComptimeOption::new_None())
+        Tile::<T>::of_impl::<E>(
+            tensor,
+            space,
+            spec,
+            ComptimeOption::new_None(),
+            Coords::<u32>::new(),
+        )
+    }
+
+    /// [`of`](Tile::of) for a gather whose coefficients are not all comptime: `coefficients` holds
+    /// one value per [`Scale::Dynamic`](crate::Scale) term of the spec's projection, in
+    /// [`Projection::dynamic_index`] order (physical axis major, term order within). A runtime
+    /// stride or dilation is exactly this, and the kernel builds the carrier from its own scalar
+    /// arguments, so nothing about it reaches the launch.
+    pub fn of_gathered<E: CubePrimitive<Scalar = T>>(
+        tensor: &Tensor<E>,
+        #[comptime] space: Space,
+        #[comptime] spec: TileSpec,
+        coefficients: Coords<u32>,
+    ) -> Tile<T> {
+        Tile::<T>::of_impl::<E>(
+            tensor,
+            space,
+            spec,
+            ComptimeOption::new_None(),
+            coefficients,
+        )
     }
 
     /// [`of`](Tile::of) from a quantized operand: the values tensor is storage-typed (its
@@ -151,7 +182,13 @@ impl<T: Numeric> Tile<T> {
             scale_shape: comptime!(Vec::new()),
             scheme: comptime!(scheme),
         };
-        Tile::<T>::of_impl::<E>(values, space, spec, ComptimeOption::new_Some(info))
+        Tile::<T>::of_impl::<E>(
+            values,
+            space,
+            spec,
+            ComptimeOption::new_Some(info),
+            Coords::<u32>::new(),
+        )
     }
 
     /// Shared body of [`of`](Tile::of)/[`of_dequant`](Tile::of_dequant): `E` is the *binding*
@@ -162,6 +199,7 @@ impl<T: Numeric> Tile<T> {
         #[comptime] space: Space,
         #[comptime] spec: TileSpec,
         quant: ComptimeOption<QuantInfo>,
+        coefficients: Coords<u32>,
     ) -> Tile<T> {
         // The one projection: the kernel's space narrowed to this operand's axes.
         let space = comptime!(space.project(spec.axes()));
@@ -177,6 +215,20 @@ impl<T: Numeric> Tile<T> {
             quant.is_none() || coords.is_direct(),
             "Tile::of: a gathered operand cannot be quantized; its scale grid is shaped over its \
              logical axes, which its buffer's physical axes no longer match"
+        ));
+        let given = coefficients.len();
+        comptime!(assert!(
+            given == coords.dynamic_count(),
+            "Tile::of: the projection has {} Dynamic coefficients but {given} were given",
+            coords.dynamic_count()
+        ));
+        // A staged operand's smem is allocated from its compacted window, whose extent a runtime
+        // coefficient makes runtime. `Compaction::of` refuses it too; this is the earlier, clearer
+        // report, at the operand rather than at the stage.
+        comptime!(assert!(
+            !coords.has_dynamic() || !space.partitioner().stages(),
+            "Tile::of: a Dynamic coefficient cannot be staged, its window has no comptime extent; \
+             the schedule must be Direct"
         ));
         // Stage layout: the explicit override, else derived from the operand's leaf.
         let stage = comptime!(StagePlan {
@@ -253,6 +305,7 @@ impl<T: Numeric> Tile<T> {
                 },
                 window: Window::new(origin, extent, bound, comptime!(coords.may_underflow())),
                 projection: comptime!(coords),
+                coefficients,
                 window_start: 0u32,
                 access: comptime!(Access {
                     whole: true,
@@ -474,6 +527,9 @@ impl<T: Numeric> MemData<T> {
                 // Stage origins are never negative.
                 window: Window::new(origin, extent, bound, false),
                 projection: comptime!(form.projection),
+                // A stage's own mapping is the compacted one, which is fully `Static`: a Dynamic
+                // coefficient never reaches a stage ([`Compaction::of`] refuses it).
+                coefficients: Coords::<u32>::new(),
                 window_start: 0u32,
                 access: comptime!(Access {
                     whole: true,
@@ -1272,26 +1328,54 @@ impl<T: Numeric> MemData<T> {
                 let picks =
                     comptime!((0..proj.physical_axis(pa).terms().len()).collect::<Vec<_>>());
                 let mut terms = Coords::<u32>::new();
+                // The receptive field's leading `1`, so the sum below needs no seed.
+                let mut spans = Coords::<u32>::new();
+                spans.push(comptime!(1u32).runtime());
                 #[unroll]
                 for t in 0..comptime!(proj.physical_axis(pa).terms().len()) {
                     let term = comptime!(proj.physical_axis(pa).terms()[t]);
-                    let step = comptime!({
-                        let s = space.partitioner().edge(term.axis) * term.scale.get();
-                        if pa == last { s / w } else { s }
-                    });
-                    terms.push(region.coord(term.axis).fmul(step).fcast::<u32>());
+                    let edge = comptime!(space.partitioner().edge(term.axis));
+                    match comptime!(term.scale) {
+                        Scale::Static(s) => {
+                            let step = comptime!(if pa == last { edge * s / w } else { edge * s });
+                            terms.push(region.coord(term.axis).fmul(step).fcast::<u32>());
+                            spans.push(comptime!(((edge - 1) * s) as u32).runtime());
+                        }
+                        // The line division above never meets a runtime coefficient: the innermost
+                        // physical axis is a single identity term, which `Projection::validate`
+                        // requires and `Static` is the only spelling of.
+                        Scale::Dynamic => {
+                            let coefficient = self
+                                .coefficients
+                                .at(comptime!(proj.dynamic_index(pa, t).unwrap()));
+                            terms.push(
+                                region
+                                    .coord(term.axis)
+                                    .fcast::<u32>()
+                                    .fmul(comptime!(edge as u32).runtime())
+                                    .fmul(coefficient),
+                            );
+                            spans.push(comptime!((edge - 1) as u32).runtime().fmul(coefficient));
+                        }
+                    }
                 }
-                let advance = terms.fsum(picks);
+                let advance = terms.fsum(comptime!(picks.clone()));
 
-                // The receptive field of the child edges: `1 + Σ (edge - 1) * scale`.
-                let span = comptime!({
-                    let s = proj.span(pa, |a| space.partitioner().edge(a));
-                    if pa == last { s / w } else { s }
-                });
+                // The receptive field of the child edges: `1 + Σ (edge - 1) * scale`, which stays
+                // comptime for the mapping that is.
+                let span = if comptime!(proj.physical_axis(pa).dynamic_count() == 0) {
+                    comptime!({
+                        let s = proj.span(pa, |a| space.partitioner().edge(a));
+                        (if pa == last { s / w } else { s }) as u32
+                    })
+                    .runtime()
+                } else {
+                    spans.fsum(comptime!((0..picks.len() + 1).collect::<Vec<_>>()))
+                };
 
                 // `advance` only moves forward, so add directly to the signed origin.
                 origin.push(self.window.origin.at(pa).fadd(advance.fcast::<i32>()));
-                extent.push(comptime!(span as u32).runtime());
+                extent.push(span);
                 // `Projection::validate` pins a gathered operand to untiled storage (bare gmem, or
                 // the row-major compacted stage of one), so one physical axis step is one stride
                 // and the advance passes straight through.
@@ -1340,8 +1424,9 @@ impl<T: Numeric> MemData<T> {
                 comptime!(self.window.signed),
             ),
             // How the logical axes address the physical ones is a fact about the buffer, invariant
-            // down the descent.
+            // down the descent, and so are its runtime coefficients.
             projection: comptime!(proj),
+            coefficients: self.coefficients.clone(),
             window_start: start,
             // The window no longer covers the buffer, so the straight-through fill is off.
             access: comptime!(Access {

--- a/crates/cubek-tile/src/tile/view/matrix.rs
+++ b/crates/cubek-tile/src/tile/view/matrix.rs
@@ -240,13 +240,19 @@ pub(crate) fn projected_batch_matrix(
     bound: &Coords<u32>,
     #[comptime] space: Space,
     #[comptime] projection: Projection,
+    coefficients: Coords<u32>,
     #[comptime] vector_size: usize,
     i: usize,
 ) -> ProjectedBatchMatrix {
     let gathered = comptime!(!projection.is_direct());
     ProjectedBatchMatrix::new(
         batch_matrix(bound, comptime!(&space), gathered, vector_size, i),
-        axis_projection(comptime!(space), comptime!(projection), vector_size),
+        axis_projection(
+            comptime!(space),
+            comptime!(projection),
+            coefficients,
+            vector_size,
+        ),
     )
 }
 
@@ -256,13 +262,19 @@ pub(crate) fn projected_batch_matrix(
 pub(crate) fn projected_grouped_matrix(
     #[comptime] space: Space,
     #[comptime] projection: Projection,
+    coefficients: Coords<u32>,
     #[comptime] vector_size: usize,
     #[comptime] rows: usize,
     #[comptime] cols: usize,
 ) -> ProjectedGroupedMatrix {
     ProjectedGroupedMatrix::new(
         grouped_matrix(comptime!(&space), vector_size, rows, cols),
-        axis_projection(comptime!(space), comptime!(projection), vector_size),
+        axis_projection(
+            comptime!(space),
+            comptime!(projection),
+            coefficients,
+            vector_size,
+        ),
     )
 }
 
@@ -278,6 +290,7 @@ impl<T: Numeric> Tile<T> {
                     &bound,
                     comptime!(self.space.clone()),
                     comptime!(g.projection.clone()),
+                    g.coefficients.clone(),
                     vector_size,
                     i,
                 );
@@ -304,6 +317,7 @@ impl<T: Numeric> Tile<T> {
                     &bound,
                     comptime!(self.space.clone()),
                     comptime!(g.projection.clone()),
+                    g.coefficients.clone(),
                     vector_size,
                     i,
                 );
@@ -333,6 +347,7 @@ impl<T: Numeric> Tile<T> {
                     &bound,
                     comptime!(self.space.clone()),
                     comptime!(g.projection.clone()),
+                    g.coefficients.clone(),
                     vector_size,
                     i,
                 );
@@ -365,6 +380,7 @@ impl<T: Numeric> Tile<T> {
                 let layout = projected_grouped_matrix(
                     comptime!(self.space.clone()),
                     comptime!(g.projection.clone()),
+                    g.coefficients.clone(),
                     vector_size,
                     rows,
                     cols,

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -92,6 +92,9 @@ pub struct AxisProjection {
     /// The tile's per-logical-axis extents, in the space's axis order. The innermost is a
     /// line count, matching the window's innermost physical axis.
     shape: Coords<u32>,
+    /// The projection's runtime coefficients, in [`Projection::dynamic_index`] order; empty for a
+    /// fully-`Static` mapping.
+    coefficients: Coords<u32>,
     #[cube(comptime)]
     space: Space,
     #[cube(comptime)]
@@ -102,6 +105,7 @@ pub struct AxisProjection {
 impl AxisProjection {
     pub fn new(
         shape: Coords<u32>,
+        coefficients: Coords<u32>,
         #[comptime] space: Space,
         #[comptime] projection: Projection,
     ) -> Self {
@@ -111,8 +115,15 @@ impl AxisProjection {
             "AxisProjection: shape has {rank} entries but the space spans {} logical axes",
             space.rank()
         ));
+        let given = coefficients.len();
+        comptime!(assert!(
+            given == projection.dynamic_count(),
+            "AxisProjection: the projection has {} Dynamic coefficients but {given} were given",
+            projection.dynamic_count()
+        ));
         AxisProjection {
             shape,
+            coefficients,
             space,
             projection,
         }
@@ -139,7 +150,15 @@ impl Layout for AxisProjection {
             for t in 0..n {
                 let term = comptime!(map.terms()[t]);
                 let p = comptime!(self.space.position(term.axis));
-                terms.push(pos[p].fmul(comptime!(term.scale.get() as u32)));
+                match comptime!(term.scale) {
+                    Scale::Static(s) => terms.push(pos[p].fmul(comptime!(s as u32))),
+                    Scale::Dynamic => terms.push(
+                        pos[p].fmul(
+                            self.coefficients
+                                .at(comptime!(self.projection.dynamic_index(pa, t).unwrap())),
+                        ),
+                    ),
+                }
             }
             out.push(terms.fsum(comptime!((0..n).collect::<Vec<_>>())));
         }
@@ -235,6 +254,7 @@ impl<T: Numeric> Tile<T> {
                 let layout = axis_projection(
                     comptime!(self.space.clone()),
                     comptime!(g.projection.clone()),
+                    g.coefficients.clone(),
                     self.vector_size(),
                 );
                 g.nd_transparent::<I, WP, W>(layout)
@@ -253,12 +273,13 @@ impl<T: Numeric> Tile<T> {
 pub(crate) fn axis_projection(
     #[comptime] space: Space,
     #[comptime] projection: Projection,
+    coefficients: Coords<u32>,
     #[comptime] vector_size: usize,
 ) -> AxisProjection {
     let rank = comptime!(space.rank());
     let shape = const_coords(comptime!(line_extents(&space, vector_size, 0, rank)));
 
-    AxisProjection::new(shape, space, projection)
+    AxisProjection::new(shape, coefficients, space, projection)
 }
 
 /// Returns the extents of `space` in the range `from..to`, with the innermost axis

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -92,8 +92,9 @@ pub struct AxisProjection {
     /// The tile's per-logical-axis extents, in the space's axis order. The innermost is a
     /// line count, matching the window's innermost physical axis.
     shape: Coords<u32>,
-    /// The projection's runtime coefficients, in [`Projection::dynamic_index`] order; empty for a
-    /// fully-`Static` mapping.
+    /// The projection's runtime coefficients, in [`Projection::dynamic_scale_index`] order; empty
+    /// for a fully-`Static` mapping. The constant offsets are not among them: a tap is relative to
+    /// the window, which they placed.
     coefficients: Coords<u32>,
     #[cube(comptime)]
     space: Space,
@@ -117,9 +118,9 @@ impl AxisProjection {
         ));
         let given = coefficients.len();
         comptime!(assert!(
-            given == projection.dynamic_count(),
+            given == projection.dynamic_scale_count(),
             "AxisProjection: the projection has {} Dynamic coefficients but {given} were given",
-            projection.dynamic_count()
+            projection.dynamic_scale_count()
         ));
         AxisProjection {
             shape,
@@ -152,12 +153,9 @@ impl Layout for AxisProjection {
                 let p = comptime!(self.space.position(term.axis));
                 match comptime!(term.scale) {
                     Scale::Static(s) => terms.push(pos[p].fmul(comptime!(s as u32))),
-                    Scale::Dynamic => terms.push(
-                        pos[p].fmul(
-                            self.coefficients
-                                .at(comptime!(self.projection.dynamic_index(pa, t).unwrap())),
-                        ),
-                    ),
+                    Scale::Dynamic => terms.push(pos[p].fmul(self.coefficients.at(comptime!(
+                        self.projection.dynamic_scale_index(pa, t).unwrap()
+                    )))),
                 }
             }
             out.push(terms.fsum(comptime!((0..n).collect::<Vec<_>>())));

--- a/crates/cubek-tile/tests/tile/conv.rs
+++ b/crates/cubek-tile/tests/tile/conv.rs
@@ -537,6 +537,142 @@ fn conv1d_masked_overhang_strided() {
     .check_at(2, 4, 1, true, Schedule::Direct);
 }
 
+// ---- runtime coefficients --------------------------------------------------
+
+/// [`conv_kernel`] with the input's stride and dilation arriving as runtime scalars rather than
+/// baked into its projection: the two `Scale::Dynamic` coefficients ride the tile.
+#[cube(launch)]
+fn conv_kernel_dynamic<E: Numeric>(
+    input: &TileArg<'_, E, Const<1>>,
+    weight: &TileArg<'_, E, Const<1>>,
+    out: &TileArg<'_, E, Const<1>>,
+    stride: u32,
+    dilation: u32,
+    #[comptime] space: Space,
+    #[define(E)] _dtype: StorageType,
+) {
+    // In `Projection::dynamic_index` order: physical axis 0's terms, `OH` then `RH`.
+    let mut coefficients = Coords::<u32>::new();
+    coefficients.push(stride);
+    coefficients.push(dilation);
+
+    let input = input.tile_gathered(comptime!(space.clone()), coefficients);
+    let weight = weight.tile(comptime!(space.clone()));
+    let mut out = out.tile(space);
+    out.zero();
+    out.mma(&input, &weight);
+}
+
+impl Conv1d {
+    /// [`check`](Conv1d::check) with both coefficients `Dynamic`, so the same convolution runs off
+    /// a kernel that was compiled without knowing either.
+    /// Only `Schedule::Direct`: staging a runtime coefficient is refused at expansion, since the
+    /// smem it would allocate has no comptime extent.
+    fn check_dynamic(&self, tile_oh: usize, tile_co: usize) {
+        let client = <TestRuntime as Runtime>::client(&Default::default());
+        let f32_ty = f32::as_type_native_unchecked().storage_type();
+
+        let space = Tiling::new()
+            .extents(&[(OH, self.oh), (CO, self.co), (RH, self.rh), (CI, self.ci)])
+            .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+                l.axis(OH, Cut::sequential(tile_oh))
+                    .axis(CO, Cut::sequential(tile_co))
+                    .axis(RH, Cut::sequential(self.rh))
+                    .axis(CI, Cut::sequential(self.ci))
+            })
+            .build();
+
+        let in_spec = TileSpec::new(Projection::new(
+            &[OH, RH, CI],
+            &[
+                PhysicalAxisMap::scaled(&[(OH, Scale::Dynamic), (RH, Scale::Dynamic)]),
+                PhysicalAxisMap::of(CI),
+            ],
+        ));
+
+        let in_shape = shape![self.in_len(), self.ci];
+        let w_shape = shape![self.rh, self.ci, self.co];
+        let input = ramp(in_shape.num_elements(), 7);
+        let weight = ramp(w_shape.num_elements(), 5);
+
+        let (in_handle, _) = TestInput::builder(client.clone(), in_shape)
+            .dtype(f32_ty)
+            .custom(input.clone())
+            .generate_with_f32_host_data();
+        let (w_handle, _) = TestInput::builder(client.clone(), w_shape)
+            .dtype(f32_ty)
+            .custom(weight.clone())
+            .generate_with_f32_host_data();
+        let out_handle = TestInput::builder(client.clone(), shape![self.oh, self.co])
+            .dtype(f32_ty)
+            .zeros()
+            .generate_without_host_data();
+
+        conv_kernel_dynamic::launch::<TestRuntime>(
+            &client,
+            space.cube_count(),
+            space.cube_dim(&client),
+            TileArgLaunch::new(in_handle.binding().into_tensor_arg(), in_spec),
+            TileArgLaunch::new(
+                w_handle.binding().into_tensor_arg(),
+                TileSpec::direct(&[RH, CI, CO]),
+            ),
+            TileArgLaunch::new(
+                out_handle.clone().binding().into_tensor_arg(),
+                TileSpec::direct(&[OH, CO]),
+            ),
+            self.stride as u32,
+            self.dilation as u32,
+            space,
+            f32_ty,
+        );
+
+        let got = HostData::from_tensor_handle(&client, out_handle, HostDataType::F32);
+        let want = self.reference(&input, &weight);
+        for o in 0..self.oh {
+            for c in 0..self.co {
+                assert_eq!(
+                    got.get_f32(&[o, c]),
+                    want[o * self.co + c],
+                    "dynamic conv1d stride {} dilation {}: wrong at ({o}, {c})",
+                    self.stride,
+                    self.dilation
+                );
+            }
+        }
+    }
+}
+
+/// The degenerate coefficients, which a `Static` projection folds away entirely: the runtime path
+/// has to produce the same answer without that folding.
+#[test]
+fn conv1d_dynamic_unit_coefficients() {
+    Conv1d {
+        oh: 8,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 1,
+        dilation: 1,
+    }
+    .check_dynamic(4, 4);
+}
+
+/// A stride and a dilation that both exceed one, over several tiles: the window advance and the
+/// receptive field are then runtime values, which is what the descent has to size its window from.
+#[test]
+fn conv1d_dynamic_strided_and_dilated() {
+    Conv1d {
+        oh: 6,
+        co: 4,
+        rh: 4,
+        ci: 3,
+        stride: 3,
+        dilation: 2,
+    }
+    .check_dynamic(2, 2);
+}
+
 // ---- 2-D -------------------------------------------------------------------
 
 /// `out[oh, ow, co] = Σ_{rh, rw, ci} w[rh, rw, ci, co] · in[oh·sh + rh·dh, ow·sw + rw·dw, ci]`.

--- a/crates/cubek-tile/tests/tile/conv.rs
+++ b/crates/cubek-tile/tests/tile/conv.rs
@@ -551,12 +551,12 @@ fn conv_kernel_dynamic<E: Numeric>(
     #[comptime] space: Space,
     #[define(E)] _dtype: StorageType,
 ) {
-    // In `Projection::dynamic_index` order: physical axis 0's terms, `OH` then `RH`.
+    // In `Projection::dynamic_scale_index` order: physical axis 0's terms, `OH` then `RH`.
     let mut coefficients = Coords::<u32>::new();
     coefficients.push(stride);
     coefficients.push(dilation);
 
-    let input = input.tile_gathered(comptime!(space.clone()), coefficients);
+    let input = input.tile_gathered(comptime!(space.clone()), coefficients, Coords::new());
     let weight = weight.tile(comptime!(space.clone()));
     let mut out = out.tile(space);
     out.zero();
@@ -671,6 +671,241 @@ fn conv1d_dynamic_strided_and_dilated() {
         dilation: 2,
     }
     .check_dynamic(2, 2);
+}
+
+/// [`conv_kernel`] with the input's padding arriving as a runtime scalar: the `Offset::Dynamic`
+/// rides the tile as a signed value, while the stride and the dilation stay comptime.
+#[cube(launch)]
+fn conv_kernel_dynamic_padding<E: Numeric>(
+    input: &TileArg<'_, E, Const<1>>,
+    weight: &TileArg<'_, E, Const<1>>,
+    out: &TileArg<'_, E, Const<1>>,
+    offset: i32,
+    #[comptime] space: Space,
+    #[define(E)] _dtype: StorageType,
+) {
+    let mut offsets = Coords::<i32>::new();
+    offsets.push(offset);
+
+    let input = input.tile_gathered(comptime!(space.clone()), Coords::new(), offsets);
+    let weight = weight.tile(comptime!(space.clone()));
+    let mut out = out.tile(space);
+    out.zero();
+    out.mma(&input, &weight);
+}
+
+/// [`conv_kernel_dynamic`] with the padding runtime too: nothing of the input's affine map is
+/// known when the kernel is compiled.
+#[cube(launch)]
+fn conv_kernel_all_dynamic<E: Numeric>(
+    input: &TileArg<'_, E, Const<1>>,
+    weight: &TileArg<'_, E, Const<1>>,
+    out: &TileArg<'_, E, Const<1>>,
+    stride: u32,
+    dilation: u32,
+    offset: i32,
+    #[comptime] space: Space,
+    #[define(E)] _dtype: StorageType,
+) {
+    let mut coefficients = Coords::<u32>::new();
+    coefficients.push(stride);
+    coefficients.push(dilation);
+    let mut offsets = Coords::<i32>::new();
+    offsets.push(offset);
+
+    let input = input.tile_gathered(comptime!(space.clone()), coefficients, offsets);
+    let weight = weight.tile(comptime!(space.clone()));
+    let mut out = out.tile(space);
+    out.zero();
+    out.mma(&input, &weight);
+}
+
+impl Conv1d {
+    /// The padded reference: a tap outside `[0, in_len)` reads zero.
+    fn reference_padded(
+        &self,
+        input: &[f32],
+        weight: &[f32],
+        in_len: usize,
+        padding: usize,
+    ) -> Vec<f32> {
+        let mut out = vec![0.0f32; self.oh * self.co];
+        for o in 0..self.oh {
+            for c in 0..self.co {
+                let mut acc = 0.0f32;
+                for r in 0..self.rh {
+                    for i in 0..self.ci {
+                        let h = (o * self.stride + r * self.dilation) as isize - padding as isize;
+                        let x = if h >= 0 && (h as usize) < in_len {
+                            input[(h as usize) * self.ci + i]
+                        } else {
+                            0.0
+                        };
+                        acc += x * weight[(r * self.ci + i) * self.co + c];
+                    }
+                }
+                out[o * self.co + c] = acc;
+            }
+        }
+        out
+    }
+
+    /// A padded convolution whose padding is an `Offset::Dynamic`, so the window origin is placed
+    /// at runtime and the underflow guard is armed without knowing the sign. `dynamic_scales` also
+    /// hands the stride and the dilation over at runtime, which forces `Schedule::Direct`; a
+    /// dynamic offset alone stages, since the compaction drops it.
+    #[allow(clippy::too_many_arguments)]
+    fn check_dynamic_padded(
+        &self,
+        tile_oh: usize,
+        tile_co: usize,
+        padding: usize,
+        in_len: usize,
+        schedule: Schedule,
+        dynamic_scales: bool,
+    ) {
+        let client = <TestRuntime as Runtime>::client(&Default::default());
+        let f32_ty = f32::as_type_native_unchecked().storage_type();
+
+        let space = Tiling::new()
+            .extents(&[(OH, self.oh), (CO, self.co), (RH, self.rh), (CI, self.ci)])
+            .level(WalkOrder::RowMajor, schedule, |l| {
+                l.axis(OH, Cut::sequential(tile_oh))
+                    .axis(CO, Cut::sequential(tile_co))
+                    .axis(RH, Cut::sequential(self.rh))
+                    .axis(CI, Cut::sequential(self.ci))
+            })
+            .build();
+
+        let gathered = if dynamic_scales {
+            PhysicalAxisMap::scaled_with_offset(
+                &[(OH, Scale::Dynamic), (RH, Scale::Dynamic)],
+                Offset::Dynamic,
+            )
+        } else {
+            PhysicalAxisMap::affine_with_offset(
+                &[(OH, self.stride), (RH, self.dilation)],
+                Offset::Dynamic,
+            )
+        };
+        let in_spec = TileSpec::new(Projection::new(
+            &[OH, RH, CI],
+            &[gathered, PhysicalAxisMap::of(CI)],
+        ))
+        .checked(true);
+
+        let in_shape = shape![in_len, self.ci];
+        let w_shape = shape![self.rh, self.ci, self.co];
+        let input = ramp(in_shape.num_elements(), 7);
+        let weight = ramp(w_shape.num_elements(), 5);
+
+        let (in_handle, _) = TestInput::builder(client.clone(), in_shape)
+            .dtype(f32_ty)
+            .custom(input.clone())
+            .generate_with_f32_host_data();
+        let (w_handle, _) = TestInput::builder(client.clone(), w_shape)
+            .dtype(f32_ty)
+            .custom(weight.clone())
+            .generate_with_f32_host_data();
+        let out_handle = TestInput::builder(client.clone(), shape![self.oh, self.co])
+            .dtype(f32_ty)
+            .zeros()
+            .generate_without_host_data();
+
+        let in_binding = in_handle.binding();
+        let w_binding = w_handle.binding();
+        let out_binding = out_handle.clone().binding();
+        let offset = -(padding as i32);
+        if dynamic_scales {
+            conv_kernel_all_dynamic::launch::<TestRuntime>(
+                &client,
+                space.cube_count(),
+                space.cube_dim(&client),
+                TileArgLaunch::new(in_binding.into_tensor_arg(), in_spec),
+                TileArgLaunch::new(w_binding.into_tensor_arg(), TileSpec::direct(&[RH, CI, CO])),
+                TileArgLaunch::new(
+                    out_binding.into_tensor_arg(),
+                    TileSpec::direct(&[OH, CO]).checked(true),
+                ),
+                self.stride as u32,
+                self.dilation as u32,
+                offset,
+                space,
+                f32_ty,
+            );
+        } else {
+            conv_kernel_dynamic_padding::launch::<TestRuntime>(
+                &client,
+                space.cube_count(),
+                space.cube_dim(&client),
+                TileArgLaunch::new(in_binding.into_tensor_arg(), in_spec),
+                TileArgLaunch::new(w_binding.into_tensor_arg(), TileSpec::direct(&[RH, CI, CO])),
+                TileArgLaunch::new(
+                    out_binding.into_tensor_arg(),
+                    TileSpec::direct(&[OH, CO]).checked(true),
+                ),
+                offset,
+                space,
+                f32_ty,
+            );
+        }
+
+        let got = HostData::from_tensor_handle(&client, out_handle, HostDataType::F32);
+        let want = self.reference_padded(&input, &weight, in_len, padding);
+        for o in 0..self.oh {
+            for c in 0..self.co {
+                assert_eq!(
+                    got.get_f32(&[o, c]),
+                    want[o * self.co + c],
+                    "dynamic padded conv1d {schedule:?} padding {padding}: wrong at ({o}, {c})"
+                );
+            }
+        }
+    }
+}
+
+/// A runtime padding under a direct schedule: the taps that underflow must still mask to zero,
+/// though nothing proved at comptime that the origin was negative.
+#[test]
+fn conv1d_dynamic_padding_direct() {
+    Conv1d {
+        oh: 6,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 1,
+        dilation: 1,
+    }
+    .check_dynamic_padded(3, 4, 1, 6, Schedule::Direct, false);
+}
+
+/// The same padding staged: a dynamic offset costs no comptime window geometry, so unlike a
+/// dynamic coefficient it survives the compaction into smem.
+#[test]
+fn conv1d_dynamic_padding_staged() {
+    Conv1d {
+        oh: 6,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 1,
+        dilation: 1,
+    }
+    .check_dynamic_padded(3, 4, 1, 6, Schedule::Staged, false);
+}
+
+/// Stride, dilation and padding all runtime at once: the whole affine map arrives with the launch.
+#[test]
+fn conv1d_all_dynamic() {
+    Conv1d {
+        oh: 6,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 2,
+        dilation: 1,
+    }
+    .check_dynamic_padded(3, 4, 1, 8, Schedule::Direct, true);
 }
 
 // ---- 2-D -------------------------------------------------------------------


### PR DESCRIPTION
Stacked on #474.

A gathered projection's coefficients and constant term had to be comptime, so a kernel
was compiled per stride, dilation and padding. Both halves can now arrive at runtime.

## Changes

- `Scale::Dynamic` is no longer refused: `Tile::of_gathered` / `TileArg::tile_gathered`
  take one `u32` per dynamic coefficient, in `Projection::dynamic_scale_index` order.
- `Offset::{Static, Dynamic}` mirrors `Scale` for the constant term, carried apart as
  signed `i32` in `Projection::dynamic_offset_index` order, since a padding places the
  window before the buffer's origin.
- Each reader matches per term at comptime, so a fully `Static` mapping folds exactly as
  before.
- A dynamic coefficient cannot be staged, its receptive field having no comptime extent:
  `Compaction::of` refuses it host-side, `Tile::of` at expansion. A dynamic offset stages
  fine, the compaction dropping the offset and `span` being offset-invariant.
- A dynamic offset conservatively arms the window's signed underflow guard, its sign not
  being knowable at comptime.

## Tests

1-D convolutions with a runtime stride and dilation, a runtime padding (direct and
staged), and all three at once, each against the same CPU reference. Host-side: carrier
order, that a dynamic map is not invertible, and that `Compaction::of` refuses a dynamic
coefficient but compacts a dynamic offset unchanged.

`cargo clippy -p cubek-tile --all-targets` clean, `--lib` 59 passed, `--test '*'` 151
passed with `register_matmul_unit_split_k` failing identically on the base branch.
