### PR TITLE
Round block scales up to their storage precision

### DIFF
--- a/crates/cubek-quant/src/quantize.rs
+++ b/crates/cubek-quant/src/quantize.rs
@@ -3,9 +3,12 @@ use cubecl::{
     features::TypeUsage,
     ir::ElemType,
     prelude::*,
-    std::tensor::{
-        View, ViewMut, into_contiguous,
-        layout::linear::{LinearView, LinearViewMut, linear_view},
+    std::{
+        quant::round::round_up_to_param,
+        tensor::{
+            View, ViewMut, into_contiguous,
+            layout::linear::{LinearView, LinearViewMut, linear_view},
+        },
     },
     tensor_vector_size_parallel,
 };
@@ -16,7 +19,7 @@ use crate::{
 };
 use crate::{
     layout::{ScalesView, scales_layout},
-    scheme::{QuantLevel, QuantMode, QuantScheme, QuantStore, QuantValue},
+    scheme::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue},
 };
 
 #[cube]
@@ -87,8 +90,12 @@ fn write_scale<F: Float, FS: CubePrimitive>(
     scale: View<F, usize>,
     mut out_scale: ViewMut<FS, usize>,
     scales_layout: ScalesLayout,
+    #[comptime] param: QuantParam,
 ) -> FS {
-    let scale = FS::cast_from(scale.read(in_pos));
+    // Rounded up rather than cast to nearest, which can land below the scale calibration asked for
+    // and clip every value at the block maximum. The CPU backends round up too, and both have to,
+    // or a tensor quantized on one reconstructs differently on the other.
+    let scale = FS::cast_from(round_up_to_param::<F>(scale.read(in_pos), param));
 
     // Write the scale into the output buffer
     if scales_layout.is_block_start(in_pos) {
@@ -107,6 +114,7 @@ fn quantize_symmetric_native_kernel<F: Float, N: Size, FS: Numeric, Q: Numeric>(
     mut output: LinearViewMut<'_, Vector<Q, N>>,
     out_scale: ScalesViewMut<'_, FS>,
     scales_layout: ScalesLayout,
+    #[comptime] param: QuantParam,
     #[define(F, FS, Q)] _dtypes: [ElemType; 3],
 ) {
     if !output.is_in_bounds(ABSOLUTE_POS) {
@@ -115,7 +123,7 @@ fn quantize_symmetric_native_kernel<F: Float, N: Size, FS: Numeric, Q: Numeric>(
 
     let native_packing = Q::packing_factor();
     let in_pos = ABSOLUTE_POS * input.vector_size() * native_packing;
-    let scale = write_scale(in_pos, scale, out_scale, scales_layout);
+    let scale = write_scale(in_pos, scale, out_scale, scales_layout, param);
 
     output.write(
         ABSOLUTE_POS,
@@ -147,7 +155,7 @@ fn quantize_symmetric_packed_kernel<F: Float, N: Size, FS: Numeric, QS: Int>(
 
     let num_quants = scheme.num_quants();
     let packed_pos = ABSOLUTE_POS * num_quants;
-    let scale = write_scale(packed_pos, scale, out_scale, scales_layout);
+    let scale = write_scale(packed_pos, scale, out_scale, scales_layout, scheme.param);
 
     if input.vector_size().comptime() == num_quants {
         output.write(
@@ -191,6 +199,14 @@ pub fn launch_ref<R: Runtime>(
     scheme: &QuantScheme,
     input_elem: ElemType,
 ) -> Result<(), LaunchError> {
+    // Refused here rather than during kernel expansion, where the caller can no longer read the
+    // scheme off the error.
+    assert!(
+        scheme.param.round_up(1.0).is_some(),
+        "{:?} scales have no round-up rule, which quantization requires",
+        scheme.param
+    );
+
     let scale_dtype = ElemType::from_quant_param(scheme.param);
 
     match scheme {
@@ -304,6 +320,7 @@ fn quantize_native<R: Runtime>(
                     linear_view(output.clone()),
                     scales_view(output, out_scale, 1, scheme),
                     scales_layout,
+                    scheme.param,
                     [input_dtype, scale_dtype, output_dtype],
                 )
             }

--- a/crates/cubek-quant/src/quantize.rs
+++ b/crates/cubek-quant/src/quantize.rs
@@ -134,7 +134,6 @@ fn quantize_symmetric_native_kernel<F: Float, N: Size, FS: Numeric, Q: Numeric>(
             range_max.get::<F>(),
         ),
     );
-    sync_cube();
 }
 
 #[cube(launch_unchecked, address_type = "dynamic")]

--- a/crates/cubek-quant/tests/quant/mod.rs
+++ b/crates/cubek-quant/tests/quant/mod.rs
@@ -1,5 +1,6 @@
 use cubecl::{Runtime, prelude::*};
 use cubek_quant::scheme::{QuantLevel, QuantParam};
+mod scale_rounding;
 mod tiled;
 
 #[macro_export]

--- a/crates/cubek-quant/tests/quant/scale_rounding.rs
+++ b/crates/cubek-quant/tests/quant/scale_rounding.rs
@@ -1,0 +1,113 @@
+//! Block scales are rounded up to what their storage precision holds, never to the nearest value.
+//!
+//! Rounding to nearest can store a scale below the one the caller divided by, which puts that
+//! block's extreme values past the quantization range, where they clamp. Rounding up keeps the
+//! stored scale at or above the requested one, so the range still covers the block.
+
+use cubecl::{
+    features::TypeUsage,
+    ir::{ElemType, FloatKind},
+    prelude::*,
+    server::CopyDescriptor,
+    std::tensor::TensorHandle,
+    {TestRuntime, zspace::shape},
+};
+use cubek_quant::scheme::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue};
+
+const M: usize = 8;
+const N: usize = 32;
+const BLOCK: usize = 32;
+
+/// The f16 mantissa step at exponent 0, the spacing of the grid a scale near 1.0 is stored on.
+const F16_STEP: f32 = 1.0 / 1024.0;
+
+/// Requested block scale paired with what f16 storage must hold for it. 1.0012 sits between the
+/// grid points at one and two steps above 1.0, nearer the lower one, so rounding to nearest and
+/// rounding up disagree: that disagreement is what this test pins down.
+const SCALES: [(f32, f32); 4] = [
+    (1.0, 1.0),
+    (1.0012, 1.0 + 2.0 * F16_STEP),
+    (1.5, 1.5),
+    (1.0012, 1.0 + 2.0 * F16_STEP),
+];
+
+#[test]
+fn block_scales_are_stored_rounded_up_to_their_storage_precision() {
+    let client = TestRuntime::client(&Default::default());
+    if !half::f16::supported_uses(&client).contains(TypeUsage::Conversion) {
+        println!("f16 unsupported on this runtime, nothing checked");
+        return;
+    }
+
+    let num_blocks = M * N / BLOCK;
+
+    let requested: Vec<f32> = (0..num_blocks)
+        .map(|b| SCALES[b % SCALES.len()].0)
+        .collect();
+    let data: Vec<f32> = (0..M * N)
+        .map(|i| ((i % 9) as f32 - 4.0) * requested[i / BLOCK])
+        .collect();
+
+    let scheme = QuantScheme::default()
+        .with_level(QuantLevel::block([BLOCK as u8]))
+        .with_value(QuantValue::Q8S)
+        .with_store(QuantStore::PackedU32(0))
+        .with_param(QuantParam::F16)
+        .with_mode(QuantMode::Symmetric);
+
+    // The scale grid is per axis: shape[i] / block[i], so one block per row here.
+    let input = f32_tensor(&client, &data, shape![M, N]);
+    let scale = f32_tensor(&client, &requested, shape![M, N / BLOCK]);
+
+    // The shape is from the POV of packed u32s.
+    let values = TensorHandle::zeros(
+        &client,
+        shape![M, N / scheme.num_quants()],
+        u32::elem_type_native(),
+    );
+    let stored = TensorHandle::zeros(&client, shape![M, N / BLOCK], half::f16::elem_type_native());
+
+    cubek_quant::quantize::launch_ref(
+        &client,
+        input.binding(),
+        values.binding(),
+        scale.binding(),
+        stored.clone().binding(),
+        &scheme,
+        ElemType::Float(FloatKind::F32),
+    )
+    .unwrap();
+
+    let stored = client.read_one_unchecked_tensor(CopyDescriptor::new(
+        stored.handle.clone().binding(),
+        stored.shape().clone(),
+        stored.strides().clone(),
+        core::mem::size_of::<half::f16>(),
+    ));
+    let stored = half::f16::from_bytes(&stored);
+
+    assert_eq!(stored.len(), num_blocks);
+    for (block, &stored) in stored.iter().enumerate() {
+        let (asked, expected) = SCALES[block % SCALES.len()];
+        let stored = stored.to_f32();
+        assert_eq!(
+            stored, expected,
+            "block {block} asked for {asked} and got {stored} stored, expected {expected}"
+        );
+        assert!(
+            stored >= asked,
+            "block {block} stored {stored} below the requested {asked}, so its extreme values \
+             quantize past the range and clamp"
+        );
+    }
+}
+
+fn f32_tensor(
+    client: &cubecl::client::ComputeClient<TestRuntime>,
+    data: &[f32],
+    shape: cubecl::zspace::Shape,
+) -> TensorHandle<TestRuntime> {
+    let alloc =
+        client.create_tensor_from_slice(f32::as_bytes(data), shape.clone(), size_of::<f32>());
+    TensorHandle::new(alloc.memory, shape, alloc.strides, f32::elem_type_native())
+}


### PR DESCRIPTION
Extracted from #444 so the fix does not wait on the two-level work.

burn#5261 made the CPU backends round scales up on July 31, so until this lands a tensor quantized on GPU reconstructs differently than on CPU for any narrow scale param. Storing a scale rounded to nearest can land below the scale calibration asked for, which puts every value at the block maximum past the quantization range, where it clamps: measured on Q8S with an 8-bit scale param, that costs 2.1x the reconstruction error of an f32 scale instead of 1.07x.

The kernel uses `round_up_to_param` from cubecl-std rather than a second copy of the rule, so both backends share one implementation. UE8M0, which has no round-up rule upstream, is refused at `launch_ref`, where the caller can still read the scheme off the error.

Also drops the trailing `sync_cube` from the native quantize kernel: units retired by the bounds check never reach it, which is undefined behavior on CUDA.

The new test pins the f16 case where rounding to nearest and rounding up disagree, and asserts the stored scale is never below the requested one.