### PR TITLE
A gathered operand's mapping stated at the launch

### DIFF
--- a/crates/cubek-tile/src/ops/matmul/lower.rs
+++ b/crates/cubek-tile/src/ops/matmul/lower.rs
@@ -15,9 +15,7 @@ impl<Acc: Numeric> Tile<Acc> {
         match comptime!(partitioner) {
             Partitioner::Final => mma_leaf(self, lhs, rhs),
             Partitioner::Level(level) => {
-                // The level's operation space is the merge of the operands' runtime
-                // spaces; the output contributes no axis beyond `lhs ∪ rhs`.
-                let op_space = lhs.runtime_space().merge_with(&rhs.runtime_space());
+                let op_space = self.op_space(lhs, rhs);
                 match comptime!(level.schedule()) {
                     Schedule::Direct => self.mma_direct(lhs, rhs, op_space),
                     Schedule::Staged => self.mma_staged(lhs, rhs, op_space),
@@ -25,5 +23,31 @@ impl<Acc: Numeric> Tile<Acc> {
                 }
             }
         }
+    }
+
+    /// The level's operation space: the merge of the operands' spaces, sized by whichever operand
+    /// [`witnesses`](Tile::witnesses) each [`Dynamic`](crate::Extent) axis. The output contributes
+    /// no axis beyond `lhs ∪ rhs`, which is why the schedules can merge the same two for their own
+    /// comptime decisions.
+    ///
+    /// The accumulator is asked for sizes all the same, because spanning an axis and being able to
+    /// state its size are different things. A gathered operand spans the axes its affine map reads
+    /// (a convolution's `OH` and `RH` both address one input dim), but its bound is the receptive
+    /// field they reach over, so it can answer for neither: the output positions come off the
+    /// accumulator and the window off the weights.
+    ///
+    /// It is asked first for the same reason: an axis it spans is one it writes, so its bound is
+    /// the extent the walk must cover, whatever an input's buffer reaches over.
+    fn op_space<Lhs: Numeric, Rhs: Numeric>(&self, lhs: &Tile<Lhs>, rhs: &Tile<Rhs>) -> Space {
+        let merged = comptime!({
+            let merged = Space::merge(&[&lhs.space, &rhs.space]);
+            assert!(
+                self.space.axes().all(|axis| merged.contains(axis)),
+                "Tile::mma: the output spans an axis neither operand does, so the walk would never \
+                 step it and every region would write the same slice"
+            );
+            merged
+        });
+        witnessed_space(merged, self, lhs, rhs)
     }
 }

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -67,19 +67,6 @@ impl TileSpec {
         self.projection.logical_axes()
     }
 
-    /// Derive an operand's spec from its realized [`ConcreteLayout`]: the [`Projection`] and the
-    /// tiling both read off the layout's repeated axis labels. The one derivation every
-    /// launch site shares.
-    pub fn from_concrete(
-        layout: &ConcreteLayout,
-        boundary: Option<Boundary>,
-        units: usize,
-    ) -> Self {
-        TileSpec::new(Projection::of_layout(layout))
-            .with_boundary(boundary)
-            .units(units)
-    }
-
     /// State what this operand is at the instruction (default [`Leaf::Memory`], the memory form).
     pub fn leaf(mut self, leaf: Leaf) -> Self {
         self.leaf = leaf;

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -36,8 +36,9 @@ impl Projection {
     /// A storage-tiled logical axis labels several physical axes, which is the whole encoding of
     /// its tiling: the digit each fragment carries follows from that repetition
     /// ([`digit`](Projection::digit)), so no extent is read here and none is baked in. What
-    /// [`TileSpec::from_concrete`](crate::TileSpec::from_concrete) builds every operand's mapping
-    /// from.
+    /// [`StridedTileSource::subspace`](crate::StridedTileSource::subspace) derives a labeled
+    /// operand's mapping from; [`StridedTileSource::gathered`](crate::StridedTileSource::gathered)
+    /// is the entry for one no labeling describes.
     pub fn of_layout(layout: &ConcreteLayout) -> Projection {
         Projection {
             physical: layout
@@ -653,7 +654,7 @@ mod tests {
             PhysicalAxis::new(A, 8),
             PhysicalAxis::new(B, 8),
         ]);
-        let spec = TileSpec::from_concrete(&layout, None, 0);
+        let spec = TileSpec::new(Projection::of_layout(&layout));
 
         assert_eq!(spec.projection.physical_rank(), layout.axes().len());
         assert_eq!(

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -9,7 +9,7 @@ use cubecl::prelude::*;
 use cubecl::quant::scheme::QuantScheme;
 
 use crate::{
-    Axis, Boundary, ConcreteLayout, DequantAt, Extent, Leaf, LoadMethod, PhysicalAxis, Projection,
+    Axis, Boundary, ConcreteLayout, DequantAt, Leaf, LoadMethod, PhysicalAxis, Projection,
     QuantTileArgLaunch, Space, StageStorage, StorageTiling, TileArgLaunch, TileSpec,
     validate_scheme,
 };
@@ -104,15 +104,18 @@ impl<'a, Sp, Sub, Q, R: Runtime> StridedTileSource<'a, Sp, Sub, Q, R> {
     /// Sets an explicit affine [`Projection`] for a gathered operand (e.g. convolution or resample),
     /// mapping logical axes to buffer dimensions.
     ///
-    /// This replaces [`subspace`](Self::subspace), [`batches`](Self::batches), and
-    /// [`tiling`](Self::tiling). Setting any of those alongside `gathered` is an error.
+    /// Mutually exclusive with [`subspace`](Self::subspace), [`batches`](Self::batches), and
+    /// [`tiling`](Self::tiling).
     ///
     /// # Bounds Checking & Extents
-    /// - If the projection [`may_underflow`](Projection::may_underflow), boundary checking is enabled
-    ///   by default unless overridden with [`checked`](Self::checked).
-    /// - Logical axes sharing a physical dimension must be [`Static`](crate::Extent) in the kernel space
-    ///   ([`Space::launcher_over`](crate::Space::launcher_over)).
-    /// - Dynamic coefficients/offsets ([`Scale::Dynamic`](crate::Scale), [`Offset::Dynamic`](crate::Offset))
+    /// - Boundary checking is enabled by default if the projection [`may_underflow`](Projection::may_underflow)
+    ///   (override with [`checked`](Self::checked)).
+    /// - An axis sharing a physical dim with another has no extent of its own here (the buffer holds
+    ///   the receptive field they reach over), so if it is [`Dynamic`](crate::Extent) some other
+    ///   operand of the operation must state its size ([`Tile::witnesses`](crate::Tile::witnesses)).
+    ///   Nothing here can see the other operands, so an axis no operand answers for is reported at
+    ///   expansion, by the op that walks it.
+    /// - Dynamic scale and offset coefficients ([`Scale::Dynamic`](crate::Scale), [`Offset::Dynamic`](crate::Offset))
     ///   are passed at runtime via [`TileArg::tile_gathered`](crate::TileArg::tile_gathered).
     pub fn gathered(mut self, projection: Projection) -> StridedTileSource<'a, Sp, Set, Q, R> {
         self.data.projection = Some(projection);
@@ -493,16 +496,6 @@ fn check_stated<R: Runtime>(
             space.contains(axis),
             "StridedTileSource::gathered: the mapping spans {axis:?}, which the launched space \
              does not have"
-        );
-        // When multiple logical axes share a physical dimension (gathered), individual runtime
-        // extents cannot be recovered from the buffer shape and must be static in the space.
-        let pa = projection.carriers(axis)[0];
-        assert!(
-            projection.physical_axis(pa).is_identity(axis)
-                || matches!(space.extent_raw(axis), Extent::Static(_)),
-            "StridedTileSource::gathered: {axis:?} is gathered, so this operand's buffer holds the \
-             receptive field its axes reach over rather than that axis's own extent; keep it \
-             static in the kernel space (`Space::launcher_over`)"
         );
     }
 }

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -9,8 +9,9 @@ use cubecl::prelude::*;
 use cubecl::quant::scheme::QuantScheme;
 
 use crate::{
-    Axis, Boundary, ConcreteLayout, DequantAt, Leaf, LoadMethod, PhysicalAxis, QuantTileArgLaunch,
-    Space, StageStorage, StorageTiling, TileArgLaunch, TileSpec, validate_scheme,
+    Axis, Boundary, ConcreteLayout, DequantAt, Extent, Leaf, LoadMethod, PhysicalAxis, Projection,
+    QuantTileArgLaunch, Space, StageStorage, StorageTiling, TileArgLaunch, TileSpec,
+    validate_scheme,
 };
 
 /// Typestate marker: a required [`StridedTileSource`] field has been set.
@@ -29,6 +30,9 @@ struct TileSourceData<'a, R: Runtime> {
     batch_axes: &'a [Axis],
     /// How the subspace axes are storage-tiled in the binding; `None` is untiled.
     tiling: Option<StorageTiling>,
+    /// The operand's own affine mapping, when it states one ([`gathered`](StridedTileSource::gathered));
+    /// `None` derives it from the labeled dims instead.
+    projection: Option<Projection>,
     v: usize,
     boundary: Option<Option<Boundary>>,
     stage: Option<StageStorage>,
@@ -43,6 +47,8 @@ struct TileSourceData<'a, R: Runtime> {
 /// Typestate builder for a strided tile kernel operand, started with
 /// [`Launcher::arg`](crate::Launcher::arg) or [`StridedOperand::source`]. The `Sp`/`Sub`
 /// markers make [`build`](Self::build) exist only once both required setters are [`Set`];
+/// `Sub` is satisfied by [`subspace`](Self::subspace), which labels the buffer's dims, or by
+/// [`gathered`](Self::gathered), which states the affine mapping outright;
 /// the `Q` marker records whether [`quantized`](Self::quantized) was called, so `build`
 /// returns a [`StridedOperand`] (plain) or a [`QuantOperand`] (quantized) and no call
 /// site ever probes an option.
@@ -61,6 +67,7 @@ impl<'a, R: Runtime> StridedTileSource<'a, Unset, Unset, Unset, R> {
                 subspace: &[],
                 batch_axes: &[],
                 tiling: None,
+                projection: None,
                 v: 1,
                 boundary: None,
                 stage: None,
@@ -83,10 +90,32 @@ impl<'a, Sp, Sub, Q, R: Runtime> StridedTileSource<'a, Sp, Sub, Q, R> {
         }
     }
 
-    /// The inner block of axes the operand iterates, its `[row, col]` for a matmul (required,
-    /// non-empty). Complementary to [`batches`](Self::batches), the outer dims.
+    /// The inner block of axes the operand iterates, its `[row, col]` for a matmul (required
+    /// unless [`gathered`](Self::gathered) states the mapping instead, non-empty). Complementary
+    /// to [`batches`](Self::batches), the outer dims.
     pub fn subspace(mut self, axes: &'a [Axis]) -> StridedTileSource<'a, Sp, Set, Q, R> {
         self.data.subspace = axes;
+        StridedTileSource {
+            data: self.data,
+            _state: PhantomData,
+        }
+    }
+
+    /// Sets an explicit affine [`Projection`] for a gathered operand (e.g. convolution or resample),
+    /// mapping logical axes to buffer dimensions.
+    ///
+    /// This replaces [`subspace`](Self::subspace), [`batches`](Self::batches), and
+    /// [`tiling`](Self::tiling). Setting any of those alongside `gathered` is an error.
+    ///
+    /// # Bounds Checking & Extents
+    /// - If the projection [`may_underflow`](Projection::may_underflow), boundary checking is enabled
+    ///   by default unless overridden with [`checked`](Self::checked).
+    /// - Logical axes sharing a physical dimension must be [`Static`](crate::Extent) in the kernel space
+    ///   ([`Space::launcher_over`](crate::Space::launcher_over)).
+    /// - Dynamic coefficients/offsets ([`Scale::Dynamic`](crate::Scale), [`Offset::Dynamic`](crate::Offset))
+    ///   are passed at runtime via [`TileArg::tile_gathered`](crate::TileArg::tile_gathered).
+    pub fn gathered(mut self, projection: Projection) -> StridedTileSource<'a, Sp, Set, Q, R> {
+        self.data.projection = Some(projection);
         StridedTileSource {
             data: self.data,
             _state: PhantomData,
@@ -119,7 +148,8 @@ impl<'a, Sp, Sub, Q, R: Runtime> StridedTileSource<'a, Sp, Sub, Q, R> {
 
     /// Force the overhang bounds-check on or off (using [`Boundary::Zero`] when checked).
     /// Default: derived from the concrete space when minted by a [`Launcher`](crate::Launcher)
-    /// (checked exactly when a subspace axis [`overhangs`](Space::overhangs)), else `Some(Boundary::Zero)`.
+    /// (checked when an axis this operand addresses [`overhangs`](Space::overhangs), or when a
+    /// [`gathered`](Self::gathered) mapping may underflow), else `Some(Boundary::Zero)`.
     /// A boolean convenience over [`with_boundary`](Self::with_boundary): it unconditionally
     /// overwrites whatever mode was set before it, so a `with_boundary(Some(Boundary::Clamp))`
     /// before this call is silently dropped back to `Zero`. Sequence a `Clamp` override after
@@ -271,7 +301,8 @@ impl<R: Runtime> QuantOperand<R> {
 impl<R: Runtime> StridedOperand<R> {
     /// Start describing a strided tile kernel operand sourced from `binding`: a
     /// [`StridedTileSource`] builder. Set the required [`space`](StridedTileSource::space)
-    /// and [`subspace`](StridedTileSource::subspace) (`build` won't compile until both are
+    /// and either [`subspace`](StridedTileSource::subspace) or
+    /// [`gathered`](StridedTileSource::gathered) (`build` won't compile until both are
     /// set), then optionally [`batches`](StridedTileSource::batches),
     /// [`tiling`](StridedTileSource::tiling), [`vectorize`](StridedTileSource::vectorize),
     /// or [`checked`](StridedTileSource::checked). Optional defaults are the safe ones, so
@@ -290,9 +321,9 @@ struct Realized<R: Runtime> {
 }
 
 impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
-    /// The derivation both builds share: fold the labeled dims into a [`ConcreteLayout`],
-    /// derive the bounds-check from overhang, and mint the comptime [`TileSpec`] via
-    /// [`TileSpec::from_concrete`].
+    /// The derivation both builds share: settle the operand's [`Projection`] (the labeled dims
+    /// folded into a [`ConcreteLayout`], or the [`gathered`](StridedTileSource::gathered) mapping
+    /// as given), derive the bounds-check, and mint the comptime [`TileSpec`].
     fn realize(self) -> Realized<R> {
         let TileSourceData {
             mut binding,
@@ -301,6 +332,7 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
             batch_axes,
             subspace,
             tiling,
+            projection,
             v,
             boundary,
             stage,
@@ -310,92 +342,168 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
         } = self.data;
         let space = space.unwrap();
 
-        let rank = binding.shape.len();
-        let tiling = tiling.unwrap_or_else(|| StorageTiling::uniform(subspace.len(), 0));
-        assert_eq!(
-            tiling.rank(),
-            subspace.len(),
-            "StridedTileSource: the tiling describes {} axes but the subspace has {}",
-            tiling.rank(),
-            subspace.len()
-        );
-        // One axis label per buffer dim: the trailing block is the subspace emitted level-major
-        // per `tiling`, and whatever leads it is this operand's batches, labeled by the trailing
-        // (right-aligned) slice of `batch_axes`.
-        let block = tiling.order(subspace);
-        let block_dims = block.len();
-        assert!(
-            rank >= block_dims,
-            "StridedTileSource: binding rank {rank} is smaller than its subspace block of {block_dims} dims ({} axes over {tiling:?})",
-            subspace.len()
-        );
-        let batch_dims = rank - block_dims;
-        assert!(
-            batch_dims <= batch_axes.len(),
-            "StridedTileSource: {batch_dims} batch dims but only {} batch axes given",
-            batch_axes.len()
-        );
-        let mut physical_axes = Vec::with_capacity(rank);
-        physical_axes.extend_from_slice(&batch_axes[batch_axes.len() - batch_dims..]);
-        physical_axes.extend_from_slice(&block);
+        // Use the explicit projection if gathered, or derive it from labeled axes.
+        // `addressed` contains all logical axes used for bounds checking.
+        let (projection, addressed) = match projection {
+            Some(projection) => {
+                check_stated(&binding, space, &projection, subspace, batch_axes, &tiling);
+                let addressed = projection.logical_axes().to_vec();
+                (projection, addressed)
+            }
+            None => labeled(&mut binding, subspace, batch_axes, tiling),
+        };
 
-        // Explicit override wins; a Launcher-minted source derives the check from overhang, and
-        // the free-standing path stays conservatively checked. A dim whose axis is absent from the
-        // space is a broadcast omission (it drops out below): nothing to overhang.
+        // Derive boundary check: use explicit override if set, otherwise check for overhang or underflow.
         let boundary = boundary.unwrap_or_else(|| match concrete {
             Some(concrete) => {
-                let overhangs = physical_axes
+                let overhangs = addressed
                     .iter()
                     .filter(|&&axis| concrete.contains(axis))
                     .any(|&axis| concrete.overhangs(axis));
-                if overhangs {
-                    Some(Boundary::Zero)
-                } else {
-                    None
-                }
+                (overhangs || projection.may_underflow()).then_some(Boundary::Zero)
             }
             None => Some(Boundary::Zero),
         });
 
-        // A masked access counts its length in lines and would clip valid rows, so a
-        // bounds-checked operand must stay scalar.
+        // Bounds-checked operands cannot be vectorized.
         assert!(
             !(boundary.is_some() && v > 1),
-            "StridedTileSource: a bounds-checked operand cannot be vectorized"
+            "StridedTileSource: a bounds-checked operand cannot be vectorized; serve it scalar or \
+             state `checked(false)` if the launch proves every access in bounds"
         );
+        // Validate projection vector width alignment on the host side.
+        projection.validate(v);
 
-        let mut phys = Vec::new();
-        let mut shape = Vec::new();
-        let mut strides = Vec::new();
-
-        for (i, &axis) in physical_axes.iter().enumerate() {
-            let extent = binding.shape[i];
-            // A size-1 batch dim is a broadcast omission: the dim and its axis both drop out. A
-            // subspace axis never does, however small, since the tile is shaped over it.
-            if batch_axes.contains(&axis) && extent == 1 && !subspace.contains(&axis) {
-                continue;
-            }
-            phys.push(PhysicalAxis::new(axis, extent));
-            shape.push(extent);
-            strides.push(binding.strides[i]);
-        }
-
-        binding.shape = shape[..].into();
-        binding.strides = strides[..].into();
-        let mut spec =
-            TileSpec::from_concrete(&ConcreteLayout::new(&phys), boundary, units).leaf(leaf);
+        let mut spec = TileSpec::new(projection)
+            .with_boundary(boundary)
+            .units(units)
+            .leaf(leaf);
         if let Some(stage) = stage {
             spec = spec.staged(stage);
         }
         if let Some(quant) = &quant {
+            // Quantization is not supported for gathered operands.
+            assert!(
+                spec.projection.untiled().is_direct(),
+                "StridedTileSource::quantized: a gathered operand cannot be quantized; its scale \
+                 grid is shaped over its logical axes, which its buffer's dims no longer match"
+            );
             quant.validate(&space.project(spec.axes()), v, leaf);
         }
+        // Dynamic projection scales cannot be staged to shared memory (requires compile-time extent).
+        assert!(
+            !spec.projection.has_dynamic_scales() || !space.partitioner().stages(),
+            "StridedTileSource: a Dynamic coefficient cannot be staged, its window has no \
+             comptime extent; the schedule must be Direct"
+        );
         Realized {
             tensor: binding.into_tensor_arg(),
             vector_size: v,
             spec,
             quant,
         }
+    }
+}
+
+/// Derives a [`Projection`] from labeled subspace and batch axes.
+///
+/// Leading batch dimensions align with `batch_axes` (size-1 broadcast dims are omitted).
+/// The inner subspace axes are laid out according to `tiling`.
+///
+/// Returns the projection along with all physical axes prior to broadcast omission (for bounds checking).
+fn labeled<R: Runtime>(
+    binding: &mut TensorBinding<R>,
+    subspace: &[Axis],
+    batch_axes: &[Axis],
+    tiling: Option<StorageTiling>,
+) -> (Projection, Vec<Axis>) {
+    let rank = binding.shape.len();
+    let tiling = tiling.unwrap_or_else(|| StorageTiling::uniform(subspace.len(), 0));
+    assert_eq!(
+        tiling.rank(),
+        subspace.len(),
+        "StridedTileSource: the tiling describes {} axes but the subspace has {}",
+        tiling.rank(),
+        subspace.len()
+    );
+    let block = tiling.order(subspace);
+    let block_dims = block.len();
+    assert!(
+        rank >= block_dims,
+        "StridedTileSource: binding rank {rank} is smaller than its subspace block of {block_dims} dims ({} axes over {tiling:?})",
+        subspace.len()
+    );
+    let batch_dims = rank - block_dims;
+    assert!(
+        batch_dims <= batch_axes.len(),
+        "StridedTileSource: {batch_dims} batch dims but only {} batch axes given",
+        batch_axes.len()
+    );
+    let mut physical_axes = Vec::with_capacity(rank);
+    physical_axes.extend_from_slice(&batch_axes[batch_axes.len() - batch_dims..]);
+    physical_axes.extend_from_slice(&block);
+
+    let mut phys = Vec::new();
+    let mut shape = Vec::new();
+    let mut strides = Vec::new();
+
+    for (i, &axis) in physical_axes.iter().enumerate() {
+        let extent = binding.shape[i];
+        // A subspace axis never drops out, however small, since the tile is shaped over it.
+        if batch_axes.contains(&axis) && extent == 1 && !subspace.contains(&axis) {
+            continue;
+        }
+        phys.push(PhysicalAxis::new(axis, extent));
+        shape.push(extent);
+        strides.push(binding.strides[i]);
+    }
+
+    binding.shape = shape[..].into();
+    binding.strides = strides[..].into();
+    (
+        Projection::of_layout(&ConcreteLayout::new(&phys)),
+        physical_axes,
+    )
+}
+
+/// Validates an explicit gathered [`Projection`] against the tensor binding and iteration space.
+/// Ensures mutually exclusive labeling options (`subspace`, `batch_axes`, `tiling`) were not provided.
+fn check_stated<R: Runtime>(
+    binding: &TensorBinding<R>,
+    space: &Space,
+    projection: &Projection,
+    subspace: &[Axis],
+    batch_axes: &[Axis],
+    tiling: &Option<StorageTiling>,
+) {
+    assert!(
+        subspace.is_empty() && batch_axes.is_empty() && tiling.is_none(),
+        "StridedTileSource::gathered: the mapping is stated outright, so `subspace`, `batches` \
+         and `tiling` have nothing left to describe"
+    );
+    assert_eq!(
+        projection.physical_rank(),
+        binding.shape.len(),
+        "StridedTileSource::gathered: the mapping addresses {} dims but the binding has {}",
+        projection.physical_rank(),
+        binding.shape.len()
+    );
+    for &axis in projection.logical_axes() {
+        assert!(
+            space.contains(axis),
+            "StridedTileSource::gathered: the mapping spans {axis:?}, which the launched space \
+             does not have"
+        );
+        // When multiple logical axes share a physical dimension (gathered), individual runtime
+        // extents cannot be recovered from the buffer shape and must be static in the space.
+        let pa = projection.carriers(axis)[0];
+        assert!(
+            projection.physical_axis(pa).is_identity(axis)
+                || matches!(space.extent_raw(axis), Extent::Static(_)),
+            "StridedTileSource::gathered: {axis:?} is gathered, so this operand's buffer holds the \
+             receptive field its axes reach over rather than that axis's own extent; keep it \
+             static in the kernel space (`Space::launcher_over`)"
+        );
     }
 }
 

--- a/crates/cubek-tile/src/space/base.rs
+++ b/crates/cubek-tile/src/space/base.rs
@@ -120,8 +120,9 @@ impl std::hash::Hash for Space {
 }
 
 /// Comptime tiling spec read off a runtime `Space`'s `#[cube(comptime)]` data. Tiles carry a comptime
-/// `Space`, so only [`Walk::over`](crate::Walk), which takes the runtime operation space built by
-/// [`merge_with`](Space::merge_with), needs these; everything else calls the host methods directly.
+/// `Space`, so only [`Walk::over`](crate::Walk), which takes the runtime operation space
+/// [`witnessed_space`](crate::witnessed_space) builds from an op's operands, needs these;
+/// everything else calls the host methods directly.
 impl SpaceExpand {
     fn comptime(&self) -> Space {
         Space {
@@ -160,39 +161,6 @@ impl Space {
                 sizes,
             },
             partitioner: comptime!(space.partitioner.clone()),
-        }
-    }
-
-    /// Merge two already-sized runtime spaces into the operation space: the comptime structure is
-    /// the host [`merge`](Space::merge) of their specs, and each merged axis takes its runtime size
-    /// from whichever input spans it. A fully-`Static` merge carries no runtime sizes.
-    pub fn merge_with(&self, other: &Space) -> Space {
-        let merged = comptime!(Space::merge(&[&self.clone(), &other.clone()]));
-        let mut sizes = Sequence::<usize>::new();
-        if comptime!(!merged.is_static()) {
-            #[unroll]
-            for p in 0..comptime!(merged.rank()) {
-                let axis = comptime!(merged.axis_at(p));
-                if comptime!(self.clone().contains(axis)) {
-                    sizes.push(self.size(axis));
-                } else {
-                    sizes.push(other.size(axis));
-                }
-            }
-        }
-        Space::with_sizes(merged, sizes)
-    }
-
-    /// This space's runtime size along `axis`: a `Static` axis folds to its comptime extent
-    /// (so a fully-static operand needs no `sizes` at all), a `Dynamic` one reads the
-    /// per-axis `sizes`, valid only once filled.
-    fn size(&self, #[comptime] axis: Axis) -> usize {
-        match comptime!(self.clone().extent_raw(axis)) {
-            Extent::Static(n) => comptime!(n).runtime(),
-            Extent::Dynamic => *self
-                .extents
-                .sizes
-                .index(comptime!(self.clone().position(axis))),
         }
     }
 }

--- a/crates/cubek-tile/src/space/partition/launcher.rs
+++ b/crates/cubek-tile/src/space/partition/launcher.rs
@@ -31,9 +31,9 @@ impl Space {
     /// Creates a [`Launcher`] where only the specified `dynamic` axes have dynamic extents in
     /// the kernel space; all other axes remain compile-time static.
     ///
-    /// Useful for gathered operands whose shared dimensions cannot provide individual runtime
-    /// extents, or to specialize kernel loops along specific axes. Passing `&[]` creates a
-    /// fully static launch.
+    /// Useful to specialize kernel loops along specific axes, or for an axis no operand can state
+    /// the size of at runtime ([`Tile::witnesses`](crate::Tile::witnesses)). Passing `&[]` creates
+    /// a fully static launch.
     pub fn launcher_over<'c, R: Runtime>(
         self,
         client: &'c ComputeClient<R>,

--- a/crates/cubek-tile/src/space/partition/launcher.rs
+++ b/crates/cubek-tile/src/space/partition/launcher.rs
@@ -16,23 +16,53 @@ pub struct Launcher<'c, R: Runtime> {
 }
 
 impl Space {
-    /// Bind this concrete (real-extent) space to `client` for launching. The kernel-form space
-    /// goes fully dynamic so one compiled kernel serves every shape; a static-shape constructor
-    /// can later skip that derivation without changing this one. Any `Unit` axis's deferred lane
-    /// count is stamped here from the hardware `plane_size` ([`Space::resolve_lanes`]).
+    /// Creates a [`Launcher`] with all kernel space axes marked dynamic, allowing one compiled
+    /// kernel to serve arbitrary shapes.
+    ///
+    /// Resolves any `Unit` axis lane counts using the device `plane_size`. Use
+    /// [`launcher_over`](Self::launcher_over) if specific axes should remain static.
     pub fn launcher<R: Runtime>(self, client: &ComputeClient<R>) -> Launcher<'_, R> {
         let plane_size = client.properties().hardware.plane_size_max as usize;
         let concrete = self.resolve_lanes(plane_size);
         let kernel = concrete.clone().all_dynamic();
+        Launcher::new(concrete, kernel, client)
+    }
+
+    /// Creates a [`Launcher`] where only the specified `dynamic` axes have dynamic extents in
+    /// the kernel space; all other axes remain compile-time static.
+    ///
+    /// Useful for gathered operands whose shared dimensions cannot provide individual runtime
+    /// extents, or to specialize kernel loops along specific axes. Passing `&[]` creates a
+    /// fully static launch.
+    pub fn launcher_over<'c, R: Runtime>(
+        self,
+        client: &'c ComputeClient<R>,
+        dynamic: &[Axis],
+    ) -> Launcher<'c, R> {
+        // An axis the space does not have would be dropped by `with_dynamic`, leaving a kernel
+        // specialized along the axis the caller meant to free.
+        for &axis in dynamic {
+            assert!(
+                self.contains(axis),
+                "Space::launcher_over: {axis:?} is not an axis of this space"
+            );
+        }
+        let plane_size = client.properties().hardware.plane_size_max as usize;
+        let concrete = self.resolve_lanes(plane_size);
+        let kernel = concrete.clone().with_dynamic(dynamic);
+        Launcher::new(concrete, kernel, client)
+    }
+}
+
+impl<'c, R: Runtime> Launcher<'c, R> {
+    fn new(concrete: Space, kernel: Space, client: &'c ComputeClient<R>) -> Self {
         Launcher {
             concrete,
             kernel,
             client,
         }
     }
-}
 
-impl<'c, R: Runtime> Launcher<'c, R> {
     pub fn cube_count(&self) -> CubeCount {
         self.concrete.cube_count()
     }
@@ -51,9 +81,8 @@ impl<'c, R: Runtime> Launcher<'c, R> {
         &self.concrete
     }
 
-    /// Start a tile operand over the kernel space: [`StridedOperand::source`] with
-    /// [`space`](StridedTileSource::space) pre-set and the bounds-check derived from the concrete
-    /// space's overhang (an explicit [`checked`](StridedTileSource::checked) still wins).
+    /// Starts configuring a tile operand builder ([`StridedTileSource`]) bound to this launcher's
+    /// kernel space, with automatic bounds checking derived from the concrete space overhang.
     pub fn arg(&self, binding: TensorBinding<R>) -> StridedTileSource<'_, Set, Unset, Unset, R> {
         StridedOperand::source(binding)
             .space(&self.kernel)

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -191,20 +191,27 @@ pub struct Tile<T: Numeric> {
     pub leaf: Leaf,
 }
 
-/// Returns the physical dimension index in the tile's window bounds corresponding to `axis`.
-///
-/// For direct mappings, each logical axis maps 1:1 to a physical dimension. For gathered operands
-/// sharing dimensions, only identity-mapped axes carry valid runtime extents; other axes must be
-/// static in the space.
+/// The one physical dim whose bound is `axis`'s own extent: it carries `axis` alone, at
+/// coefficient `1`. `None` otherwise, which is either of the two ways a bound stops being that
+/// extent: a gather, where the dim holds the receptive field several axes reach over, and storage
+/// tiling, where the extent is the product over the dims the axis is split across.
+fn bound_states(projection: &Projection, axis: Axis) -> Option<usize> {
+    match projection.carriers(axis)[..] {
+        [pa] if projection.physical_axis(pa).is_identity(axis) => Some(pa),
+        _ => None,
+    }
+}
+
+/// The physical dim in this tile's window bounds that `axis`'s runtime extent is read off. A
+/// direct operand maps each axis 1:1; anything else has to be answered by an operand of the same
+/// operation that does ([`Tile::witnesses`]).
 fn bound_position(projection: &Projection, axis: Axis) -> usize {
-    let pa = projection.carriers(axis)[0];
-    assert!(
-        projection.physical_axis(pa).is_identity(axis),
-        "Tile::runtime_extent: {axis:?} is gathered, so this operand's window holds the receptive \
-         field its axes reach over rather than that axis's own extent; a gathered axis must reach \
-         the kernel Static"
-    );
-    pa
+    bound_states(projection, axis).unwrap_or_else(|| {
+        panic!(
+            "Tile::runtime_extent: no bound of this operand is {axis:?}'s own extent (it gathers \
+             over it, or splits it across storage fragments); ask an operand that witnesses it"
+        )
+    })
 }
 
 #[cube]
@@ -288,6 +295,27 @@ impl<T: Numeric> Tile<T> {
     pub fn gathered(&self) -> comptime_type!(bool) {
         let projection = self.projection();
         comptime!(!projection.is_direct())
+    }
+
+    /// Whether this tile can state `axis`'s runtime size for the operation it takes part in: it
+    /// spans the axis [`Dynamic`](crate::Extent), has a buffer to read a bound off, and that bound
+    /// is the axis's own extent ([`bound_states`]). Each clause rules out an operand that spans the
+    /// axis without being able to answer for it: a `Static` one knows its size at comptime already
+    /// (and a broadcast `1` is not the operation's extent), a fragment has no bound, and a gathered
+    /// axis's bound is the receptive field its axes reach over.
+    ///
+    /// Spanning an axis and having to supply it are therefore separate questions: an operation
+    /// sizes each `Dynamic` axis from whichever of its operands witnesses it and lets the others
+    /// pass ([`witnessed_space`]).
+    pub fn witnesses(&self, #[comptime] axis: Axis) -> comptime_type!(bool) {
+        let bounded = self.bounded();
+        let projection = self.projection();
+        comptime!(
+            bounded
+                && self.space.contains(axis)
+                && self.space.is_dynamic(axis)
+                && bound_states(&projection, axis).is_some()
+        )
     }
 
     /// How this tile's logical axes address its buffer's physical ones. A fragment and a tma source
@@ -383,10 +411,21 @@ impl<T: Numeric> Tile<T> {
         }
     }
 
+    /// Whether this tile has a buffer bound to read an extent off: memory and a tensor map carry
+    /// the tensor's shape, a resident fragment carries nothing but its cells. The kinds
+    /// [`runtime_extent`](Tile::runtime_extent) can answer for, so the two match the same way.
+    fn bounded(&self) -> comptime_type!(bool) {
+        match &self.tile_kind {
+            TileKind::Gmem(_) | TileKind::Smem(_) | TileKind::TmaGmem(_) => comptime!(true),
+            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => comptime!(false),
+        }
+    }
+
     /// This operand's runtime logical size along `axis`, read off the [`bound`](MemData)
     /// folded from the tensor shape. The source of a [`Dynamic`](crate::Extent) axis's
-    /// tile count. A cmma fragment has no buffer extent, and a gathered axis has no bound of its
-    /// own ([`bound_position`]).
+    /// tile count. Only an axis this tile [`witnesses`](Tile::witnesses) has one: a fragment has no
+    /// buffer extent ([`bounded`](Tile::bounded)), and a gathered or storage-tiled axis no bound of
+    /// its own ([`bound_position`]).
     pub fn runtime_extent(&self, #[comptime] axis: Axis) -> usize {
         let projection = self.projection();
         let p = comptime!(bound_position(&projection, axis));
@@ -404,27 +443,12 @@ impl<T: Numeric> Tile<T> {
         comptime!(if p == last { w } else { 1usize }) * raw
     }
 
-    /// The runtime space to walk this tile: its comptime tiling spec plus the runtime sizes of any
-    /// `Dynamic` axes, read off the tile. A fully-`Static` tile short-circuits to no runtime sizes.
+    /// The runtime space to walk this tile *alone*: [`witnessed_space`] with no other operand to
+    /// ask, so every `Dynamic` axis must be one this tile itself
+    /// [`witnesses`](Tile::witnesses). An operation over several operands sizes its space from all
+    /// of them instead, which is what lets a gathered operand ride an axis it cannot answer for.
     pub fn runtime_space(&self) -> Space {
-        let space = comptime!(self.space.clone());
-        let mut sizes = Sequence::<usize>::new();
-        if comptime!(!space.is_static()) {
-            #[unroll]
-            for p in 0..comptime!(space.rank()) {
-                let axis = comptime!(space.axis_at(p));
-                // `sizes` is positional, so every axis pushes — but only a `Dynamic` one is
-                // ever read back ([`Extents::count`] folds a `Static` axis to its comptime
-                // extent). Fold it here too rather than asking the tile: a plane tile has no
-                // buffer bound to answer with, and one `Dynamic` axis elsewhere in the space
-                // must not make its `Static` axes unreadable.
-                sizes.push(match comptime!(space.extent_raw(axis)) {
-                    Extent::Static(n) => comptime!(n).runtime(),
-                    Extent::Dynamic => self.runtime_extent(axis),
-                });
-            }
-        }
-        Space::with_sizes(space, sizes)
+        witnessed_space(comptime!(self.space.clone()), self, self, self)
     }
 
     /// Zero this tile: `mma` accumulates over whatever is there, so a routine whose contract is
@@ -522,5 +546,80 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::drain_cast_into: only a partition drains with a cast")
             }
         }
+    }
+}
+
+/// `space` with each [`Dynamic`](crate::Extent) axis sized by the first of `a`, `b`, `c` that
+/// [`witnesses`](Tile::witnesses) it, which is how an operation turns its comptime space into the
+/// runtime one [`Walk::over`](crate::Walk) takes. A fully-`Static` space short-circuits to no
+/// runtime sizes. One tile may stand for all three ([`runtime_space`](Tile::runtime_space)).
+#[cube]
+pub fn witnessed_space<A: Numeric, B: Numeric, C: Numeric>(
+    #[comptime] space: Space,
+    a: &Tile<A>,
+    b: &Tile<B>,
+    c: &Tile<C>,
+) -> Space {
+    let mut sizes = Sequence::<usize>::new();
+    if comptime!(!space.is_static()) {
+        #[unroll]
+        for p in 0..comptime!(space.rank()) {
+            let axis = comptime!(space.axis_at(p));
+            // `sizes` is positional, so every axis pushes, but only a `Dynamic` one is ever read
+            // back ([`Extents::count`] folds a `Static` axis to its comptime extent). Fold it here
+            // too rather than asking an operand: one `Dynamic` axis must not make the `Static`
+            // ones unreadable on a tile that has no bound to answer with.
+            let size = match comptime!(space.extent_raw(axis)) {
+                Extent::Static(n) => comptime!(n).runtime(),
+                Extent::Dynamic => {
+                    let by_a = a.witnesses(axis);
+                    let by_b = b.witnesses(axis);
+                    let by_c = c.witnesses(axis);
+                    if comptime!(by_a) {
+                        a.runtime_extent(axis)
+                    } else if comptime!(by_b) {
+                        b.runtime_extent(axis)
+                    } else if comptime!(by_c) {
+                        c.runtime_extent(axis)
+                    } else {
+                        panic!(
+                            "witnessed_space: {axis:?} is Dynamic and no operand states its size; \
+                             every operand spanning it gathers over it, holds it Static, or is a \
+                             fragment. Keep it Static in the kernel space, or give the operation \
+                             an operand that maps it identically"
+                        )
+                    }
+                }
+            };
+            sizes.push(size);
+        }
+    }
+    Space::with_sizes(space, sizes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: Axis = Axis(0);
+    const B: Axis = Axis(1);
+
+    /// The discrimination the operation space rests on: a bound is an axis's own extent only when
+    /// one dim carries that axis alone. The two ways it stops being one are a gather, whose dim
+    /// holds the receptive field its axes reach over, and storage tiling, which splits the extent
+    /// across dims so no single bound is it.
+    #[test]
+    fn bound_states_wants_one_dim_carrying_the_axis_alone() {
+        let direct = Projection::direct(&[A, B]);
+        assert_eq!(bound_states(&direct, A), Some(0));
+        assert_eq!(bound_states(&direct, B), Some(1));
+
+        let gathered = Projection::new(&[A, B], &[PhysicalAxisMap::affine(&[(A, 1), (B, 1)])]);
+        assert_eq!(bound_states(&gathered, A), None);
+        assert_eq!(bound_states(&gathered, B), None);
+
+        let tiled = Projection::tiled(&[A, B], StorageTiling::per_axis(&[1, 2]));
+        assert_eq!(bound_states(&tiled, A), Some(0));
+        assert_eq!(bound_states(&tiled, B), None);
     }
 }

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -191,6 +191,22 @@ pub struct Tile<T: Numeric> {
     pub leaf: Leaf,
 }
 
+/// Returns the physical dimension index in the tile's window bounds corresponding to `axis`.
+///
+/// For direct mappings, each logical axis maps 1:1 to a physical dimension. For gathered operands
+/// sharing dimensions, only identity-mapped axes carry valid runtime extents; other axes must be
+/// static in the space.
+fn bound_position(projection: &Projection, axis: Axis) -> usize {
+    let pa = projection.carriers(axis)[0];
+    assert!(
+        projection.physical_axis(pa).is_identity(axis),
+        "Tile::runtime_extent: {axis:?} is gathered, so this operand's window holds the receptive \
+         field its axes reach over rather than that axis's own extent; a gathered axis must reach \
+         the kernel Static"
+    );
+    pa
+}
+
 #[cube]
 impl<T: Numeric> Tile<T> {
     /// How this operand's bytes move: a strided cooperative copy or a TMA hardware bulk
@@ -369,9 +385,11 @@ impl<T: Numeric> Tile<T> {
 
     /// This operand's runtime logical size along `axis`, read off the [`bound`](MemData)
     /// folded from the tensor shape. The source of a [`Dynamic`](crate::Extent) axis's
-    /// tile count. A cmma fragment has no buffer extent.
+    /// tile count. A cmma fragment has no buffer extent, and a gathered axis has no bound of its
+    /// own ([`bound_position`]).
     pub fn runtime_extent(&self, #[comptime] axis: Axis) -> usize {
-        let p = comptime!(self.space.position(axis));
+        let projection = self.projection();
+        let p = comptime!(bound_position(&projection, axis));
         let raw = match &self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => g.window.bound.at(p).fcast::<usize>(),
             TileKind::TmaGmem(t) => t.bound[p].fcast::<usize>(),
@@ -381,7 +399,7 @@ impl<T: Numeric> Tile<T> {
         };
         // `bound` is a line count on the vectorized innermost axis; the walk divides by
         // conceptual edges, so return line count × width.
-        let last = comptime!(self.space.rank() - 1);
+        let last = comptime!(projection.physical_rank() - 1);
         let w = self.vector_size();
         comptime!(if p == last { w } else { 1usize }) * raw
     }

--- a/crates/cubek-tile/tests/tile/conv.rs
+++ b/crates/cubek-tile/tests/tile/conv.rs
@@ -612,6 +612,161 @@ fn conv1d_masked_overhang_strided() {
     .check_at(2, 4, 1, true, Schedule::Direct);
 }
 
+// ---- through the Launcher --------------------------------------------------
+
+impl Conv1d {
+    /// [`check_at`](Conv1d::check_at) driven end to end by [`Launcher`]: the input reaches the
+    /// launch through [`StridedTileSource::gathered`] instead of a hand-built [`TileSpec`], so the
+    /// kernel projects from the kernel-form (fully dynamic) space and one compiled kernel serves
+    /// every shape. `padding` shifts the window's origin, which the builder's derived check has to
+    /// arm on by itself.
+    fn check_launched(&self, tile_oh: usize, tile_co: usize, padding: usize, schedule: Schedule) {
+        let client = <TestRuntime as Runtime>::client(&Default::default());
+        let f32_ty = f32::as_type_native_unchecked().storage_type();
+
+        let space = Tiling::new()
+            .extents(&[(OH, self.oh), (CO, self.co), (RH, self.rh), (CI, self.ci)])
+            .level(WalkOrder::RowMajor, schedule, |l| {
+                l.axis(OH, Cut::sequential(tile_oh))
+                    .axis(CO, Cut::sequential(tile_co))
+                    .axis(RH, Cut::sequential(self.rh))
+                    .axis(CI, Cut::sequential(self.ci))
+            })
+            .build();
+
+        // Padding shortens the input by exactly what it shifts the window back by, so the last
+        // output position's last tap still lands on the final row.
+        let in_len = self.in_len() - padding;
+        let in_shape = shape![in_len, self.ci];
+        let w_shape = shape![self.rh, self.ci, self.co];
+        let input = ramp(in_shape.num_elements(), 7);
+        let weight = ramp(w_shape.num_elements(), 5);
+
+        let (in_handle, _) = TestInput::builder(client.clone(), in_shape)
+            .dtype(f32_ty)
+            .custom(input.clone())
+            .generate_with_f32_host_data();
+        let (w_handle, _) = TestInput::builder(client.clone(), w_shape)
+            .dtype(f32_ty)
+            .custom(weight.clone())
+            .generate_with_f32_host_data();
+        let out_handle = TestInput::builder(client.clone(), shape![self.oh, self.co])
+            .dtype(f32_ty)
+            .zeros()
+            .generate_without_host_data();
+
+        // `OH` and `RH` share the input's gathered dim, whose bound is the receptive field they
+        // reach over rather than either extent, so they reach the kernel static. `CO` no gathered
+        // operand spans and `CI` identity-maps a dim of its own, so both can go runtime.
+        let launch = space.launcher_over(&client, &[CO, CI]);
+        let in_arg = launch
+            .arg(in_handle.binding())
+            .gathered(Projection::new(
+                &[OH, RH, CI],
+                &[
+                    PhysicalAxisMap::affine_with_offset(
+                        &[(OH, self.stride), (RH, self.dilation)],
+                        -(padding as isize),
+                    ),
+                    PhysicalAxisMap::of(CI),
+                ],
+            ))
+            .build();
+        let w_arg = launch
+            .arg(w_handle.binding())
+            .subspace(&[RH, CI, CO])
+            .build();
+        let out_arg = launch
+            .arg(out_handle.clone().binding())
+            .subspace(&[OH, CO])
+            .build();
+
+        conv_kernel::launch::<TestRuntime>(
+            &client,
+            launch.cube_count(),
+            launch.cube_dim(),
+            in_arg.arg(),
+            w_arg.arg(),
+            out_arg.arg(),
+            launch.space().clone(),
+            f32_ty,
+        );
+
+        let got = HostData::from_tensor_handle(&client, out_handle, HostDataType::F32);
+        let want = self.reference_padded(&input, &weight, in_len, padding);
+        for o in 0..self.oh {
+            for c in 0..self.co {
+                assert_eq!(
+                    got.get_f32(&[o, c]),
+                    want[o * self.co + c],
+                    "launched conv1d {schedule:?} padding {padding}: wrong at ({o}, {c})"
+                );
+            }
+        }
+    }
+}
+
+/// The plainest gather off the builder: nothing overhangs and the origin cannot go negative, so
+/// the derived check is off and the kernel's own extents are all runtime.
+#[test]
+fn conv1d_launched_dense_window() {
+    Conv1d {
+        oh: 8,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 1,
+        dilation: 1,
+    }
+    .check_launched(4, 4, 0, Schedule::Direct);
+}
+
+/// Stride and dilation both off `1`, staged: the affine advance and the compaction have to survive
+/// the dynamic space the launcher hands the kernel.
+#[test]
+fn conv1d_launched_staged_strided_and_dilated() {
+    Conv1d {
+        oh: 6,
+        co: 4,
+        rh: 4,
+        ci: 3,
+        stride: 3,
+        dilation: 2,
+    }
+    .check_launched(2, 2, 0, Schedule::Staged);
+}
+
+/// A padded window with no overhang anywhere: nothing about the tiling says the operand needs a
+/// check, so the mask is armed by the negative origin alone and the padded taps must read zero.
+#[test]
+fn conv1d_launched_padding_arms_the_check() {
+    Conv1d {
+        oh: 6,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 1,
+        dilation: 1,
+    }
+    .check_launched(3, 4, 1, Schedule::Direct);
+}
+
+/// An output extent the tile edge does not divide, so the overhang arms the check through the
+/// affine map: the tap that runs past the input reads `0` and the row that does not exist is not
+/// written.
+#[test]
+fn conv1d_launched_masked_overhang() {
+    Conv1d {
+        oh: 7,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 1,
+        dilation: 1,
+    }
+    .check_launched(4, 4, 0, Schedule::Direct);
+}
+
 // ---- runtime coefficients --------------------------------------------------
 
 /// [`conv_kernel`] with the input's stride and dilation arriving as runtime scalars rather than

--- a/crates/cubek-tile/tests/tile/conv.rs
+++ b/crates/cubek-tile/tests/tile/conv.rs
@@ -617,10 +617,17 @@ fn conv1d_masked_overhang_strided() {
 impl Conv1d {
     /// [`check_at`](Conv1d::check_at) driven end to end by [`Launcher`]: the input reaches the
     /// launch through [`StridedTileSource::gathered`] instead of a hand-built [`TileSpec`], so the
-    /// kernel projects from the kernel-form (fully dynamic) space and one compiled kernel serves
-    /// every shape. `padding` shifts the window's origin, which the builder's derived check has to
-    /// arm on by itself.
-    fn check_launched(&self, tile_oh: usize, tile_co: usize, padding: usize, schedule: Schedule) {
+    /// kernel projects from the kernel-form space and one compiled kernel serves every shape.
+    /// `padding` shifts the window's origin, which the builder's derived check has to arm on by
+    /// itself. `dynamic` is the axis set the kernel takes at runtime, `None` for all of them.
+    fn check_launched_over(
+        &self,
+        tile_oh: usize,
+        tile_co: usize,
+        padding: usize,
+        schedule: Schedule,
+        dynamic: Option<&[Axis]>,
+    ) {
         let client = <TestRuntime as Runtime>::client(&Default::default());
         let f32_ty = f32::as_type_native_unchecked().storage_type();
 
@@ -655,10 +662,13 @@ impl Conv1d {
             .zeros()
             .generate_without_host_data();
 
-        // `OH` and `RH` share the input's gathered dim, whose bound is the receptive field they
-        // reach over rather than either extent, so they reach the kernel static. `CO` no gathered
-        // operand spans and `CI` identity-maps a dim of its own, so both can go runtime.
-        let launch = space.launcher_over(&client, &[CO, CI]);
+        // Every axis here can go runtime, including the two the input gathers over: `OH` is stated
+        // by the output, which maps it identically, and `RH` by the weight. Only an axis no
+        // operand witnesses has to stay static, which is what `dynamic` narrows to.
+        let launch = match dynamic {
+            Some(axes) => space.launcher_over(&client, axes),
+            None => space.launcher(&client),
+        };
         let in_arg = launch
             .arg(in_handle.binding())
             .gathered(Projection::new(
@@ -704,6 +714,44 @@ impl Conv1d {
             }
         }
     }
+
+    /// [`check_launched_over`](Conv1d::check_launched_over) with every axis runtime.
+    fn check_launched(&self, tile_oh: usize, tile_co: usize, padding: usize, schedule: Schedule) {
+        self.check_launched_over(tile_oh, tile_co, padding, schedule, None);
+    }
+}
+
+/// The two axes the input gathers over, `OH` and `RH`, kept static while the rest goes runtime:
+/// the launch a gathered operand was restricted to before any operand could state a gathered axis'
+/// size. It has to keep working, since an axis no operand witnesses still has to reach the kernel
+/// static.
+#[test]
+fn conv1d_launched_static_window() {
+    Conv1d {
+        oh: 6,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 2,
+        dilation: 1,
+    }
+    .check_launched_over(3, 4, 0, Schedule::Direct, Some(&[CO, CI]));
+}
+
+/// The same convolution with `OH` and `RH` runtime as well, at a tiling neither divides: the walk
+/// counts are `div_ceil`s of sizes read off the output (`OH`) and the weight (`RH`), and the
+/// trailing partial tile is masked exactly as the static form's is.
+#[test]
+fn conv1d_launched_dynamic_window_masked_overhang() {
+    Conv1d {
+        oh: 7,
+        co: 4,
+        rh: 3,
+        ci: 2,
+        stride: 2,
+        dilation: 2,
+    }
+    .check_launched(4, 4, 1, Schedule::Direct);
 }
 
 /// The plainest gather off the builder: nothing overhangs and the origin cannot go negative, so

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -294,14 +294,14 @@ fn arg_gathered_validates_the_innermost_dim() {
         .build();
 }
 
-/// An axis sharing its dim with another has no extent of its own to read back at runtime, so the
-/// kernel space has to state it. Left [`Dynamic`], it would otherwise reach the kernel and wrongly size
-/// the window there, with nothing to report.
+/// An axis sharing its dim with another has no extent of its own to read back here, but the
+/// operand is free to ride it [`Dynamic`] anyway: whoever maps it identically states its size when
+/// the op walks it. The builder sees one operand, so it is not the place to rule on that; an axis
+/// no operand answers for is reported by `witnessed_space`, at expansion.
 #[test]
-#[should_panic(expected = "keep it static in the kernel space")]
-fn arg_gathered_dynamic_axis_panics() {
+fn arg_gathered_dynamic_axis_is_accepted() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
-    // `K` shares the gathered dim with `M`, so freeing it leaves neither an extent.
+    // `K` shares the gathered dim with `M`, so neither reads an extent off *this* operand.
     let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[N, K]);
     let _ = launch
         .arg(binding(&client, &[79, 64]))

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -5,7 +5,10 @@ use cubecl::{
     prelude::*,
     quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue},
 };
-use cubek_tile::{Axis, CubeAxis, Cut, DequantAt, Schedule, StridedOperand, Tiling, WalkOrder};
+use cubek_tile::{
+    Axis, Boundary, CubeAxis, Cut, DequantAt, Offset, PhysicalAxisMap, Projection, Scale, Schedule,
+    StridedOperand, Tiling, WalkOrder,
+};
 
 const M: Axis = Axis(0);
 const N: Axis = Axis(1);
@@ -36,6 +39,25 @@ fn launcher_kernel_space_is_dynamic_concrete_is_not() {
         assert!(!launch.concrete().is_dynamic(axis));
     }
     assert_eq!(launch.concrete().extent(M), 64);
+}
+
+#[test]
+fn launcher_over_frees_only_the_listed_axes() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[M, K]);
+
+    assert!(launch.space().is_dynamic(M));
+    assert!(launch.space().is_dynamic(K));
+    assert!(!launch.space().is_dynamic(N));
+}
+
+/// An axis the space does not have would be dropped silently, leaving the kernel specialized along
+/// the axis the caller meant to free.
+#[test]
+#[should_panic(expected = "is not an axis of this space")]
+fn launcher_over_unknown_axis_panics() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let _ = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[Axis(9)]);
 }
 
 /// The footgun the launcher removes: geometry read after `all_dynamic` has no extents to
@@ -138,6 +160,196 @@ fn arg_right_aligns_batches_and_drops_size_one() {
         .build();
     assert!(!broadcast.spec.axes().contains(&B0));
     assert!(!broadcast.spec.axes().contains(&B1));
+}
+
+// ---- StridedTileSource::gathered -------------------------------------------
+
+/// A convolution-shaped input over `batched_space`: output positions `M` at `stride` and taps `K`
+/// at `dilation` share one physical dim, channels `N` ride the other. Three logical axes over a
+/// rank-2 buffer, which no list of dim labels describes.
+fn window(stride: usize, dilation: usize, offset: impl Into<Offset>) -> Projection {
+    Projection::new(
+        &[M, K, N],
+        &[
+            PhysicalAxisMap::affine_with_offset(&[(M, stride), (K, dilation)], offset),
+            PhysicalAxisMap::of(N),
+        ],
+    )
+}
+
+/// The mapping reaches the spec as given: the buffer keeps its two dims and the tile spans the
+/// three logical axes, in the projection's own order.
+#[test]
+fn arg_gathered_states_its_own_mapping() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[N]);
+
+    let input = launch
+        .arg(binding(&client, &[79, 64]))
+        .gathered(window(1, 1, 0))
+        .build();
+
+    assert_eq!(input.spec.axes(), &[M, K, N]);
+    assert_eq!(input.spec.projection, window(1, 1, 0));
+    assert_eq!(input.spec.projection.physical_rank(), 2);
+    // Nothing overhangs and the origin cannot go negative, so the gather stays unchecked.
+    assert_eq!(input.spec.boundary, None);
+}
+
+/// An overhanging axis arms the check through the affine map just as it does through a label: the
+/// tap axis `K` is one of the two the gathered dim is addressed by.
+#[test]
+fn arg_gathered_derives_check_from_overhang() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    // k = 18 overhangs its leaf (4).
+    let launch = batched_space(1, 1, 64, 64, 18).launcher_over(&client, &[N]);
+
+    let input = launch
+        .arg(binding(&client, &[81, 64]))
+        .gathered(window(1, 1, 0))
+        .build();
+    assert_eq!(input.spec.boundary, Some(Boundary::Zero));
+
+    // An explicit override still wins over the derivation.
+    let forced = launch
+        .arg(binding(&client, &[81, 64]))
+        .gathered(window(1, 1, 0))
+        .checked(false)
+        .build();
+    assert_eq!(forced.spec.boundary, None);
+}
+
+/// A padded window reads before the buffer's start whatever the tiling divides, so the derivation
+/// arms on the offset's sign alone. A forward shift cannot underflow and stays unchecked.
+#[test]
+fn arg_gathered_derives_check_from_underflow() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[N]);
+
+    let padded = launch
+        .arg(binding(&client, &[64, 64]))
+        .gathered(window(1, 1, -1))
+        .build();
+    assert_eq!(padded.spec.boundary, Some(Boundary::Zero));
+
+    // A runtime offset's sign is unknown at launch, so it arms the guard conservatively.
+    let dynamic = launch
+        .arg(binding(&client, &[64, 64]))
+        .gathered(window(1, 1, Offset::Dynamic))
+        .build();
+    assert_eq!(dynamic.spec.boundary, Some(Boundary::Zero));
+
+    let shifted = launch
+        .arg(binding(&client, &[96, 64]))
+        .gathered(window(1, 1, 1))
+        .build();
+    assert_eq!(shifted.spec.boundary, None);
+}
+
+/// The stated mapping replaces the labeling whole, so a leftover `subspace` describes nothing and
+/// is refused rather than silently dropped.
+#[test]
+#[should_panic(expected = "nothing left to describe")]
+fn arg_gathered_alongside_a_subspace_panics() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[N]);
+    let _ = launch
+        .arg(binding(&client, &[79, 64]))
+        .subspace(&[M, N])
+        .gathered(window(1, 1, 0))
+        .build();
+}
+
+/// One map per buffer dim: a mapping that addresses fewer dims than the binding has would read
+/// every coarser stride as if it were the operand's own.
+#[test]
+#[should_panic(expected = "addresses 2 dims but the binding has 3")]
+fn arg_gathered_rank_mismatch_panics() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[N]);
+    let _ = launch
+        .arg(binding(&client, &[4, 79, 64]))
+        .gathered(window(1, 1, 0))
+        .build();
+}
+
+/// The gather contract runs on the caller's thread now that the builder knows the served width:
+/// the innermost dim is addressed in lines, so it must be one logical axis at coefficient 1.
+#[test]
+#[should_panic(expected = "innermost physical axis")]
+fn arg_gathered_validates_the_innermost_dim() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[M]);
+    let _ = launch
+        .arg(binding(&client, &[64, 79]))
+        .gathered(Projection::new(
+            &[M, K, N],
+            &[
+                PhysicalAxisMap::of(M),
+                PhysicalAxisMap::affine(&[(N, 1), (K, 2)]),
+            ],
+        ))
+        .vectorize(4)
+        .checked(false)
+        .build();
+}
+
+/// An axis sharing its dim with another has no extent of its own to read back at runtime, so the
+/// kernel space has to state it. Left [`Dynamic`], it would otherwise reach the kernel and mis-size
+/// the window there, with nothing to report.
+#[test]
+#[should_panic(expected = "keep it static in the kernel space")]
+fn arg_gathered_dynamic_axis_panics() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    // `K` shares the gathered dim with `M`, so freeing it leaves neither an extent.
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[N, K]);
+    let _ = launch
+        .arg(binding(&client, &[79, 64]))
+        .gathered(window(1, 1, 0))
+        .build();
+}
+
+/// The axis a gather does identity-map still reads its own extent, so it is free to stay runtime
+/// alongside the two that share a dim.
+#[test]
+fn arg_gathered_identity_axis_may_stay_dynamic() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[N]);
+
+    let input = launch
+        .arg(binding(&client, &[79, 64]))
+        .gathered(window(1, 1, 0))
+        .build();
+    assert_eq!(input.spec.axes(), &[M, K, N]);
+    assert!(launch.space().is_dynamic(N));
+    assert!(!launch.space().is_dynamic(M));
+}
+
+/// A runtime coefficient leaves the compacted window with no comptime extent, so the smem it would
+/// be staged into cannot be sized. Reported here rather than at the stage, on the caller's thread.
+#[test]
+#[should_panic(expected = "cannot be staged")]
+fn arg_gathered_dynamic_coefficient_cannot_stage() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let staged = Tiling::new()
+        .extents(&[(M, 64), (N, 64), (K, 16)])
+        .level(WalkOrder::RowMajor, Schedule::Staged, |l| {
+            l.axis(M, Cut::cube(CubeAxis::X, 16))
+                .axis(N, Cut::cube(CubeAxis::Y, 32))
+                .axis(K, Cut::sequential(16))
+        })
+        .build()
+        .launcher_over(&client, &[N]);
+    let _ = staged
+        .arg(binding(&client, &[79, 64]))
+        .gathered(Projection::new(
+            &[M, K, N],
+            &[
+                PhysicalAxisMap::scaled(&[(M, Scale::Dynamic), (K, Scale::Dynamic)]),
+                PhysicalAxisMap::of(N),
+            ],
+        ))
+        .build();
 }
 
 // ---- Launcher::vector_size -------------------------------------------------

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -295,7 +295,7 @@ fn arg_gathered_validates_the_innermost_dim() {
 }
 
 /// An axis sharing its dim with another has no extent of its own to read back at runtime, so the
-/// kernel space has to state it. Left [`Dynamic`], it would otherwise reach the kernel and mis-size
+/// kernel space has to state it. Left [`Dynamic`], it would otherwise reach the kernel and wrongly size
 /// the window there, with nothing to report.
 #[test]
 #[should_panic(expected = "keep it static in the kernel space")]


### PR DESCRIPTION
Stacked on #478.

A gathered operand (conv, resample) maps several logical axes onto one buffer dim: `Ih <- Oh*stride + Rh*dilation - padding`. No list of dim labels describes that, so until now it could only reach a kernel through a hand-built `TileSpec`.

## `StridedTileSource::gathered`

Takes the `Projection` outright, filling the same typestate slot as `subspace`:

```rust
launch.arg(input.binding())
    .gathered(Projection::new(
        &[OH, RH, CI],
        &[
            PhysicalAxisMap::affine_with_offset(&[(OH, stride), (RH, dilation)], -padding),
            PhysicalAxisMap::of(CI),
        ],
    ))
    .build()
```

`subspace`, `batches` and `tiling` describe a mapping this one supplies whole, so setting them alongside it is refused rather than silently dropped. Everything else composes as before.

The derived bounds-check gains one arm: a projection that may underflow reads before the buffer's start whatever the tiling does, so padding arms the mask on its own.

## `Space::launcher_over`

`launcher` with only the listed axes made dynamic. A gathered dim's bound is the receptive field its axes reach over, not any one axis's extent, so an axis sharing a dim has nothing to report at runtime and must reach the kernel static:

```rust
// OH and RH share the input's gathered dim; CO and CI can go runtime.
let launch = space.launcher_over(&client, &[CO, CI]);
```

Building refuses a mapping the space contradicts, so getting this wrong is a launch-time panic naming the axis rather than a wrong answer in the kernel.

## Also

- `TileSpec::from_concrete` folded into the builder, its two callers now going through `gathered` or the label path.
- `Tile::runtime_extent` finds an axis's bound through the projection rather than the space, which is what lets a gathered operand be indexed at all.

## Tests

Eleven builder tests over `gathered` and `launcher_over` (mapping passthrough, the two bounds-check derivations, and each refusal), plus four end-to-end conv1d launches: dense, staged with stride and dilation, padding arming the mask, and a masked overhang.
