### PR TITLE
Fix matmul autotune key stride factors overstating real alignment

### DIFF
--- a/crates/cubek-matmul/src/strategy/tune_key.rs
+++ b/crates/cubek-matmul/src/strategy/tune_key.rs
@@ -137,7 +137,7 @@ impl MatmulAutotuneKey {
             k: k as u32,
         });
 
-        // The alignment factors below are computed from the *anchored* dims —
+        // The pow2 factors below are computed from the *anchored* dims —
         // the same bucketing the `m`/`n`/`k` fields get — never from the raw
         // values. A dimension carrying a runtime-dependent length (a KV-cache
         // width, a dynamic batch) would otherwise re-split every anchored
@@ -147,6 +147,11 @@ impl MatmulAutotuneKey {
         // bucket shares the kernel choice benchmarked on one representative,
         // and the launch still derives the legal line size from the real
         // tensors.
+        //
+        // The stride factors are the exception: [`stride_factor`] must split
+        // out real strides under the 16-byte async-copy/TMA threshold, or a
+        // winner tuned on an aligned bucket member is an invalid config for
+        // the under-aligned ones. See its doc comment.
         let m_anchored = anchor(m, None, None, None);
         let n_anchored = anchor(n, None, None, None);
         let k_anchored = anchor(k, None, None, None);
@@ -173,21 +178,21 @@ impl MatmulAutotuneKey {
         // its transposed view. Batch strides are products of these, so their
         // alignment can only be higher.
         let lhs_stride_factor = match matrix_layout_lhs {
-            MatrixBatchLayout::Contiguous => stride_factor(k_anchored, elem_lhs),
+            MatrixBatchLayout::Contiguous => stride_factor(k, k_anchored, elem_lhs),
             // TMA can't handle discontiguous batches because they're all combined into one dim
             MatrixBatchLayout::MildlyPermuted {
                 transposed: true,
                 batch_swap: false,
-            } => stride_factor(m_anchored, elem_lhs),
+            } => stride_factor(m, m_anchored, elem_lhs),
             _ => 0,
         };
         let rhs_stride_factor = match matrix_layout_rhs {
-            MatrixBatchLayout::Contiguous => stride_factor(n_anchored, elem_rhs),
+            MatrixBatchLayout::Contiguous => stride_factor(n, n_anchored, elem_rhs),
             // TMA can't handle discontiguous batches because they're all combined into one dim
             MatrixBatchLayout::MildlyPermuted {
                 transposed: true,
                 batch_swap: false,
-            } => stride_factor(k_anchored, elem_rhs),
+            } => stride_factor(k, k_anchored, elem_rhs),
             _ => 0,
         };
 
@@ -219,9 +224,38 @@ impl MatmulAutotuneKey {
     }
 }
 
-/// Stride alignment (in powers of two of bytes) of the canonical row stride
-/// `cols` — the tightest non-contiguous stride of the layout.
-fn stride_factor(cols: usize, elem: ElemType) -> u8 {
+/// Async-copy and TMA global readers require 16-byte (2^4) aligned strides;
+/// selection-time validation checks the *real* strides against this threshold
+/// (`validate_async_copy_with_problem` / `validate_tma_with_problem`).
+const READER_ALIGN_FACTOR: u8 = 4;
+
+/// Stride alignment (in powers of two of bytes) of the canonical row stride —
+/// the tightest non-contiguous stride of the layout (`cols` for a contiguous
+/// `[.., rows, cols]`, `rows` for its transposed view).
+///
+/// Aligned dims key from the *anchored* value so raw lengths inside one
+/// anchored bucket share a key (see the bucket comment in [`from_parts`]).
+/// A dim whose real stride is under the 16-byte reader threshold must NOT
+/// share that bucket: async-copy/TMA algorithms validate the real strides at
+/// setup, so a winner tuned on an aligned representative is an invalid config
+/// for the under-aligned members of its bucket — the launch then fails after
+/// selection instead of never being selected. Clamping the anchored factor to
+/// the threshold keeps the invariant `factor < 4  ⟺  real stride is under
+/// 16 bytes` even when the anchor base is not a power of two (autotune levels
+/// 0 and 2).
+///
+/// [`from_parts`]: MatmulAutotuneKey::from_parts
+fn stride_factor(cols_raw: usize, cols_anchored: usize, elem: ElemType) -> u8 {
+    let raw = raw_stride_factor(cols_raw, elem);
+    if raw < READER_ALIGN_FACTOR {
+        raw
+    } else {
+        raw_stride_factor(cols_anchored, elem).max(READER_ALIGN_FACTOR)
+    }
+}
+
+/// [`stride_factor`] of one dim, without bucketing.
+fn raw_stride_factor(cols: usize, elem: ElemType) -> u8 {
     let bytes = (cols * elem.size_bits()) / 8;
     bytes.trailing_zeros().min(MAX_STRIDE_FACTOR) as u8
 }
@@ -264,12 +298,39 @@ mod tests {
     /// endlessly for problems the anchor treats as equal.
     #[test]
     fn raw_lengths_within_a_bucket_share_one_key() {
-        // 65..=128 all anchor to the 128 bucket, at every alignment class:
-        // odd, 2-, 4-, 8-, 16-aligned, and the exact power of two.
-        let reference = key(64, 69, 64);
-        for kv in [70, 76, 88, 96, 112, 128] {
+        // 65..=128 all anchor to the 128 bucket. Every 16-byte-aligned raw
+        // length shares the bucket key: 76/88/96/112 (f32 row strides of
+        // 304/352/384/448 bytes) and the exact power of two.
+        let reference = key(64, 76, 64);
+        for kv in [88, 96, 112, 128] {
             assert_eq!(reference, key(64, kv, 64), "kv {kv} split the bucket");
         }
+    }
+
+    /// Raw lengths whose real row stride is under the 16-byte async-copy/TMA
+    /// threshold must NOT share the bucket of the aligned lengths: the reader
+    /// algorithms validate the real strides at setup, so an async-copy winner
+    /// tuned on an aligned representative is an invalid config for the
+    /// under-aligned members and the launch fails after selection. On an async
+    /// runner that failure is only warn-logged, which surfaced as silent NaN
+    /// weights in training (see the PR description for the full chain).
+    #[test]
+    fn under_aligned_lengths_split_from_the_aligned_bucket() {
+        let aligned = key(64, 128, 64);
+        // 126: f32 row stride 504 bytes = 8-byte aligned; anchors to 128.
+        assert_ne!(
+            aligned,
+            key(64, 126, 64),
+            "under-aligned kv shared the bucket"
+        );
+        // 69 (odd) and 70 (2-aligned) split too, and by alignment class.
+        assert_ne!(aligned, key(64, 69, 64));
+        assert_ne!(aligned, key(64, 70, 64));
+        assert_ne!(
+            key(64, 69, 64),
+            key(64, 70, 64),
+            "distinct under-aligned classes merged"
+        );
     }
 
     /// The bucket maximum shares its bucket's key. The scale thresholds sit
@@ -315,10 +376,19 @@ mod tests {
                 None,
             )
         };
-        // 65..=128 all anchor to the 128 bucket, at every alignment class.
-        let reference = key_t(69);
-        for m in [70, 76, 88, 96, 112, 128] {
+        // 65..=128 all anchor to the 128 bucket; the 16-byte-aligned raw
+        // lengths share its key.
+        let reference = key_t(76);
+        for m in [88, 96, 112, 128] {
             assert_eq!(reference, key_t(m), "m {m} split the transposed bucket");
         }
+        // Under-aligned rows split out, exactly as in the contiguous case:
+        // this is the `dW = x^T @ dy` shape of a Linear(126, _) backward,
+        // whose real canonical stride is 126 * 4 = 504 bytes.
+        assert_ne!(
+            reference,
+            key_t(126),
+            "under-aligned transposed m shared the bucket"
+        );
     }
 }


### PR DESCRIPTION
Addresses https://github.com/tracel-ai/burn/issues/5352 (one of two layers; see Scope).

## Problem

`MatmulAutotuneKey::from_parts` computes `lhs_stride_factor` / `rhs_stride_factor` from the **anchored** dims (`stride_factor(k_anchored, …)`), never from the raw values. The comment above the anchored block explains why: a runtime-dependent dim would re-split every anchored bucket by the raw value's alignment class and re-tune endlessly.

But this makes the key **overstate** alignment: a dim of 126 in f32 has a real canonical row stride of 126 × 4 = 504 bytes (8-byte aligned), while `anchor(126) = 128` keys it as 512 bytes (512-byte aligned). The problem then shares an autotune bucket with genuinely aligned problems (e.g. a 128-wide dim).

That is unsound for the async-copy/TMA read strategies, which are selection-time validated **against the real strides** (`validate_async_copy_with_problem`: "Async copy requires strides to be aligned to 16 bytes"). The failure sequence:

1. The bucket is first tuned on an aligned representative; an async-copy kernel wins and is cached.
2. A later cache hit from an under-aligned bucket member re-runs setup, validation fails — *after* autotune has committed to the winner.
3. The caller sees `Unable to launch matmul because the config is invalid` at a point where errors are no longer recoverable: `.expect("Should run when selected by autotune.")` in `cubecl-runtime`'s `LocalTuner::execute`, or `matmul(...).unwrap()` in `burn-cubecl`. On an async device runner the panic is caught and only warn-logged, and the op's registered output buffers are left uninitialized — downstream this surfaces as silent NaN corruption in training (see the linked burn issue).

A `Linear(126, N)` layer hits this in ordinary training: the backward `dW = x^T @ dy` matmul has canonical stride 126 and shares its bucket with the 128-wide hidden-layer gradients.

## Fix

Keep the anchored bucketing for every dim whose real stride meets the 16-byte reader threshold — the no-churn property the existing tests pin down is untouched for them — but report the real alignment class when it falls below the threshold. The invariant after this change: `factor < 4 ⟺ the real canonical stride is under 16 bytes`, so a bucket can never mix members that pass the reader validators with members that fail them. The anchored branch is clamped to the threshold so the invariant also holds when the anchor base is not a power of two (autotune levels 0 and 2).

Under-aligned dims are rare (the vast majority of models use aligned widths), so the extra key granularity is confined to problems that genuinely need their own tuning decision.

## Scope

This fixes the key's soundness (a bucket can no longer mix members that pass the async-copy/TMA validators with members that fail them — the collision buckets are present in real-workload autotune caches, e.g. a `Linear(126, _)`'s problems sharing buckets with 128-wide ones). It is one of two layers needed for the training-corruption issue linked above, and the two only work together. The matmul tuner decides which strategies may run a problem from this key: the `tma` group already refuses its strategies unless both stride factors clear the 16-byte threshold, and the specialized cyclic strategies (which read through `AsyncPartialCyclicLoading`) need the same treatment. Neither gate can fire while the key derives its factors from the anchored dims, so this PR is what makes them effective; the companion burn PR (https://github.com/tracel-ai/burn/pull/5370) adds the missing gate. Merging either alone is a no-op for the bug.

An earlier attempt at that second layer made the tuner fall back to other candidates after a launch failure (cubecl#1510). It was rejected upstream, correctly — recovery would have to hand the real inputs to another candidate, and autotune must not clone them.

## Tests

- `under_aligned_lengths_split_from_the_aligned_bucket` — the regression: 126 (504 B) no longer shares the 128 bucket; distinct under-aligned classes (odd vs 2-aligned) stay distinct.
- `transposed_lhs_shares_bucket_key` — extended with the transposed `dW = x^T @ dy` shape of a `Linear(126, _)` backward.
- `raw_lengths_within_a_bucket_share_one_key` / `bucket_maxima_share_the_bucket_key` — updated to assert the preserved no-churn property over the 16-byte-aligned members.

## Validate your PR with burn

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [x] Submit a PR in burn with your fixes and link it here — https://github.com/tracel-ai/burn/pull/5370 (the companion gate, not a compatibility fix: nothing in burn breaks against this change).

Validation details: burn main does not currently compile against cubecl/cubek main (pre-existing quant API drift from cubecl#1479, unrelated to this change), so validation ran against burn's pinned revs, mirroring the maintainers' rev-bump flow. With this fix cherry-picked onto burn's pinned cubek (`611491b`) — branch [`validate/keyfix-on-burn-pin`](https://github.com/RAV64/cubek/tree/validate/keyfix-on-burn-pin) — burn compiles cleanly with `std,autodiff,optim,cuda,fusion,autotune`, and the training reproduction from the linked issue trains to completion (3/3 fresh-cache runs, finite decreasing losses), identical to the unpatched baseline. The change is API-neutral: key values change for under-aligned dims; the key type and construction are unchanged. All 16 `cubek-matmul` unit tests pass on both cubek main and the pinned base.
