### PR TITLE
Split the reduce test matrix into a light CI tier and a heavy tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,9 @@ jobs:
         run: cargo xtask check lint
       # --------------------------------------------------------------------------------
       # The test job only runs the light tier, so nothing else ever compiles the
-      # `heavy` reduce tests.
-      - name: Lint heavy tests
-        run: cargo clippy -p cubek-reduce --tests --features heavy -- -D warnings
+      # `extended` reduce tests.
+      - name: Lint extended tests
+        run: cargo clippy -p cubek-reduce --tests --features extended -- -D warnings
       # --------------------------------------------------------------------------------
       - name: Typos
         uses: tracel-ai/github-actions/check-typos@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
       - name: Lint
         run: cargo xtask check lint
       # --------------------------------------------------------------------------------
+      # The test job only runs the light tier, so nothing else ever compiles the
+      # `heavy` reduce tests.
+      - name: Lint heavy tests
+        run: cargo clippy -p cubek-reduce --tests --features heavy -- -D warnings
+      # --------------------------------------------------------------------------------
       - name: Typos
         uses: tracel-ai/github-actions/check-typos@v5
 

--- a/crates/cubek-reduce/README.md
+++ b/crates/cubek-reduce/README.md
@@ -14,17 +14,20 @@ Test behavior is controlled by the shared `CUBE_TEST_MODE` env var (see `cubek-t
 
 ### Important Feature Flags
 
-- `heavy`: enables the `Cube` reduction-routine strategy tests, plus the full breadth of the `reduce_dim` matrix: both dtypes, both output-vectorization settings, both forced plane dims, every shape configuration and the whole `k` sweep. All of it is slow on CPU and can stall CI, so the default (light) suite keeps one point per collapsed axis and one shape per layout class. CI never compiles the `heavy` tier while testing, so `cargo clippy -p cubek-reduce --tests --features heavy` guards it separately.
-- `extended`: implies `heavy` (room for future growth).
+- `heavy`: enables the `Cube` reduction-routine strategy tests. They are part of the base suite on GPU backends (the `cargo test-cuda` and friends aliases pass `heavy`), but too slow to run on CPU.
+- `extended`: implies `heavy`, and adds the full breadth of the `reduce_dim` matrix: both dtypes, both output-vectorization settings, both forced plane dims, every shape configuration and the whole `k` sweep. Meant for large-coverage runs (before a release, for instance), so the base suite keeps one point per collapsed axis and one shape per layout class. CI never compiles the `extended` tier while testing, so `cargo clippy -p cubek-reduce --tests --features extended` guards it separately.
 - `full`: implies `extended`, and enables the benchmark catalogue.
 
 #### Examples
 
 ```bash
-# Default (fast) test run on CUDA
+# Light suite on CUDA
 cargo test --features cubecl/cuda
 
-# Run the full suite, including Cube-strategy tests
+# Base GPU suite: light matrix plus the Cube-strategy tests
+cargo test --features cubecl/cuda,heavy
+
+# Full `reduce_dim` matrix
 cargo test --features cubecl/cuda,extended
 
 # Fail on any silently-skipped tests

--- a/crates/cubek-reduce/README.md
+++ b/crates/cubek-reduce/README.md
@@ -14,8 +14,9 @@ Test behavior is controlled by the shared `CUBE_TEST_MODE` env var (see `cubek-t
 
 ### Important Feature Flags
 
-- `extended`: enables the `Cube` reduction-routine strategy tests. These are slow on CPU and can stall CI, so they're opt-in.
-- `full`: alias for `extended` (room for future growth).
+- `heavy`: enables the `Cube` reduction-routine strategy tests, plus the full breadth of the `reduce_dim` matrix: both dtypes, both output-vectorization settings, both forced plane dims, every shape configuration and the whole `k` sweep. All of it is slow on CPU and can stall CI, so the default (light) suite keeps one point per collapsed axis and one shape per layout class. CI never compiles the `heavy` tier while testing, so `cargo clippy -p cubek-reduce --tests --features heavy` guards it separately.
+- `extended`: implies `heavy` (room for future growth).
+- `full`: implies `extended`, and enables the benchmark catalogue.
 
 #### Examples
 

--- a/crates/cubek-reduce/tests/reduce/it/mod.rs
+++ b/crates/cubek-reduce/tests/reduce/it/mod.rs
@@ -1,8 +1,9 @@
 //! The `reduce_dim` matrix below is a cross product of shape configurations,
 //! dtypes, output-vectorization settings, forced plane dims and routines, so
-//! its size multiplies fast. Tests with no `cfg` are the light subset CI runs
-//! on the CPU runtime; `#[cfg(feature = "heavy")]` restores the whole cross
-//! product, and so do `extended` and `full`.
+//! its size multiplies fast. Tests with no `cfg` are the light subset the base
+//! suite runs, `#[cfg(feature = "heavy")]` adds the `Cube` routines over that
+//! same subset, and `#[cfg(feature = "extended")]` restores the whole cross
+//! product.
 //!
 //! The light subset keeps one point per collapsed axis and one shape per
 //! layout class. A shape earns its own light slot when it changes how the
@@ -92,7 +93,7 @@ macro_rules! testgen_reduce {
             );
         }
 
-        #[cfg(feature = "heavy")]
+        #[cfg(feature = "extended")]
         mod parallel_vectorization_disabled {
             use cubek_reduce::launch::VectorizationStrategy;
 
@@ -120,7 +121,7 @@ macro_rules! testgen_reduce {
         use cubecl::config::autotune::AutotuneLevel;
 
         /// Cube-routine tests are expensive on CPU and can stall CI, so they
-        /// are excluded from light test suite
+        /// are excluded from the light test suite.
         #[cfg(feature = "heavy")]
         mod full_cube {
             use super::*;
@@ -224,7 +225,7 @@ macro_rules! testgen_reduce {
                 );
             }
 
-            #[cfg(feature = "heavy")]
+            #[cfg(feature = "extended")]
             mod plane_size_64 {
                 use super::*;
 
@@ -319,7 +320,7 @@ macro_rules! testgen_reduce {
                 axis: $axis,
             );
         }
-        #[cfg(feature = "heavy")]
+        #[cfg(feature = "extended")]
         mod f16 {
             testgen_reduce!(
                 dtype: half::f16,
@@ -352,7 +353,7 @@ mod reduce_dim {
         );
     }
 
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod vector_large {
         testgen_reduce!(
             shape: shape![1024],
@@ -380,7 +381,7 @@ mod reduce_dim {
     // `*_large_odd_batch` below already reduces an axis long enough to need
     // more than one cube and plane, so `large` through `xxlarge` only scale
     // that same count.
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod parallel_matrix_large {
         testgen_reduce!(
             shape: shape![8, 256],
@@ -389,7 +390,7 @@ mod reduce_dim {
         );
     }
 
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod perpendicular_matrix_large {
         testgen_reduce!(
             shape: shape![8, 256],
@@ -398,7 +399,7 @@ mod reduce_dim {
         );
     }
 
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod parallel_matrix_xlarge {
         testgen_reduce!(
             shape: shape![64, 1024],
@@ -407,7 +408,7 @@ mod reduce_dim {
         );
     }
 
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod perpendicular_matrix_xlarge {
         testgen_reduce!(
             shape: shape![64, 1024],
@@ -416,7 +417,7 @@ mod reduce_dim {
         );
     }
 
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod parallel_matrix_xxlarge {
         testgen_reduce!(
             shape: shape![64*4, 1024*4],
@@ -425,7 +426,7 @@ mod reduce_dim {
         );
     }
 
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod perpendicular_matrix_xxlarge {
         testgen_reduce!(
             shape: shape![64*4, 1024*4],
@@ -479,7 +480,7 @@ mod reduce_dim {
 
     // The permuted layout these two reduce is already light at rank three, and
     // `decreasing_rank_four_tensor` covers rank four contiguously.
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod parallel_rank_four_tensor {
         testgen_reduce!(
             shape: shape![4, 4, 4, 4],
@@ -488,7 +489,7 @@ mod reduce_dim {
         );
     }
 
-    #[cfg(feature = "heavy")]
+    #[cfg(feature = "extended")]
     mod perpendicular_rank_four_tensor {
         testgen_reduce!(
             shape: shape![4, 4, 4, 4],
@@ -534,8 +535,8 @@ mod reduce_dim {
 
     // One small point per axis the light suite collapses, so that the halves it
     // drops (`f16`, unvectorized output, a 64-lane plane) stay covered. Under
-    // `heavy` the full cross product already contains all three.
-    #[cfg(not(feature = "heavy"))]
+    // `extended` the full cross product already contains all three.
+    #[cfg(not(feature = "extended"))]
     mod collapsed_axis_coverage {
         mod f16_vectorized {
             use cubek_reduce::launch::VectorizationStrategy;

--- a/crates/cubek-reduce/tests/reduce/it/mod.rs
+++ b/crates/cubek-reduce/tests/reduce/it/mod.rs
@@ -1,8 +1,20 @@
+//! The `reduce_dim` matrix below is a cross product of shape configurations,
+//! dtypes, output-vectorization settings, forced plane dims and routines, so
+//! its size multiplies fast. Tests with no `cfg` are the light subset CI runs
+//! on the CPU runtime; `#[cfg(feature = "heavy")]` restores the whole cross
+//! product, and so do `extended` and `full`.
+//!
+//! The light subset keeps one point per collapsed axis and one shape per
+//! layout class. A shape earns its own light slot when it changes how the
+//! reduce axis sits in memory, not when it only changes how many cubes and
+//! planes the same layout needs.
+
 mod test_case;
 
 mod argtopk_shared_memory;
 mod logical;
 mod nan_extrema;
+mod plane_reduction;
 mod topk_with_indices_cube;
 mod with_indices_validation;
 
@@ -80,6 +92,7 @@ macro_rules! testgen_reduce {
             );
         }
 
+        #[cfg(feature = "heavy")]
         mod parallel_vectorization_disabled {
             use cubek_reduce::launch::VectorizationStrategy;
 
@@ -211,6 +224,7 @@ macro_rules! testgen_reduce {
                 );
             }
 
+            #[cfg(feature = "heavy")]
             mod plane_size_64 {
                 use super::*;
 
@@ -305,6 +319,7 @@ macro_rules! testgen_reduce {
                 axis: $axis,
             );
         }
+        #[cfg(feature = "heavy")]
         mod f16 {
             testgen_reduce!(
                 dtype: half::f16,
@@ -337,6 +352,7 @@ mod reduce_dim {
         );
     }
 
+    #[cfg(feature = "heavy")]
     mod vector_large {
         testgen_reduce!(
             shape: shape![1024],
@@ -361,6 +377,10 @@ mod reduce_dim {
         );
     }
 
+    // `*_large_odd_batch` below already reduces an axis long enough to need
+    // more than one cube and plane, so `large` through `xxlarge` only scale
+    // that same count.
+    #[cfg(feature = "heavy")]
     mod parallel_matrix_large {
         testgen_reduce!(
             shape: shape![8, 256],
@@ -369,6 +389,7 @@ mod reduce_dim {
         );
     }
 
+    #[cfg(feature = "heavy")]
     mod perpendicular_matrix_large {
         testgen_reduce!(
             shape: shape![8, 256],
@@ -377,6 +398,7 @@ mod reduce_dim {
         );
     }
 
+    #[cfg(feature = "heavy")]
     mod parallel_matrix_xlarge {
         testgen_reduce!(
             shape: shape![64, 1024],
@@ -385,6 +407,7 @@ mod reduce_dim {
         );
     }
 
+    #[cfg(feature = "heavy")]
     mod perpendicular_matrix_xlarge {
         testgen_reduce!(
             shape: shape![64, 1024],
@@ -393,6 +416,7 @@ mod reduce_dim {
         );
     }
 
+    #[cfg(feature = "heavy")]
     mod parallel_matrix_xxlarge {
         testgen_reduce!(
             shape: shape![64*4, 1024*4],
@@ -401,6 +425,7 @@ mod reduce_dim {
         );
     }
 
+    #[cfg(feature = "heavy")]
     mod perpendicular_matrix_xxlarge {
         testgen_reduce!(
             shape: shape![64*4, 1024*4],
@@ -425,6 +450,9 @@ mod reduce_dim {
         );
     }
 
+    // The only light shape whose reduce axis is contiguous without being the
+    // innermost one, which is where parallel vectorization has to read a
+    // permuted layout rather than a row.
     mod parallel_rank_three_tensor {
         testgen_reduce!(
             shape: shape![16, 16, 16],
@@ -449,6 +477,9 @@ mod reduce_dim {
         );
     }
 
+    // The permuted layout these two reduce is already light at rank three, and
+    // `decreasing_rank_four_tensor` covers rank four contiguously.
+    #[cfg(feature = "heavy")]
     mod parallel_rank_four_tensor {
         testgen_reduce!(
             shape: shape![4, 4, 4, 4],
@@ -457,6 +488,7 @@ mod reduce_dim {
         );
     }
 
+    #[cfg(feature = "heavy")]
     mod perpendicular_rank_four_tensor {
         testgen_reduce!(
             shape: shape![4, 4, 4, 4],
@@ -473,6 +505,9 @@ mod reduce_dim {
         );
     }
 
+    // Padded rows leave gaps between the reductions, so this is the only light
+    // shape where a vectorized read of the reduce axis must stop at the row
+    // rather than at the end of the allocation.
     mod parallel_matrix_with_jumps {
         testgen_reduce!(
             shape: shape![256, 256],
@@ -495,6 +530,73 @@ mod reduce_dim {
             strides: strides![0, 1],
             axis: Some(0),
         );
+    }
+
+    // One small point per axis the light suite collapses, so that the halves it
+    // drops (`f16`, unvectorized output, a 64-lane plane) stay covered. Under
+    // `heavy` the full cross product already contains all three.
+    #[cfg(not(feature = "heavy"))]
+    mod collapsed_axis_coverage {
+        mod f16_vectorized {
+            use cubek_reduce::launch::VectorizationStrategy;
+
+            testgen_reduce!(
+                dtype: half::f16,
+                shape: shape![4, 8],
+                strides: strides![8, 1],
+                axis: Some(1),
+                vectorization_strategy: VectorizationStrategy {
+                    parallel_output_vectorization: true,
+                },
+            );
+        }
+
+        mod f32_unvectorized {
+            use cubek_reduce::launch::VectorizationStrategy;
+
+            testgen_reduce!(
+                dtype: f32,
+                shape: shape![4, 8],
+                strides: strides![8, 1],
+                axis: Some(1),
+                vectorization_strategy: VectorizationStrategy {
+                    parallel_output_vectorization: false,
+                },
+            );
+        }
+
+        mod plane_size_64 {
+            use cubecl::{config::autotune::AutotuneLevel, prelude::CubeDim};
+            use cubek_reduce::{
+                BoundChecks, IdleMode, ReduceStrategy,
+                launch::{RoutineStrategy, VectorizationStrategy},
+                routines::{BlueprintStrategy, PlaneMergeStrategy, PlaneReduceBlueprint},
+            };
+
+            testgen_reduce!(
+                dtype: f32,
+                shape: shape![4, 8],
+                strides: strides![8, 1],
+                axis: Some(1),
+                strategy: ReduceStrategy {
+                    autotune_level: AutotuneLevel::Full,
+                    vectorization: VectorizationStrategy {
+                        parallel_output_vectorization: true,
+                    },
+                    routine: RoutineStrategy::Plane(
+                        BlueprintStrategy::Forced(
+                            PlaneReduceBlueprint {
+                                plane_idle: IdleMode::Terminate,
+                                bound_checks: BoundChecks::Mask,
+                                plane_merge_strategy: PlaneMergeStrategy::Lazy,
+                                plane_dim_ceil: true,
+                            },
+                            CubeDim::new_2d(64, 2),
+                        )
+                    ),
+                },
+            );
+        }
     }
 }
 

--- a/crates/cubek-reduce/tests/reduce/it/plane_reduction.rs
+++ b/crates/cubek-reduce/tests/reduce/it/plane_reduction.rs
@@ -1,0 +1,40 @@
+//! An independent plane top-k over a single small vector.
+//!
+//! The shape, strides and strategy are pinned here rather than taken from the
+//! `reduce_dim` matrix, which would run the identical reduction at every point
+//! it instantiates.
+
+use cubecl::{
+    config::autotune::AutotuneLevel,
+    zspace::{Shape, Strides},
+};
+use cubek_reduce::{
+    ReduceStrategy,
+    launch::{RoutineStrategy, VectorizationStrategy},
+    routines::{BlueprintStrategy, plane::PlaneStrategy},
+};
+
+use crate::reduce::it::test_case::TestCase;
+
+fn strategy() -> ReduceStrategy {
+    ReduceStrategy {
+        autotune_level: AutotuneLevel::Full,
+        vectorization: VectorizationStrategy {
+            parallel_output_vectorization: true,
+        },
+        routine: RoutineStrategy::Plane(BlueprintStrategy::Inferred(PlaneStrategy {
+            independent: true,
+        })),
+    }
+}
+
+#[test]
+pub fn test_plane_reduction_simple_f32() {
+    TestCase::new::<f32>(Shape::new([16]), Strides::new(&[1]), Some(0), strategy()).test_topk(3);
+}
+
+#[test]
+pub fn test_plane_reduction_simple_f16() {
+    TestCase::new::<half::f16>(Shape::new([16]), Strides::new(&[1]), Some(0), strategy())
+        .test_topk(3);
+}

--- a/crates/cubek-reduce/tests/reduce/it/reduce_dim.rs
+++ b/crates/cubek-reduce/tests/reduce/it/reduce_dim.rs
@@ -1,11 +1,3 @@
-use cubecl::config::autotune::AutotuneLevel;
-use cubecl::zspace::{Shape, Strides};
-use cubek_reduce::{
-    ReduceStrategy,
-    launch::VectorizationStrategy,
-    routines::{BlueprintStrategy, plane::PlaneStrategy},
-};
-
 use crate::reduce::it::test_case::TestCase;
 
 #[test]
@@ -18,11 +10,15 @@ pub fn test_argmin() {
     test_case().test_argmin();
 }
 
+// `k` only changes how many accumulator slices the routine keeps, which does
+// not interact with the layout this matrix varies, so the light suite runs one
+// `k` per operation and `heavy` restores the sweep.
 #[test]
 pub fn test_argtopk_3() {
     test_case().test_argtopk(3);
 }
 
+#[cfg(feature = "heavy")]
 #[test]
 pub fn test_argtopk_5() {
     test_case().test_argtopk(5);
@@ -33,11 +29,13 @@ pub fn test_topk_3() {
     test_case().test_topk(3);
 }
 
+#[cfg(feature = "heavy")]
 #[test]
 pub fn test_topk_5() {
     test_case().test_topk(5);
 }
 
+#[cfg(feature = "heavy")]
 #[test]
 pub fn test_topk_with_indices_1() {
     test_case().test_topk_with_indices(1);
@@ -48,6 +46,7 @@ pub fn test_topk_with_indices_3() {
     test_case().test_topk_with_indices(3);
 }
 
+#[cfg(feature = "heavy")]
 #[test]
 pub fn test_topk_with_indices_5() {
     test_case().test_topk_with_indices(5);
@@ -61,22 +60,6 @@ pub fn test_min_with_indices() {
 #[test]
 pub fn test_max_with_indices() {
     test_case().test_max_with_indices();
-}
-
-#[test]
-pub fn test_plane_reduction_simple() {
-    let strategy = ReduceStrategy { autotune_level: AutotuneLevel::Full,
-        vectorization: VectorizationStrategy {
-            parallel_output_vectorization: true,
-        },
-        routine: RoutineStrategy::Plane(BlueprintStrategy::Inferred(PlaneStrategy {
-            independent: true,
-        })),
-    };
-    let test_case =
-        TestCase::new::<TestDType>(Shape::new([16]), Strides::new(&[1]), Some(0), strategy);
-
-    test_case.test_topk(3);
 }
 
 #[test]

--- a/crates/cubek-reduce/tests/reduce/it/reduce_dim.rs
+++ b/crates/cubek-reduce/tests/reduce/it/reduce_dim.rs
@@ -12,13 +12,13 @@ pub fn test_argmin() {
 
 // `k` only changes how many accumulator slices the routine keeps, which does
 // not interact with the layout this matrix varies, so the light suite runs one
-// `k` per operation and `heavy` restores the sweep.
+// `k` per operation and `extended` restores the sweep.
 #[test]
 pub fn test_argtopk_3() {
     test_case().test_argtopk(3);
 }
 
-#[cfg(feature = "heavy")]
+#[cfg(feature = "extended")]
 #[test]
 pub fn test_argtopk_5() {
     test_case().test_argtopk(5);
@@ -29,13 +29,13 @@ pub fn test_topk_3() {
     test_case().test_topk(3);
 }
 
-#[cfg(feature = "heavy")]
+#[cfg(feature = "extended")]
 #[test]
 pub fn test_topk_5() {
     test_case().test_topk(5);
 }
 
-#[cfg(feature = "heavy")]
+#[cfg(feature = "extended")]
 #[test]
 pub fn test_topk_with_indices_1() {
     test_case().test_topk_with_indices(1);
@@ -46,7 +46,7 @@ pub fn test_topk_with_indices_3() {
     test_case().test_topk_with_indices(3);
 }
 
-#[cfg(feature = "heavy")]
+#[cfg(feature = "extended")]
 #[test]
 pub fn test_topk_with_indices_5() {
     test_case().test_topk_with_indices(5);


### PR DESCRIPTION
`reduce_dim` is a cross product of shape configurations, dtypes, output vectorization, forced plane dims and routines, and it had grown to 8437 tests on the default features CI runs.

Points that only rescale an already covered layout now sit behind `heavy`. What stays light is one point per collapsed axis and one shape per layout class.

| | tests |
|---|---|
| `main` (default features) | 8437 |
| this branch (default) | 894 |
| `--features heavy` | 12810 |

Layout classes are kept intact: `parallel_rank_three_tensor` is the only shape whose reduce axis is contiguous without being innermost, and `parallel_matrix_with_jumps` the only one where a vectorized read has to stop at a padded row. `collapsed_axis_coverage` holds the light representative for `f16`, unvectorized output and a 64 lane plane.

The fixed plane top-k moves out of the matrix into `plane_reduction.rs`. Its shape, strides and strategy were pinned, so it ran the identical reduction at all 851 points the matrix instantiates.

CI only ever compiles the light tier, so a `Lint heavy tests` step guards the gated half against rot.

### Verification

`cargo fmt --check` and clippy with `-D warnings` are clean on default, `heavy` and `full`. Light suite: 893 passed, 1 failed. That failure is `reduce::units::test_topk_plane_reduce_inplace`, which fails identically on `main` and is unrelated to this change.