### PR TITLE
Add procedural tile sources

### DIFF
--- a/crates/cubek-matmul/src/routines/cmma/base.rs
+++ b/crates/cubek-matmul/src/routines/cmma/base.rs
@@ -17,7 +17,6 @@ use std::fmt::Display;
 
 use cubecl::{Runtime, features::MmaConfig};
 use cubecl::{features::Tma as TmaFeature, ir::ElemType};
-use cubek_tile::Delivery;
 
 use crate::{
     definition::{MatmulAvailabilityError, MatmulProblem, MatmulSetupError},
@@ -30,6 +29,29 @@ use crate::{
 /// Upper bound on planes along one stage axis; 2×4 or 4×2 tends to saturate without
 /// blowing the cube dim.
 const MAX_PLANES_PER_AXIS: usize = 4;
+
+/// The CMMA routine's launch-time input transport choice. This is deliberately separate from
+/// [`cubek_tile::Delivery`], which describes an already-constructed tile's staging behavior.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CmmaDelivery {
+    #[default]
+    Copy,
+    Tma,
+}
+
+impl CmmaDelivery {
+    pub(crate) fn is_tma(self) -> bool {
+        matches!(self, CmmaDelivery::Tma)
+    }
+
+    fn validate_tma(self, boxes: &[usize], batched: bool) -> Result<(), String> {
+        if self.is_tma() {
+            cubek_tile::Delivery::Tma.validate_tma(boxes, batched)
+        } else {
+            Ok(())
+        }
+    }
+}
 
 /// Tiles per plane along `m`/`n`: the plane's resident fragment partition,
 /// sized so `A`/`B` fragments are reused across executes.
@@ -50,8 +72,8 @@ pub struct CmmaBlueprint {
     /// K-stage depth in elements: a multiple of `instruction.k`, chosen by [`select`]
     /// against the shared-memory budget.
     pub stage_k: usize,
-    /// How the operands' bytes move (the output is always strided).
-    pub delivery: Delivery,
+    /// Launch-time transport for both inputs (the output always uses a regular buffer copy).
+    pub delivery: CmmaDelivery,
 }
 
 impl CmmaBlueprint {
@@ -109,13 +131,13 @@ impl CmmaBlueprint {
 pub struct CmmaStrategy {
     /// How the operands' bytes move (the output is always strided). `Tma` is
     /// `Unavailable` on backends without the feature; it never silently degrades.
-    pub delivery: Delivery,
+    pub delivery: CmmaDelivery,
 }
 
 impl CmmaStrategy {
     pub fn tma() -> Self {
         CmmaStrategy {
-            delivery: Delivery::Tma,
+            delivery: CmmaDelivery::Tma,
         }
     }
 }
@@ -123,8 +145,8 @@ impl CmmaStrategy {
 impl Display for CmmaStrategy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.delivery {
-            Delivery::Strided => Ok(()),
-            Delivery::Tma => f.write_str("_tma"),
+            CmmaDelivery::Copy => Ok(()),
+            CmmaDelivery::Tma => f.write_str("_tma"),
         }
     }
 }
@@ -213,7 +235,7 @@ impl CmmaRoutine {
     fn select<R: Runtime>(
         problem: &MatmulProblem,
         device_settings: &DeviceSettings<R>,
-        delivery: Delivery,
+        delivery: CmmaDelivery,
         acc: ElemType,
     ) -> Result<CmmaBlueprint, MatmulSetupError> {
         let client = &device_settings.client;

--- a/crates/cubek-matmul/src/routines/cmma/launch.rs
+++ b/crates/cubek-matmul/src/routines/cmma/launch.rs
@@ -5,8 +5,8 @@ use cubecl::{Runtime, client::ComputeClient, prelude::*};
 use cubek_std::launch::tma::tma_operand;
 use cubek_std::{InputBinding, MatrixLayout};
 use cubek_tile::{
-    Axis, CubeAxis, Cut, Delivery, Launcher, Leaf, Schedule, Space, Strided, Tiling, Tma,
-    TmaTileArgLaunch, WalkOrder,
+    Axis, CubeAxis, Cut, Launcher, Leaf, Schedule, Space, Strided, Tiling, Tma, TmaTileArgLaunch,
+    WalkOrder,
 };
 
 use crate::{
@@ -17,7 +17,7 @@ use crate::{
     routines::{
         BlueprintStrategy, DeviceSettings, K, M, N, batch_axis,
         cmma::{
-            base::{CmmaBlueprint, CmmaRoutine},
+            base::{CmmaBlueprint, CmmaDelivery, CmmaRoutine},
             kernel::cmma_kernel,
         },
     },
@@ -183,7 +183,7 @@ fn tile_space(
 
 /// The one entry for both deliveries: the shared geometry (space, launcher, out arg) is
 /// built once, and only the operand construction dispatches on the blueprint's
-/// [`Delivery`]. A TMA plan is fully validated by then, so on CUDA it runs or fails to
+/// [`CmmaDelivery`]. A TMA plan is fully validated by then, so on CUDA it runs or fails to
 /// compile, never silently degrades.
 #[allow(clippy::result_large_err)]
 pub fn launch_ref<R: Runtime>(
@@ -217,7 +217,7 @@ pub fn launch_ref<R: Runtime>(
     // The one dispatch Rust forces: pick the compile-time family for the runtime delivery.
     // Either path runs the same kernel body and never branches on the delivery again.
     match blueprint.delivery {
-        Delivery::Strided => launch_strided::<R>(
+        CmmaDelivery::Copy => launch_strided::<R>(
             client,
             &launch,
             cube_count,
@@ -229,7 +229,7 @@ pub fn launch_ref<R: Runtime>(
             dtypes,
             leaf,
         ),
-        Delivery::Tma => launch_tma::<R>(
+        CmmaDelivery::Tma => launch_tma::<R>(
             client,
             &launch,
             cube_count,

--- a/crates/cubek-matmul/src/routines/cmma/mod.rs
+++ b/crates/cubek-matmul/src/routines/cmma/mod.rs
@@ -2,5 +2,5 @@ mod base;
 mod kernel;
 mod launch;
 
-pub use base::{CmmaBlueprint, CmmaRoutine, CmmaStrategy, Partition};
+pub use base::{CmmaBlueprint, CmmaDelivery, CmmaRoutine, CmmaStrategy, Partition};
 pub use launch::launch_ref;

--- a/crates/cubek-matmul/tests/matmul/basic/plane_accelerated.rs
+++ b/crates/cubek-matmul/tests/matmul/basic/plane_accelerated.rs
@@ -303,18 +303,18 @@ fn cmma_batched_f32() {
 /// cube-shared smem (every plane contracted plane 0's windows).
 #[test]
 fn cmma_partition_1x1_f32() {
+    use cubek_matmul::routines::cmma::CmmaDelivery;
     use cubek_matmul::routines::{
         cmma::{CmmaBlueprint, Partition},
         cpu_gemm::{Instruction, PlaneGrid},
     };
-    use cubek_tile::Delivery;
 
     let blueprint = CmmaBlueprint {
         instruction: Instruction { m: 8, n: 8, k: 8 },
         partition: Partition { m: 1, n: 1 },
         planes: PlaneGrid { m: 2, n: 1 },
         stage_k: 48,
-        delivery: Delivery::Strided,
+        delivery: CmmaDelivery::Copy,
     };
     test_matmul_strategy(
         client(),
@@ -352,12 +352,12 @@ fn cmma_tma_square_f16() {
 #[test]
 fn cmma_tma_rejects_oversized_box() {
     use cubek_matmul::definition::{AvailableVectorSizes, MatmulSetupError};
+    use cubek_matmul::routines::cmma::CmmaDelivery;
     use cubek_matmul::routines::{
         DeviceSettings,
         cmma::{CmmaBlueprint, CmmaRoutine, Partition},
         cpu_gemm::{Instruction, PlaneGrid},
     };
-    use cubek_tile::Delivery;
 
     let client = client();
     // stage_n = planes.n * partition.n * instruction.n = 512 > 256.
@@ -370,7 +370,7 @@ fn cmma_tma_rejects_oversized_box() {
         partition: Partition { m: 2, n: 8 },
         planes: PlaneGrid { m: 2, n: 4 },
         stage_k: 16,
-        delivery: Delivery::Tma,
+        delivery: CmmaDelivery::Tma,
     };
     let problem = super::common::rect(64, 1024, 64, f16_elems());
     let device_settings = DeviceSettings {

--- a/crates/cubek-matmul/tests/matmul/bench_catalog.rs
+++ b/crates/cubek-matmul/tests/matmul/bench_catalog.rs
@@ -139,7 +139,7 @@ fn gemm_cyclic_cmma_forced_point_correctness() {
         partition: Partition { m: 1, n: 4 },
         planes: PlaneGrid { m: 4, n: 1 },
         stage_k: 32,
-        delivery: cubek_tile::Delivery::Strided,
+        delivery: cubek_matmul::routines::cmma::CmmaDelivery::Copy,
     }));
     let actual = GemmCorrectness
         .kernel_result(&forced, &problem, &SEEDS)
@@ -177,7 +177,7 @@ fn gemm_cyclic_cmma_crosspoint_timing() {
         partition: Partition { m: 1, n: 4 },
         planes: PlaneGrid { m: 4, n: 1 },
         stage_k: 32,
-        delivery: cubek_tile::Delivery::Strided,
+        delivery: cubek_matmul::routines::cmma::CmmaDelivery::Copy,
     }));
 
     // The legacy engine forced to the DSL selector's point: partition 2x8x4 per plane,
@@ -245,7 +245,7 @@ fn gemm_cyclic_cmma_crosspoint_timing() {
             partition: Partition { m: 1, n: 4 },
             planes: PlaneGrid { m: 4, n: 1 },
             stage_k,
-            delivery: cubek_tile::Delivery::Strided,
+            delivery: cubek_matmul::routines::cmma::CmmaDelivery::Copy,
         }))
     };
 

--- a/crates/cubek-tile/src/instruction/mma/base.rs
+++ b/crates/cubek-tile/src/instruction/mma/base.rs
@@ -37,6 +37,7 @@ pub fn mma_leaf<E: Numeric, EL: Numeric, ER: Numeric>(
             mma_register_memory::<E, EL, ER>(g, lhs, rhs, space)
         }
         TileKind::TmaGmem(_) => panic!("mma: a tma source is not an accumulator sink"),
+        TileKind::Procedural(_) => panic!("mma: a procedural tile is not an accumulator sink"),
     }
 }
 

--- a/crates/cubek-tile/src/ops/reduce/lower.rs
+++ b/crates/cubek-tile/src/ops/reduce/lower.rs
@@ -81,6 +81,7 @@ pub fn reduce_leaf<Acc: Numeric, In: Numeric>(
             reduce_plane_tile(&mut t, input, space, inst);
         }
         TileKind::TmaGmem(_) => panic!("reduce: a tma source is not an accumulator sink"),
+        TileKind::Procedural(_) => panic!("reduce: a procedural tile is not an accumulator sink"),
     }
 }
 

--- a/crates/cubek-tile/src/physical/delivery.rs
+++ b/crates/cubek-tile/src/physical/delivery.rs
@@ -6,13 +6,14 @@ use cubecl::prelude::*;
 
 use crate::{Leaf, Space, Tile, TileArg, TmaTileArg};
 
-/// How an operand's bytes move out of it: a strided cooperative copy or a TMA hardware
-/// bulk copy. Read off a tile via [`delivery`](crate::Tile::delivery); the staging sync
-/// comes from it.
+/// How an operand reaches a stage: a strided cooperative copy, coordinate-backed cooperative
+/// materialization, or a TMA hardware bulk copy. Read off a tile via
+/// [`delivery`](crate::Tile::delivery); the staging sync comes from it.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
 pub enum Delivery {
     #[default]
     Strided,
+    Procedural,
     Tma,
 }
 
@@ -114,7 +115,7 @@ impl Default for StagePlan {
 /// pair with another operand's spec; only the kernel's one [`Space`] crosses the seam. A
 /// kernel body written over `D: DeliveryFamily` runs strided or TMA unchanged; the launch
 /// entry picks the family. One family covers both operands, since
-/// [`Sync::merge`](crate::Sync::merge) rejects a mixed pair anyway.
+/// [`Sync::for_deliveries`](crate::Sync::for_deliveries) rejects a mixed pair anyway.
 #[cube]
 pub trait DeliveryFamily: Send + core::marker::Sync + 'static {
     /// The launchable argument carrying one operand and its spec.

--- a/crates/cubek-tile/src/physical/delivery.rs
+++ b/crates/cubek-tile/src/physical/delivery.rs
@@ -1,18 +1,18 @@
-//! How an operand's bytes move: the [`Delivery`] (strided cooperative copy or TMA bulk
+//! How an operand's bytes move: the [`Delivery`] (cooperative buffer copy or TMA bulk
 //! copy) and its type-level twin [`DeliveryFamily`], which lets one kernel body serve
 //! both argument types.
 
 use cubecl::prelude::*;
 
-use crate::{Leaf, Space, Tile, TileArg, TmaTileArg};
+use crate::{Leaf, Space, Sync, Tile, TileArg, TmaTileArg};
 
-/// How an operand reaches a stage: a strided cooperative copy, coordinate-backed cooperative
+/// How an operand reaches a stage: a buffered cooperative copy, coordinate-backed cooperative
 /// materialization, or a TMA hardware bulk copy. Read off a tile via
 /// [`delivery`](crate::Tile::delivery); the staging sync comes from it.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
 pub enum Delivery {
     #[default]
-    Strided,
+    Copy,
     Procedural,
     Tma,
 }
@@ -24,6 +24,14 @@ const TMA_MAX_BOX_DIM: usize = 256;
 impl Delivery {
     pub fn is_tma(&self) -> bool {
         matches!(self, Delivery::Tma)
+    }
+
+    /// The synchronization required to materialize this source in a staging slot.
+    pub fn rendezvous(&self) -> Sync {
+        match self {
+            Delivery::Copy | Delivery::Procedural => Sync::Cube,
+            Delivery::Tma => Sync::Barrier,
+        }
     }
 
     /// Reject a plan the TMA descriptor path can't encode, so a bad plan fails here as a
@@ -126,7 +134,7 @@ pub trait DeliveryFamily: Send + core::marker::Sync + 'static {
     fn tile<E: Numeric, V: Size>(arg: &Self::Arg<E, V>, #[comptime] space: Space) -> Tile<E>;
 }
 
-/// [`Delivery::Strided`]'s family: a plain tensor + spec ([`TileArg`]), tiled in-kernel
+/// [`Delivery::Copy`]'s family: a plain tensor + spec ([`TileArg`]), tiled in-kernel
 /// by [`Tile::of`].
 pub struct Strided;
 

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -549,7 +549,7 @@ impl<'a, R: Runtime> StridedTileSource<'a, Set, Set, Set, R> {
 /// [`QuantTileArgLaunch`](crate::QuantTileArgLaunch) one.
 ///
 /// Both transports constrain, but only the leaf can differ here: this operand is
-/// [`Delivery::Strided`](crate::Delivery) by construction (that is what a [`StridedTileSource`] is),
+/// [`Delivery::Copy`](crate::Delivery) by construction (that is what a [`StridedTileSource`] is),
 /// and a strided load runs code per element, so it decodes whatever it moves. Only the leaf is left:
 /// a fragment load takes a raw window at one element type, so a leaf that loads fragments needs its
 /// values already served. A [`Delivery::Tma`](crate::Delivery) operand would invert this — a bulk

--- a/crates/cubek-tile/src/staging/base.rs
+++ b/crates/cubek-tile/src/staging/base.rs
@@ -62,12 +62,16 @@ impl<T: CubeType> Staging<T> {
         }
     }
 
-    /// Producer release: arrive `full` (elected unit) so the consumer's `full` wait can pass. The
-    /// bytes were declared per tile by [`Pipeline::fill`], so this is a bare arrival. No-op for `Cube`.
+    /// Producer release publishes a barrier slot after its required arrivals and any TMA bytes
+    /// declared by [`Pipeline::fill`] land. Mixed slots need every unit; pure TMA uses unit 0.
     pub(crate) fn release_write(&self) {
         match &self.pipeline {
-            Pipeline::Barrier { full, .. } => {
-                if UNIT_POS == 0 {
+            Pipeline::Barrier {
+                full,
+                collective_full,
+                ..
+            } => {
+                if comptime!(*collective_full) || UNIT_POS == 0 {
                     full.arrive();
                 }
             }

--- a/crates/cubek-tile/src/staging/fill.rs
+++ b/crates/cubek-tile/src/staging/fill.rs
@@ -11,6 +11,32 @@ use cubecl::unexpanded;
 
 use crate::*;
 
+/// The one resolved staging policy shared by unary and binary slots. Backing allocation,
+/// rendezvous, and producer-arrival count are derived together from the actual sources.
+#[derive(Clone, Copy)]
+struct SlotPlan {
+    stage: OperandStage,
+    sync: Sync,
+    collective_full: bool,
+}
+
+fn slot_plan(requested: OperandStage, deliveries: &[Delivery]) -> SlotPlan {
+    let stage = if deliveries.contains(&Delivery::Procedural) {
+        OperandStage::Smem
+    } else {
+        requested
+    };
+    let sync = match stage {
+        OperandStage::Plane => Sync::Solo,
+        OperandStage::Smem => Sync::for_deliveries(deliveries),
+    };
+    SlotPlan {
+        stage,
+        sync,
+        collective_full: Sync::collective_full(deliveries),
+    }
+}
+
 #[cube]
 impl<Lhs: Numeric, Rhs: Numeric> Staging<(Tile<Lhs>, Tile<Rhs>)> {
     /// Build a slot staging one region of the operands `lhs`/`rhs`. An [`OperandStage::Plane`]
@@ -35,21 +61,19 @@ impl<Lhs: Numeric, Rhs: Numeric> Staging<(Tile<Lhs>, Tile<Rhs>)> {
         // Both operands use the output leaf's staging kind. The helper preserves each tile's
         // own projection and rejects unsupported Plane/TMA/gather combinations.
         let requested_stage = comptime!(out.operand_stage(lhs.leaf));
-        // A procedural source has no fragment transport. Resolve the effective stage before
-        // allocating either operand and before choosing the pipeline: when either side needs
-        // cooperative materialization, both live in smem under the matching `Cube` pipeline.
-        let stage = resolved_stage(requested_stage, lhs_delivery, rhs_delivery);
+        let plan = comptime!(slot_plan(requested_stage, &[lhs_delivery, rhs_delivery]));
+        let stage = comptime!(plan.stage);
         let stages = (
             stage_operand(lhs, comptime!(out.clone()), stage),
             stage_operand(rhs, comptime!(out.clone()), stage),
         );
-        let sync = match comptime!(stage) {
-            OperandStage::Plane => comptime!(Sync::Solo),
-            OperandStage::Smem => {
-                comptime!(Sync::for_deliveries(&[lhs_delivery, rhs_delivery]))
-            }
-        };
-        Staging::wrap(stages, Pipeline::new(sync), pin_lhs, pin_rhs, stage)
+        Staging::wrap(
+            stages,
+            Pipeline::new(comptime!(plan.sync), comptime!(plan.collective_full)),
+            pin_lhs,
+            pin_rhs,
+            stage,
+        )
     }
 
     /// Fill the pinned operand(s), those the walk leaves invariant, from `region`'s window.
@@ -154,13 +178,16 @@ impl<T: Numeric> Staging<Tile<T>> {
         let split = comptime!(op_space.is_static() && !delivery.is_tma());
         let pin = comptime!(split && op_space.walk_invariant(&input.space));
         let requested_stage = comptime!(out.operand_stage(input.leaf));
-        let stage = resolved_stage(requested_stage, delivery, delivery);
+        let plan = comptime!(slot_plan(requested_stage, &[delivery]));
+        let stage = comptime!(plan.stage);
         let staged_input = stage_operand(input, comptime!(out.clone()), stage);
-        let sync = match comptime!(stage) {
-            OperandStage::Plane => comptime!(Sync::Solo),
-            OperandStage::Smem => comptime!(Sync::for_deliveries(&[delivery])),
-        };
-        Staging::wrap(staged_input, Pipeline::new(sync), pin, false, stage)
+        Staging::wrap(
+            staged_input,
+            Pipeline::new(comptime!(plan.sync), comptime!(plan.collective_full)),
+            pin,
+            false,
+            stage,
+        )
     }
 
     /// Fill the pinned operand from `region`'s window.
@@ -238,24 +265,6 @@ impl<T: Numeric> StagingExpand<Tile<T>> {
     }
 }
 
-/// Resolve a slot's backing before either allocation or synchronization. A procedural source is
-/// cooperatively materialized, so a requested plane stage becomes a cube-synchronized smem stage.
-#[cube]
-fn resolved_stage(
-    #[comptime] requested: OperandStage,
-    #[comptime] lhs_delivery: Delivery,
-    #[comptime] rhs_delivery: Delivery,
-) -> comptime_type!(OperandStage) {
-    if comptime!(
-        matches!(lhs_delivery, Delivery::Procedural)
-            || matches!(rhs_delivery, Delivery::Procedural)
-    ) {
-        comptime!(OperandStage::Smem)
-    } else {
-        requested
-    }
-}
-
 /// Allocate one staged operand for `stage`. A gathered operand keeps its compacted physical
 /// window and projection, so staging does not replicate each logical element for every gather
 /// tap. The leaf performs the gather on read instead; that keeps staging compact but means
@@ -296,8 +305,8 @@ mod tests {
     #[test]
     fn procedural_upgrades_a_plane_request_to_smem() {
         assert_eq!(
-            resolved_stage(OperandStage::Plane, Delivery::Procedural, Delivery::Strided),
-            OperandStage::Smem
+            slot_plan(OperandStage::Plane, &[Delivery::Procedural, Delivery::Copy]).stage,
+            OperandStage::Smem,
         );
     }
 }

--- a/crates/cubek-tile/src/staging/fill.rs
+++ b/crates/cubek-tile/src/staging/fill.rs
@@ -34,14 +34,20 @@ impl<Lhs: Numeric, Rhs: Numeric> Staging<(Tile<Lhs>, Tile<Rhs>)> {
         let pin_rhs = comptime!(split && op_space.walk_invariant(&rhs.space));
         // Both operands use the output leaf's staging kind. The helper preserves each tile's
         // own projection and rejects unsupported Plane/TMA/gather combinations.
-        let stage = comptime!(out.operand_stage(lhs.leaf));
+        let requested_stage = comptime!(out.operand_stage(lhs.leaf));
+        // A procedural source has no fragment transport. Resolve the effective stage before
+        // allocating either operand and before choosing the pipeline: when either side needs
+        // cooperative materialization, both live in smem under the matching `Cube` pipeline.
+        let stage = resolved_stage(requested_stage, lhs_delivery, rhs_delivery);
         let stages = (
             stage_operand(lhs, comptime!(out.clone()), stage),
             stage_operand(rhs, comptime!(out.clone()), stage),
         );
         let sync = match comptime!(stage) {
             OperandStage::Plane => comptime!(Sync::Solo),
-            OperandStage::Smem => comptime!(Sync::merge(lhs_delivery, rhs_delivery)),
+            OperandStage::Smem => {
+                comptime!(Sync::for_deliveries(&[lhs_delivery, rhs_delivery]))
+            }
         };
         Staging::wrap(stages, Pipeline::new(sync), pin_lhs, pin_rhs, stage)
     }
@@ -147,11 +153,12 @@ impl<T: Numeric> Staging<Tile<T>> {
         // can't decide invariance at comptime. Both fall back to streaming (pin = false).
         let split = comptime!(op_space.is_static() && !delivery.is_tma());
         let pin = comptime!(split && op_space.walk_invariant(&input.space));
-        let stage = comptime!(out.operand_stage(input.leaf));
+        let requested_stage = comptime!(out.operand_stage(input.leaf));
+        let stage = resolved_stage(requested_stage, delivery, delivery);
         let staged_input = stage_operand(input, comptime!(out.clone()), stage);
         let sync = match comptime!(stage) {
             OperandStage::Plane => comptime!(Sync::Solo),
-            OperandStage::Smem => comptime!(Sync::from(delivery)),
+            OperandStage::Smem => comptime!(Sync::for_deliveries(&[delivery])),
         };
         Staging::wrap(staged_input, Pipeline::new(sync), pin, false, stage)
     }
@@ -231,6 +238,24 @@ impl<T: Numeric> StagingExpand<Tile<T>> {
     }
 }
 
+/// Resolve a slot's backing before either allocation or synchronization. A procedural source is
+/// cooperatively materialized, so a requested plane stage becomes a cube-synchronized smem stage.
+#[cube]
+fn resolved_stage(
+    #[comptime] requested: OperandStage,
+    #[comptime] lhs_delivery: Delivery,
+    #[comptime] rhs_delivery: Delivery,
+) -> comptime_type!(OperandStage) {
+    if comptime!(
+        matches!(lhs_delivery, Delivery::Procedural)
+            || matches!(rhs_delivery, Delivery::Procedural)
+    ) {
+        comptime!(OperandStage::Smem)
+    } else {
+        requested
+    }
+}
+
 /// Allocate one staged operand for `stage`. A gathered operand keeps its compacted physical
 /// window and projection, so staging does not replicate each logical element for every gather
 /// tap. The leaf performs the gather on read instead; that keeps staging compact but means
@@ -243,12 +268,6 @@ fn stage_operand<T: Numeric>(
 ) -> Tile<T> {
     let gathered = input.gathered();
     let delivery = input.delivery();
-    // A procedural operand has no raw-memory fragment transport. Materialize it into smem at
-    // this boundary; recursive staging then treats that result exactly like any other tile.
-    let stage = match &input.tile_kind {
-        TileKind::Procedural(_) => comptime!(OperandStage::Smem),
-        _ => stage,
-    };
     match comptime!(stage) {
         OperandStage::Plane => {
             comptime!(assert!(
@@ -267,5 +286,18 @@ fn stage_operand<T: Numeric>(
             )
         }
         OperandStage::Smem => MemData::smem_like(input),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn procedural_upgrades_a_plane_request_to_smem() {
+        assert_eq!(
+            resolved_stage(OperandStage::Plane, Delivery::Procedural, Delivery::Strided),
+            OperandStage::Smem
+        );
     }
 }

--- a/crates/cubek-tile/src/staging/fill.rs
+++ b/crates/cubek-tile/src/staging/fill.rs
@@ -243,6 +243,12 @@ fn stage_operand<T: Numeric>(
 ) -> Tile<T> {
     let gathered = input.gathered();
     let delivery = input.delivery();
+    // A procedural operand has no raw-memory fragment transport. Materialize it into smem at
+    // this boundary; recursive staging then treats that result exactly like any other tile.
+    let stage = match &input.tile_kind {
+        TileKind::Procedural(_) => comptime!(OperandStage::Smem),
+        _ => stage,
+    };
     match comptime!(stage) {
         OperandStage::Plane => {
             comptime!(assert!(

--- a/crates/cubek-tile/src/staging/pipeline.rs
+++ b/crates/cubek-tile/src/staging/pipeline.rs
@@ -23,25 +23,30 @@ pub enum Sync {
 }
 
 impl Sync {
-    /// Resolve one slot's synchronization from all of its source deliveries. Strided copies and
-    /// procedural materialization are cooperative, so they share [`Cube`](Self::Cube). A slot
-    /// containing only TMA sources uses [`Barrier`](Self::Barrier). TMA cannot yet share a slot
-    /// with a synchronous source: publishing its barrier would need another cube rendezvous.
+    /// Join the rendezvous requirements of a slot's sources. `Barrier` dominates `Cube` because
+    /// TMA transaction completion must be included in the slot's publication.
     pub fn for_deliveries(deliveries: &[Delivery]) -> Sync {
         assert!(
             !deliveries.is_empty(),
             "Staging: a slot must have at least one delivery"
         );
-        let has_tma = deliveries.contains(&Delivery::Tma);
-        if has_tma {
-            assert!(
-                deliveries.iter().all(|delivery| *delivery == Delivery::Tma),
-                "Staging: a TMA source cannot share a slot with a synchronous strided or procedural source"
-            );
-            Sync::Barrier
-        } else {
-            Sync::Cube
-        }
+        deliveries.iter().fold(Sync::Cube, |sync, delivery| {
+            match (sync, delivery.rendezvous()) {
+                (Sync::Barrier, _) | (_, Sync::Barrier) => Sync::Barrier,
+                (Sync::Cube, Sync::Cube) => Sync::Cube,
+                (Sync::Solo, _) | (_, Sync::Solo) => {
+                    unreachable!("source rendezvous is never Solo")
+                }
+            }
+        })
+    }
+
+    /// Whether a barrier slot needs every unit to publish its writes. Pure TMA has one hardware
+    /// issuer; a mixed slot also contains a synchronous cooperative fill.
+    pub fn collective_full(deliveries: &[Delivery]) -> bool {
+        deliveries
+            .iter()
+            .any(|delivery| delivery.rendezvous() == Sync::Cube)
     }
 }
 
@@ -60,10 +65,15 @@ pub enum Pipeline {
     /// parity, so the fill overlaps compute. TMA motivates it, but the barrier itself is
     /// delivery-agnostic; see [`Pipeline::fill`].
     Barrier {
-        /// Producer→consumer (one producer arrival): flips once the fill's transaction bytes land.
+        /// Producer→consumer: flips after every unit arrives and all declared TMA transaction
+        /// bytes land.
         full: Shared<Barrier>,
         /// Consumer→producer (one arrival per unit): flips once every unit has read and freed the slot.
         empty: Shared<Barrier>,
+        /// A mixed TMA/synchronous slot needs every producer to publish; a pure TMA slot is
+        /// published by its elected issuer alone.
+        #[cube(comptime)]
+        collective_full: bool,
         /// mbarrier parity for `wait_parity`; flipped once per read.
         phase: u32,
     },
@@ -73,17 +83,19 @@ pub enum Pipeline {
 impl Pipeline {
     /// Allocate the pipeline for `sync`: the `full`/`empty` mbarrier pair, sealed by a proxy fence
     /// before any bulk copy, for [`Barrier`](Sync::Barrier); nothing to allocate otherwise.
-    pub(crate) fn new(#[comptime] sync: Sync) -> Pipeline {
+    pub(crate) fn new(#[comptime] sync: Sync, #[comptime] collective_full: bool) -> Pipeline {
         match sync {
             Sync::Solo => Pipeline::new_Solo(),
             Sync::Cube => Pipeline::new_Cube(),
             Sync::Barrier => {
-                // full: one producer arrival; empty: one arrival per unit.
-                let full = Barrier::shared(1, UNIT_POS == 0);
+                // A mixed slot collects cooperative writers and TMA bytes; pure TMA keeps its
+                // one elected producer arrival.
+                let full_arrivals = comptime!(if collective_full { CUBE_DIM } else { 1u32 });
+                let full = Barrier::shared(full_arrivals, UNIT_POS == 0);
                 let empty = Barrier::shared(CUBE_DIM, UNIT_POS == 0);
                 sync_async_proxy_shared();
                 sync_cube();
-                Pipeline::new_Barrier(full, empty, 0)
+                Pipeline::new_Barrier(full, empty, collective_full, 0)
             }
         }
     }
@@ -105,6 +117,7 @@ impl Pipeline {
                 }
                 // A strided source under a barrier is a plain synchronous copy.
                 (TileKind::Smem(d), TileKind::Gmem(s) | TileKind::Smem(s)) => d.fill_from(s, space),
+                (TileKind::Smem(d), TileKind::Procedural(s)) => d.fill_procedural(s, space),
                 _ => panic!("Pipeline::fill: unsupported kind pairing"),
             },
             Pipeline::Cube | Pipeline::Solo => dst.copy_from(src),
@@ -119,14 +132,25 @@ mod tests {
     #[test]
     fn procedural_and_strided_share_a_cube_pipeline() {
         assert_eq!(
-            Sync::for_deliveries(&[Delivery::Procedural, Delivery::Strided]),
+            Sync::for_deliveries(&[Delivery::Procedural, Delivery::Copy]),
             Sync::Cube
         );
     }
 
     #[test]
-    #[should_panic(expected = "TMA source cannot share a slot")]
-    fn procedural_and_tma_are_explicitly_rejected() {
-        Sync::for_deliveries(&[Delivery::Procedural, Delivery::Tma]);
+    fn procedural_and_tma_share_a_barrier_pipeline() {
+        assert_eq!(
+            Sync::for_deliveries(&[Delivery::Procedural, Delivery::Tma]),
+            Sync::Barrier
+        );
+        assert!(Sync::collective_full(&[
+            Delivery::Procedural,
+            Delivery::Tma
+        ]));
+    }
+
+    #[test]
+    fn pure_tma_keeps_its_single_producer_arrival() {
+        assert!(!Sync::collective_full(&[Delivery::Tma]));
     }
 }

--- a/crates/cubek-tile/src/staging/pipeline.rs
+++ b/crates/cubek-tile/src/staging/pipeline.rs
@@ -22,25 +22,26 @@ pub enum Sync {
     Barrier,
 }
 
-/// Deduce the strategy from the operand's [`Delivery`]: async (TMA) → `Barrier`,
-/// strided → `Cube`.
-impl From<Delivery> for Sync {
-    fn from(delivery: Delivery) -> Sync {
-        match delivery {
-            Delivery::Strided => Sync::Cube,
-            Delivery::Tma => Sync::Barrier,
-        }
-    }
-}
-
 impl Sync {
-    /// The strategy two operands share. A mix is rejected.
-    pub fn merge(lhs: Delivery, rhs: Delivery) -> Sync {
-        assert_eq!(
-            lhs, rhs,
-            "Staging: mixed delivery; all operands must be TMA sources or none"
+    /// Resolve one slot's synchronization from all of its source deliveries. Strided copies and
+    /// procedural materialization are cooperative, so they share [`Cube`](Self::Cube). A slot
+    /// containing only TMA sources uses [`Barrier`](Self::Barrier). TMA cannot yet share a slot
+    /// with a synchronous source: publishing its barrier would need another cube rendezvous.
+    pub fn for_deliveries(deliveries: &[Delivery]) -> Sync {
+        assert!(
+            !deliveries.is_empty(),
+            "Staging: a slot must have at least one delivery"
         );
-        Sync::from(lhs)
+        let has_tma = deliveries.contains(&Delivery::Tma);
+        if has_tma {
+            assert!(
+                deliveries.iter().all(|delivery| *delivery == Delivery::Tma),
+                "Staging: a TMA source cannot share a slot with a synchronous strided or procedural source"
+            );
+            Sync::Barrier
+        } else {
+            Sync::Cube
+        }
     }
 }
 
@@ -104,10 +105,28 @@ impl Pipeline {
                 }
                 // A strided source under a barrier is a plain synchronous copy.
                 (TileKind::Smem(d), TileKind::Gmem(s) | TileKind::Smem(s)) => d.fill_from(s, space),
-                (TileKind::Smem(d), TileKind::Procedural(s)) => d.fill_procedural(s, space),
                 _ => panic!("Pipeline::fill: unsupported kind pairing"),
             },
             Pipeline::Cube | Pipeline::Solo => dst.copy_from(src),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn procedural_and_strided_share_a_cube_pipeline() {
+        assert_eq!(
+            Sync::for_deliveries(&[Delivery::Procedural, Delivery::Strided]),
+            Sync::Cube
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "TMA source cannot share a slot")]
+    fn procedural_and_tma_are_explicitly_rejected() {
+        Sync::for_deliveries(&[Delivery::Procedural, Delivery::Tma]);
     }
 }

--- a/crates/cubek-tile/src/staging/pipeline.rs
+++ b/crates/cubek-tile/src/staging/pipeline.rs
@@ -104,6 +104,7 @@ impl Pipeline {
                 }
                 // A strided source under a barrier is a plain synchronous copy.
                 (TileKind::Smem(d), TileKind::Gmem(s) | TileKind::Smem(s)) => d.fill_from(s, space),
+                (TileKind::Smem(d), TileKind::Procedural(s)) => d.fill_procedural(s, space),
                 _ => panic!("Pipeline::fill: unsupported kind pairing"),
             },
             Pipeline::Cube | Pipeline::Solo => dst.copy_from(src),

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -465,6 +465,9 @@ impl<T: Numeric> MemData<T> {
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("MemData::smem_stored: a fragment is not a stage source")
             }
+            TileKind::Procedural(_) => {
+                panic!("MemData::smem_stored: a procedural tile is not a stage source")
+            }
         }
     }
 
@@ -645,6 +648,7 @@ impl<T: Numeric> Tile<T> {
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::view: a plane tile has no memory view")
             }
+            TileKind::Procedural(_) => panic!("Tile::view: a procedural tile has no memory view"),
         }
     }
 
@@ -662,6 +666,7 @@ impl<T: Numeric> Tile<T> {
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::view_mut: a plane tile has no memory view")
             }
+            TileKind::Procedural(_) => panic!("Tile::view_mut: a procedural tile is not writable"),
         }
     }
 }

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -381,6 +381,33 @@ pub(crate) struct StageMeta {
 
 #[cube]
 impl<T: Numeric> MemData<T> {
+    /// Cooperatively materialize a coordinate-backed source into this plain, direct memory tile.
+    /// This is the one bridge from a procedural source to ordinary tile consumers: once staged,
+    /// all later reads use the normal memory views and leaves.
+    pub(crate) fn fill_procedural(&mut self, src: &ProceduralData<T>, #[comptime] space: Space) {
+        comptime!(assert!(
+            self.store.quant.is_none()
+                && self.projection.is_direct()
+                && self.store.vector_size == 1,
+            "MemData::fill_procedural: procedural sources require a plain, direct scalar destination"
+        ));
+        // Read the destination's runtime window rather than the comptime space so direct copies
+        // also work when another operand witnesses a Dynamic extent.
+        let shape = self.window.extent.clone();
+        let mut dst = self.flat_mut::<Const<1>>();
+        let total = dst.shape();
+        let workers = CUBE_DIM as usize;
+        let mut i = UNIT_POS as usize;
+        while i < total {
+            let pos = unravel(&shape, i.fcast::<u32>());
+            dst.write(
+                i,
+                Vector::cast_from(src.evaluate(&pos, comptime!(space.clone()))),
+            );
+            i += workers;
+        }
+    }
+
     /// Allocate a fresh shared-memory tile shaped to stage one `divide()` sub-tile of `operand`, in
     /// the element that operand needs staged: the one it *serves* when the load is what decodes it
     /// ([`DequantAt::Load`], and always for a plain operand, whose served and stored elements are the

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -258,8 +258,8 @@ impl<T: Numeric> Tile<T> {
             TileKind::Gmem(_) | TileKind::Smem(_) => comptime!(Delivery::Strided),
             TileKind::TmaGmem(_) => comptime!(Delivery::Tma),
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => comptime!(Delivery::Strided),
-            // A procedural source is synchronously materialized into its stage.
-            TileKind::Procedural(_) => comptime!(Delivery::Strided),
+            // A procedural source is cooperatively materialized into its stage.
+            TileKind::Procedural(_) => comptime!(Delivery::Procedural),
         }
     }
 
@@ -619,9 +619,7 @@ impl<T: Numeric> Tile<T> {
                 (TileKind::Gmem(d) | TileKind::Smem(d), TileKind::Gmem(s) | TileKind::Smem(s)) => {
                     d.fill_from(s, space)
                 }
-                (TileKind::Gmem(d) | TileKind::Smem(d), TileKind::Procedural(s)) => {
-                    d.fill_procedural(s, space)
-                }
+                (TileKind::Smem(d), TileKind::Procedural(s)) => d.fill_procedural(s, space),
                 (TileKind::PlaneTile(_), TileKind::PlaneTile(_)) => {
                     panic!("Tile::copy_from: plane tile to plane tile cast not wired")
                 }

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -7,6 +7,7 @@ mod cmma;
 mod mem;
 mod mma;
 mod plane;
+mod procedural;
 mod register;
 mod tma;
 mod view;
@@ -15,6 +16,7 @@ pub use cmma::*;
 pub use mem::*;
 pub use mma::*;
 pub use plane::*;
+pub use procedural::*;
 pub use register::*;
 pub use tma::*;
 pub use view::*;
@@ -42,6 +44,8 @@ pub enum TileKind<T: Numeric> {
     /// A TMA tensor-map source: not element-addressable, its only sink is a hardware bulk
     /// copy into shared memory. Launched via [`TmaTileArg`](crate::TmaTileArg).
     TmaGmem(TmaData<T>),
+    /// A read-only source evaluated from logical coordinates with no backing buffer.
+    Procedural(ProceduralData<T>),
 }
 
 #[cube]
@@ -58,7 +62,8 @@ impl<T: Numeric> TileKind<T> {
             TileKind::Gmem(_)
             | TileKind::Smem(_)
             | TileKind::PlaneTile(_)
-            | TileKind::TmaGmem(_) => {
+            | TileKind::TmaGmem(_)
+            | TileKind::Procedural(_) => {
                 comptime!(false)
             }
         }
@@ -74,7 +79,8 @@ impl<T: Numeric> TileKind<T> {
             TileKind::Gmem(_)
             | TileKind::Smem(_)
             | TileKind::PlaneTile(_)
-            | TileKind::TmaGmem(_) => {
+            | TileKind::TmaGmem(_)
+            | TileKind::Procedural(_) => {
                 comptime!(false)
             }
         }
@@ -216,6 +222,30 @@ fn bound_position(projection: &Projection, axis: Axis) -> usize {
 
 #[cube]
 impl<T: Numeric> Tile<T> {
+    /// Create a scalar, memory-free tile over a static logical space.
+    pub fn procedural(#[comptime] space: Space, #[comptime] recipe: ProceduralRecipe) -> Self {
+        Tile::<T> {
+            tile_kind: TileKind::new_Procedural(ProceduralData::<T>::new(
+                comptime!(space.clone()),
+                recipe,
+            )),
+            space,
+            leaf: comptime!(Leaf::Memory),
+        }
+    }
+
+    /// Evaluate a procedural tile at scalar logical coordinates relative to its current region.
+    pub fn procedural_value(&self, pos: Coords<u32>) -> T {
+        match &self.tile_kind {
+            TileKind::Procedural(data) => data.evaluate(&pos, comptime!(self.space.clone())),
+            TileKind::Gmem(_)
+            | TileKind::Smem(_)
+            | TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::TmaGmem(_) => panic!("Tile::procedural_value: tile is not procedural"),
+        }
+    }
+
     /// How this operand's bytes move: a strided cooperative copy or a TMA hardware bulk
     /// copy. Comptime (the kind is fixed at trace); drives the staging sync. A resident
     /// fragment is never a fill source, so it reports strided.
@@ -224,6 +254,7 @@ impl<T: Numeric> Tile<T> {
             TileKind::Gmem(_) | TileKind::Smem(_) => comptime!(Delivery::Strided),
             TileKind::TmaGmem(_) => comptime!(Delivery::Tma),
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => comptime!(Delivery::Strided),
+            TileKind::Procedural(_) => panic!("Tile::delivery: a procedural tile has no transport"),
         }
     }
 
@@ -231,9 +262,10 @@ impl<T: Numeric> Tile<T> {
     pub(crate) fn runtime_map(&self) -> RuntimeMap {
         match &self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => g.map.clone(),
-            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) | TileKind::TmaGmem(_) => {
-                RuntimeMap::integral(comptime!(self.space.rank()))
-            }
+            TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::TmaGmem(_)
+            | TileKind::Procedural(_) => RuntimeMap::integral(comptime!(self.space.rank())),
         }
     }
 
@@ -246,6 +278,7 @@ impl<T: Numeric> Tile<T> {
             TileKind::TmaGmem(_) | TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 comptime!(StagePlan::strided())
             }
+            TileKind::Procedural(_) => panic!("Tile::stage: a procedural tile cannot be staged"),
         }
     }
 
@@ -255,7 +288,10 @@ impl<T: Numeric> Tile<T> {
     pub fn vector_size(&self) -> comptime_type!(usize) {
         match &self.tile_kind {
             TileKind::Gmem(d) | TileKind::Smem(d) => d.store.vector_size,
-            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) | TileKind::TmaGmem(_) => {
+            TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::TmaGmem(_)
+            | TileKind::Procedural(_) => {
                 comptime!(1usize)
             }
         }
@@ -267,7 +303,10 @@ impl<T: Numeric> Tile<T> {
     pub(crate) fn lane_share(&self) -> comptime_type!(LaneShare) {
         match &self.tile_kind {
             TileKind::Gmem(d) | TileKind::Smem(d) => d.lane_share,
-            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) | TileKind::TmaGmem(_) => {
+            TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::TmaGmem(_)
+            | TileKind::Procedural(_) => {
                 comptime!(LaneShare::Whole)
             }
         }
@@ -280,7 +319,10 @@ impl<T: Numeric> Tile<T> {
     pub(crate) fn dequant_at(&self) -> comptime_type!(DequantAt) {
         match &self.tile_kind {
             TileKind::Gmem(d) | TileKind::Smem(d) => d.dequant_at(),
-            TileKind::TmaGmem(_) | TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
+            TileKind::TmaGmem(_)
+            | TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::Procedural(_) => {
                 comptime!(DequantAt::Load)
             }
         }
@@ -291,7 +333,10 @@ impl<T: Numeric> Tile<T> {
     pub(crate) fn quant_pack(&self) -> comptime_type!(usize) {
         match &self.tile_kind {
             TileKind::Gmem(d) | TileKind::Smem(d) => d.quant_pack(),
-            TileKind::TmaGmem(_) | TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
+            TileKind::TmaGmem(_)
+            | TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::Procedural(_) => {
                 comptime!(0usize)
             }
         }
@@ -334,7 +379,10 @@ impl<T: Numeric> Tile<T> {
     pub(crate) fn projection(&self) -> comptime_type!(Projection) {
         match &self.tile_kind {
             TileKind::Gmem(g) | TileKind::Smem(g) => comptime!(g.projection.clone()),
-            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) | TileKind::TmaGmem(_) => {
+            TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::TmaGmem(_)
+            | TileKind::Procedural(_) => {
                 comptime!(Projection::direct_over(&self.space))
             }
         }
@@ -348,6 +396,9 @@ impl<T: Numeric> Tile<T> {
             TileKind::Smem(g) => TileKind::new_Smem(g.at(region, comptime!(self.space.clone()))),
             TileKind::TmaGmem(t) => {
                 TileKind::new_TmaGmem(t.at(region, comptime!(self.space.clone())))
+            }
+            TileKind::Procedural(p) => {
+                TileKind::new_Procedural(p.at(region, comptime!(self.space.clone())))
             }
             // A plane tile has nothing to window: pass it through. Legal only where the level
             // cuts nothing on m/n (a k-step walk); a cutting level would alias every region
@@ -427,7 +478,9 @@ impl<T: Numeric> Tile<T> {
     fn bounded(&self) -> comptime_type!(bool) {
         match &self.tile_kind {
             TileKind::Gmem(_) | TileKind::Smem(_) | TileKind::TmaGmem(_) => comptime!(true),
-            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => comptime!(false),
+            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) | TileKind::Procedural(_) => {
+                comptime!(false)
+            }
         }
     }
 
@@ -444,6 +497,9 @@ impl<T: Numeric> Tile<T> {
             TileKind::TmaGmem(t) => t.bound[p].fcast::<usize>(),
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 panic!("Tile::runtime_extent: a plane tile has no extent")
+            }
+            TileKind::Procedural(_) => {
+                panic!("Tile::runtime_extent: a procedural tile has no extent")
             }
         };
         // `bound` is a line count on the vectorized innermost axis; the walk divides by
@@ -472,6 +528,7 @@ impl<T: Numeric> Tile<T> {
                 TileKind::PlaneTile(t) => t.zero(),
                 TileKind::PlanePartition(p) => p.zero(),
                 TileKind::TmaGmem(_) => panic!("Tile::zero: a tma source is not writable"),
+                TileKind::Procedural(_) => panic!("Tile::zero: a procedural tile is not writable"),
             },
             Partitioner::Level(_) => {
                 let unroll = self.tile_kind.static_level(comptime!(self.space.clone()));
@@ -491,6 +548,7 @@ impl<T: Numeric> Tile<T> {
                 TileKind::PlaneTile(t) => t.init(val),
                 TileKind::PlanePartition(p) => p.init(val),
                 TileKind::TmaGmem(_) => panic!("Tile::init: a tma source is not writable"),
+                TileKind::Procedural(_) => panic!("Tile::init: a procedural tile is not writable"),
             },
             Partitioner::Level(_) => {
                 let unroll = self.tile_kind.static_level(comptime!(self.space.clone()));
@@ -513,6 +571,7 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::dense: a plane tile has no memory view")
             }
             TileKind::TmaGmem(_) => panic!("Tile::dense: a tma source has no element view"),
+            TileKind::Procedural(_) => panic!("Tile::dense: a procedural tile has no memory view"),
         }
     }
 
@@ -524,6 +583,7 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::dense_mut: a plane tile has no memory view")
             }
             TileKind::TmaGmem(_) => panic!("Tile::dense_mut: a tma source is not writable"),
+            TileKind::Procedural(_) => panic!("Tile::dense_mut: a procedural tile is not writable"),
         }
     }
 
@@ -539,7 +599,8 @@ impl<T: Numeric> Tile<T> {
             TileKind::Gmem(_)
             | TileKind::Smem(_)
             | TileKind::PlaneTile(_)
-            | TileKind::TmaGmem(_) => match (&mut self.tile_kind, &src.tile_kind) {
+            | TileKind::TmaGmem(_)
+            | TileKind::Procedural(_) => match (&mut self.tile_kind, &src.tile_kind) {
                 (TileKind::PlanePartition(d), TileKind::Gmem(_) | TileKind::Smem(_)) => {
                     d.fill_from(src)
                 }
@@ -571,7 +632,8 @@ impl<T: Numeric> Tile<T> {
             TileKind::Gmem(_)
             | TileKind::Smem(_)
             | TileKind::PlaneTile(_)
-            | TileKind::TmaGmem(_) => {
+            | TileKind::TmaGmem(_)
+            | TileKind::Procedural(_) => {
                 panic!("Tile::drain_cast_into: only a partition drains with a cast")
             }
         }

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -255,9 +255,11 @@ impl<T: Numeric> Tile<T> {
     /// fragment is never a fill source, so it reports strided.
     pub fn delivery(&self) -> comptime_type!(Delivery) {
         match &self.tile_kind {
-            TileKind::Gmem(_) | TileKind::Smem(_) => comptime!(Delivery::Strided),
+            TileKind::Gmem(_) | TileKind::Smem(_) => comptime!(Delivery::Copy),
             TileKind::TmaGmem(_) => comptime!(Delivery::Tma),
-            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => comptime!(Delivery::Strided),
+            TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
+                panic!("Tile::delivery: a resident fragment is not a stage source")
+            }
             // A procedural source is cooperatively materialized into its stage.
             TileKind::Procedural(_) => comptime!(Delivery::Procedural),
         }

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -222,8 +222,12 @@ fn bound_position(projection: &Projection, axis: Axis) -> usize {
 
 #[cube]
 impl<T: Numeric> Tile<T> {
-    /// Create a scalar, memory-free tile over a static logical space.
-    pub fn procedural(#[comptime] space: Space, #[comptime] recipe: ProceduralRecipe) -> Self {
+    /// Create a scalar, memory-free tile over a logical space. Dynamic extents are supplied by
+    /// another operand when an operation is walked; a procedural tile never witnesses them.
+    pub fn procedural(#[comptime] space: Space, #[comptime] recipe: ProceduralRecipe) -> Self
+    where
+        T: Float,
+    {
         Tile::<T> {
             tile_kind: TileKind::new_Procedural(ProceduralData::<T>::new(
                 comptime!(space.clone()),
@@ -254,7 +258,8 @@ impl<T: Numeric> Tile<T> {
             TileKind::Gmem(_) | TileKind::Smem(_) => comptime!(Delivery::Strided),
             TileKind::TmaGmem(_) => comptime!(Delivery::Tma),
             TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => comptime!(Delivery::Strided),
-            TileKind::Procedural(_) => panic!("Tile::delivery: a procedural tile has no transport"),
+            // A procedural source is synchronously materialized into its stage.
+            TileKind::Procedural(_) => comptime!(Delivery::Strided),
         }
     }
 
@@ -278,7 +283,7 @@ impl<T: Numeric> Tile<T> {
             TileKind::TmaGmem(_) | TileKind::PlaneTile(_) | TileKind::PlanePartition(_) => {
                 comptime!(StagePlan::strided())
             }
-            TileKind::Procedural(_) => panic!("Tile::stage: a procedural tile cannot be staged"),
+            TileKind::Procedural(_) => comptime!(StagePlan::strided()),
         }
     }
 
@@ -613,6 +618,9 @@ impl<T: Numeric> Tile<T> {
                 (TileKind::Smem(d), TileKind::TmaGmem(s)) => s.load_into(d),
                 (TileKind::Gmem(d) | TileKind::Smem(d), TileKind::Gmem(s) | TileKind::Smem(s)) => {
                     d.fill_from(s, space)
+                }
+                (TileKind::Gmem(d) | TileKind::Smem(d), TileKind::Procedural(s)) => {
+                    d.fill_procedural(s, space)
                 }
                 (TileKind::PlaneTile(_), TileKind::PlaneTile(_)) => {
                     panic!("Tile::copy_from: plane tile to plane tile cast not wired")

--- a/crates/cubek-tile/src/tile/plane.rs
+++ b/crates/cubek-tile/src/tile/plane.rs
@@ -101,7 +101,10 @@ impl<T: Numeric> PlaneTile<T> {
         match self {
             PlaneTile::Cmma(d) => match &src.tile_kind {
                 TileKind::Gmem(m) | TileKind::Smem(m) => d.load_window(m),
-                TileKind::PlaneTile(_) | TileKind::PlanePartition(_) | TileKind::TmaGmem(_) => {
+                TileKind::PlaneTile(_)
+                | TileKind::PlanePartition(_)
+                | TileKind::TmaGmem(_)
+                | TileKind::Procedural(_) => {
                     panic!("PlaneTile::load_window: a cmma fragment loads from memory")
                 }
             },
@@ -310,7 +313,10 @@ impl<T: Numeric> PlanePartition<T> {
                 let mut window = dst.fragment_window(mi, ni);
                 match &mut window.tile_kind {
                     TileKind::Gmem(g) | TileKind::Smem(g) => frag.store_window(g),
-                    TileKind::PlaneTile(_) | TileKind::PlanePartition(_) | TileKind::TmaGmem(_) => {
+                    TileKind::PlaneTile(_)
+                    | TileKind::PlanePartition(_)
+                    | TileKind::TmaGmem(_)
+                    | TileKind::Procedural(_) => {
                         panic!("PlanePartition::drain_into: the sink must be memory")
                     }
                 }
@@ -329,7 +335,10 @@ impl<T: Numeric> PlanePartition<T> {
                 let mut window = dst.fragment_window(mi, ni);
                 match &mut window.tile_kind {
                     TileKind::Gmem(g) | TileKind::Smem(g) => frag.store_cast_window(g),
-                    TileKind::PlaneTile(_) | TileKind::PlanePartition(_) | TileKind::TmaGmem(_) => {
+                    TileKind::PlaneTile(_)
+                    | TileKind::PlanePartition(_)
+                    | TileKind::TmaGmem(_)
+                    | TileKind::Procedural(_) => {
                         panic!("PlanePartition::drain_cast_into: the sink must be memory")
                     }
                 }

--- a/crates/cubek-tile/src/tile/procedural.rs
+++ b/crates/cubek-tile/src/tile/procedural.rs
@@ -52,10 +52,6 @@ pub struct ProceduralData<T: Numeric> {
 #[cube]
 impl<T: Numeric> ProceduralData<T> {
     pub(crate) fn new(#[comptime] space: Space, #[comptime] recipe: ProceduralRecipe) -> Self {
-        comptime!(assert!(
-            space.is_static(),
-            "Tile::procedural: procedural tiles require a static Space; another operand must witness Dynamic axes"
-        ));
         let mut origin = Coords::<u32>::new();
         #[unroll]
         for _ in 0..comptime!(space.rank()) {

--- a/crates/cubek-tile/src/tile/procedural.rs
+++ b/crates/cubek-tile/src/tile/procedural.rs
@@ -1,5 +1,7 @@
 //! A memory-free tile source evaluated from logical coordinates.
 
+use core::marker::PhantomData;
+
 use cubecl::prelude::*;
 
 use crate::{Axis, Coords, Fold, FoldExpand, Region, Space};
@@ -44,9 +46,10 @@ impl ProceduralRecipe {
 #[expand(derive(Clone))]
 pub struct ProceduralData<T: Numeric> {
     origin: Coords<u32>,
-    one: T,
     #[cube(comptime)]
     recipe: ProceduralRecipe,
+    #[cube(comptime)]
+    _marker: PhantomData<T>,
 }
 
 #[cube]
@@ -59,8 +62,8 @@ impl<T: Numeric> ProceduralData<T> {
         }
         ProceduralData::<T> {
             origin,
-            one: T::from_int(1),
             recipe,
+            _marker: PhantomData,
         }
     }
 
@@ -74,8 +77,8 @@ impl<T: Numeric> ProceduralData<T> {
         }
         ProceduralData::<T> {
             origin,
-            one: self.one,
             recipe: comptime!(self.recipe.clone()),
+            _marker: PhantomData,
         }
     }
 
@@ -91,14 +94,16 @@ impl<T: Numeric> ProceduralData<T> {
     ) -> T {
         match comptime!(recipe) {
             ProceduralRecipe::Zero => T::from_int(0),
-            ProceduralRecipe::One => self.one,
-            ProceduralRecipe::Uniform { denominator } => self.one / T::from_int(denominator as i64),
+            ProceduralRecipe::One => T::from_int(1),
+            ProceduralRecipe::Uniform { denominator } => {
+                T::from_int(1) / T::from_int(denominator as i64)
+            }
             ProceduralRecipe::AxisIndex { axis } => {
                 let p = comptime!(space.position(axis));
                 T::cast_from(self.origin.at(p) + pos.at(p))
             }
             ProceduralRecipe::AxisProduct(factors) => {
-                let mut value = self.one;
+                let mut value = T::from_int(1);
                 #[allow(clippy::needless_range_loop)]
                 #[unroll]
                 for i in 0..comptime!(factors.len()) {

--- a/crates/cubek-tile/src/tile/procedural.rs
+++ b/crates/cubek-tile/src/tile/procedural.rs
@@ -1,0 +1,119 @@
+//! A memory-free tile source evaluated from logical coordinates.
+
+use cubecl::prelude::*;
+
+use crate::{Axis, Coords, Fold, FoldExpand, Region, Space};
+
+/// Built-in recipes for a [`TileKind::Procedural`](crate::TileKind::Procedural) source.
+///
+/// Recipes are comptime values, not runtime callbacks. [`AxisProduct`](Self::AxisProduct)
+/// deliberately preserves separability so a later operand reader can cache one factor per axis.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum ProceduralRecipe {
+    Zero,
+    One,
+    Uniform { denominator: usize },
+    AxisIndex { axis: Axis },
+    AxisProduct(Vec<ProceduralRecipe>),
+}
+
+impl ProceduralRecipe {
+    pub fn zero() -> Self {
+        Self::Zero
+    }
+    pub fn one() -> Self {
+        Self::One
+    }
+    pub fn uniform(denominator: usize) -> Self {
+        assert!(
+            denominator > 0,
+            "ProceduralRecipe::uniform: denominator must be non-zero"
+        );
+        Self::Uniform { denominator }
+    }
+    pub fn axis_index(axis: Axis) -> Self {
+        Self::AxisIndex { axis }
+    }
+    pub fn axis_product(factors: Vec<ProceduralRecipe>) -> Self {
+        Self::AxisProduct(factors)
+    }
+}
+
+/// Runtime state of a procedural source. `origin` tracks regions selected by `Tile::at`.
+#[derive(CubeType, Clone)]
+#[expand(derive(Clone))]
+pub struct ProceduralData<T: Numeric> {
+    origin: Coords<u32>,
+    one: T,
+    #[cube(comptime)]
+    recipe: ProceduralRecipe,
+}
+
+#[cube]
+impl<T: Numeric> ProceduralData<T> {
+    pub(crate) fn new(#[comptime] space: Space, #[comptime] recipe: ProceduralRecipe) -> Self {
+        comptime!(assert!(
+            space.is_static(),
+            "Tile::procedural: procedural tiles require a static Space; another operand must witness Dynamic axes"
+        ));
+        let mut origin = Coords::<u32>::new();
+        #[unroll]
+        for _ in 0..comptime!(space.rank()) {
+            origin.push(0u32.runtime());
+        }
+        ProceduralData::<T> {
+            origin,
+            one: T::from_int(1),
+            recipe,
+        }
+    }
+
+    pub(crate) fn at(&self, region: &Region, #[comptime] space: Space) -> Self {
+        let mut origin = Coords::<u32>::new();
+        #[unroll]
+        for p in 0..comptime!(space.rank()) {
+            let axis = comptime!(space.axis_at(p));
+            let edge = comptime!(space.partitioner().edge(axis) as u32);
+            origin.push(self.origin.at(p) + region.coord(axis).fcast::<u32>() * edge);
+        }
+        ProceduralData::<T> {
+            origin,
+            one: self.one,
+            recipe: comptime!(self.recipe.clone()),
+        }
+    }
+
+    pub(crate) fn evaluate(&self, pos: &Coords<u32>, #[comptime] space: Space) -> T {
+        self.value_recipe(pos, space, comptime!(self.recipe.clone()))
+    }
+
+    fn value_recipe(
+        &self,
+        pos: &Coords<u32>,
+        #[comptime] space: Space,
+        #[comptime] recipe: ProceduralRecipe,
+    ) -> T {
+        match comptime!(recipe) {
+            ProceduralRecipe::Zero => T::from_int(0),
+            ProceduralRecipe::One => self.one,
+            ProceduralRecipe::Uniform { denominator } => self.one / T::from_int(denominator as i64),
+            ProceduralRecipe::AxisIndex { axis } => {
+                let p = comptime!(space.position(axis));
+                T::cast_from(self.origin.at(p) + pos.at(p))
+            }
+            ProceduralRecipe::AxisProduct(factors) => {
+                let mut value = self.one;
+                #[allow(clippy::needless_range_loop)]
+                #[unroll]
+                for i in 0..comptime!(factors.len()) {
+                    value *= self.value_recipe(
+                        pos,
+                        comptime!(space.clone()),
+                        comptime!(factors[i].clone()),
+                    );
+                }
+                value
+            }
+        }
+    }
+}

--- a/crates/cubek-tile/src/tile/view/flat.rs
+++ b/crates/cubek-tile/src/tile/view/flat.rs
@@ -75,6 +75,7 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::flat: a plane tile has no memory view")
             }
             TileKind::TmaGmem(_) => panic!("Tile::flat: a tma source has no element view"),
+            TileKind::Procedural(_) => panic!("Tile::flat: a procedural tile has no memory view"),
         }
     }
 
@@ -85,6 +86,7 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::flat_mut: a plane tile has no memory view")
             }
             TileKind::TmaGmem(_) => panic!("Tile::flat_mut: a tma source has no element view"),
+            TileKind::Procedural(_) => panic!("Tile::flat_mut: a procedural tile is not writable"),
         }
     }
 }

--- a/crates/cubek-tile/src/tile/view/matrix.rs
+++ b/crates/cubek-tile/src/tile/view/matrix.rs
@@ -290,6 +290,7 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::matrix: a plane tile has no memory view")
             }
             TileKind::TmaGmem(_) => panic!("Tile::matrix: a tma source has no element view"),
+            TileKind::Procedural(_) => panic!("Tile::matrix: a procedural tile has no memory view"),
         }
     }
 
@@ -317,6 +318,9 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::matrix_mut: a plane tile has no memory view")
             }
             TileKind::TmaGmem(_) => panic!("Tile::matrix_mut: a tma source has no element view"),
+            TileKind::Procedural(_) => {
+                panic!("Tile::matrix_mut: a procedural tile is not writable")
+            }
         }
     }
 
@@ -348,6 +352,9 @@ impl<T: Numeric> Tile<T> {
             }
             TileKind::TmaGmem(_) => {
                 panic!("Tile::matrix_transparent: a tma source has no element view")
+            }
+            TileKind::Procedural(_) => {
+                panic!("Tile::matrix_transparent: a procedural tile has no memory view")
             }
         }
     }
@@ -382,6 +389,9 @@ impl<T: Numeric> Tile<T> {
             }
             TileKind::TmaGmem(_) => {
                 panic!("Tile::fragment_matrix: a tma source has no element view")
+            }
+            TileKind::Procedural(_) => {
+                panic!("Tile::fragment_matrix: a procedural tile has no memory view")
             }
         }
     }

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -293,6 +293,9 @@ impl<T: Numeric> Tile<T> {
                 panic!("Tile::nd: a plane tile has no memory view")
             }
             TileKind::TmaGmem(_) => panic!("Tile::nd: a tma source has no element view"),
+            TileKind::Procedural(_) => {
+                panic!("Tile::nd: use Tile::procedural_value for a procedural tile")
+            }
         }
     }
 }

--- a/crates/cubek-tile/tests/tile/mod.rs
+++ b/crates/cubek-tile/tests/tile/mod.rs
@@ -3,6 +3,7 @@ mod conv;
 mod instruction;
 mod launcher;
 mod matmul;
+mod procedural;
 mod quant;
 mod recursive;
 mod reduce;

--- a/crates/cubek-tile/tests/tile/procedural.rs
+++ b/crates/cubek-tile/tests/tile/procedural.rs
@@ -1,0 +1,86 @@
+//! Procedural tiles evaluate logical coordinates without a tensor-backed source.
+
+use cubecl::{Runtime, TestRuntime, prelude::*, zspace::shape};
+use cubek_test_utils::{HostData, HostDataType, TestInput};
+use cubek_tile::*;
+
+const ROW: Axis = Axis(0);
+const COL: Axis = Axis(1);
+
+#[cube(launch)]
+fn procedural_kernel<E: Numeric>(
+    output: &TileArg<'_, E, Const<1>>,
+    #[comptime] space: Space,
+    #[comptime] recipe: ProceduralRecipe,
+    #[define(E)] _dtype: ElemType,
+) {
+    let source = Tile::<E>::procedural(comptime!(space.clone()), recipe);
+    // Select the second 2x3 tile, then evaluate its first logical coordinate. This exercises
+    // `Tile::at`'s origin rebasing rather than merely the top-level recipe evaluation.
+    let region = Region::trailing(comptime!(space.clone()), 1usize, 1usize);
+    let source = source.at(&region);
+    let mut pos = Coords::<u32>::new();
+    pos.push(0u32.runtime());
+    pos.push(0u32.runtime());
+
+    let mut output = output.tile(space);
+    output.init(source.procedural_value(pos));
+}
+
+fn run(recipe: ProceduralRecipe) -> HostData {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::elem_type_native();
+    let space = Tiling::new()
+        .extents(&[(ROW, 4), (COL, 6)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |level| {
+            level
+                .axis(ROW, Cut::sequential(2))
+                .axis(COL, Cut::sequential(3))
+        })
+        .build();
+    let output = TestInput::builder(client.clone(), shape![4, 6])
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+
+    procedural_kernel::launch::<TestRuntime>(
+        &client,
+        space.cube_count(),
+        space.cube_dim(&client),
+        TileArgLaunch::new(
+            output.clone().binding().into_tensor_arg(),
+            TileSpec::direct(&[ROW, COL]),
+        ),
+        space,
+        recipe,
+        dtype,
+    );
+
+    HostData::from_tensor_handle(&client, output, HostDataType::F32)
+}
+
+#[test]
+fn evaluates_separable_axis_products_after_region_rebase() {
+    // The selected region begins at (2, 3), so AxisIndex(ROW) * AxisIndex(COL) is 6.
+    let got = run(ProceduralRecipe::axis_product(vec![
+        ProceduralRecipe::axis_index(ROW),
+        ProceduralRecipe::axis_index(COL),
+    ]));
+    for row in 0..4 {
+        for col in 0..6 {
+            assert_eq!(got.get_f32(&[row, col]), 6.0);
+        }
+    }
+}
+
+#[test]
+fn evaluates_zero_one_and_uniform_recipes() {
+    for (recipe, expected) in [
+        (ProceduralRecipe::zero(), 0.0),
+        (ProceduralRecipe::one(), 1.0),
+        (ProceduralRecipe::uniform(4), 0.25),
+    ] {
+        let got = run(recipe);
+        assert_eq!(got.get_f32(&[0, 0]), expected);
+    }
+}

--- a/crates/cubek-tile/tests/tile/procedural.rs
+++ b/crates/cubek-tile/tests/tile/procedural.rs
@@ -27,18 +27,25 @@ fn procedural_kernel<E: Float>(
     output.init(source.procedural_value(pos));
 }
 
-/// Exercise the normal tile-copy path: the procedural source is materialized by the same
-/// `copy_from` transport staging uses, rather than being read through its bespoke accessor.
+/// Exercise the staging path: the procedural source is cooperatively materialized into smem
+/// before the normal memory-to-memory copy reaches the output.
 #[cube(launch)]
-fn procedural_copy_kernel<E: Float>(
+fn procedural_stage_kernel<E: Float>(
     output: &TileArg<'_, E, Const<1>>,
     #[comptime] space: Space,
     #[comptime] recipe: ProceduralRecipe,
     #[define(E)] _dtype: ElemType,
 ) {
     let source = Tile::<E>::procedural(comptime!(space.clone()), recipe);
-    let mut output = output.tile(space);
-    output.copy_from(&source);
+    let output = output.tile(comptime!(space.clone()));
+    let mut staging = Staging::single(&source, comptime!(space.clone()), comptime!(space.clone()));
+    let walk = Walk::over(source.runtime_space());
+    for region in walk {
+        staging.fill_streamed(&source, &region);
+        staging.consume_final(|staged| {
+            output.at(&region).copy_from(staged);
+        });
+    }
 }
 
 fn run(recipe: ProceduralRecipe) -> HostData {
@@ -89,7 +96,7 @@ fn run_copy(recipe: ProceduralRecipe) -> HostData {
         .zeros()
         .generate_without_host_data();
 
-    procedural_copy_kernel::launch::<TestRuntime>(
+    procedural_stage_kernel::launch::<TestRuntime>(
         &client,
         space.cube_count(),
         space.cube_dim(&client),
@@ -120,7 +127,7 @@ fn evaluates_separable_axis_products_after_region_rebase() {
 }
 
 #[test]
-fn copies_coordinate_varying_values_through_the_tile_transport() {
+fn stages_coordinate_varying_values_through_shared_memory() {
     let got = run_copy(ProceduralRecipe::axis_product(vec![
         ProceduralRecipe::axis_index(ROW),
         ProceduralRecipe::axis_index(COL),

--- a/crates/cubek-tile/tests/tile/procedural.rs
+++ b/crates/cubek-tile/tests/tile/procedural.rs
@@ -8,7 +8,7 @@ const ROW: Axis = Axis(0);
 const COL: Axis = Axis(1);
 
 #[cube(launch)]
-fn procedural_kernel<E: Numeric>(
+fn procedural_kernel<E: Float>(
     output: &TileArg<'_, E, Const<1>>,
     #[comptime] space: Space,
     #[comptime] recipe: ProceduralRecipe,
@@ -25,6 +25,20 @@ fn procedural_kernel<E: Numeric>(
 
     let mut output = output.tile(space);
     output.init(source.procedural_value(pos));
+}
+
+/// Exercise the normal tile-copy path: the procedural source is materialized by the same
+/// `copy_from` transport staging uses, rather than being read through its bespoke accessor.
+#[cube(launch)]
+fn procedural_copy_kernel<E: Float>(
+    output: &TileArg<'_, E, Const<1>>,
+    #[comptime] space: Space,
+    #[comptime] recipe: ProceduralRecipe,
+    #[define(E)] _dtype: ElemType,
+) {
+    let source = Tile::<E>::procedural(comptime!(space.clone()), recipe);
+    let mut output = output.tile(space);
+    output.copy_from(&source);
 }
 
 fn run(recipe: ProceduralRecipe) -> HostData {
@@ -59,6 +73,38 @@ fn run(recipe: ProceduralRecipe) -> HostData {
     HostData::from_tensor_handle(&client, output, HostDataType::F32)
 }
 
+fn run_copy(recipe: ProceduralRecipe) -> HostData {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::elem_type_native();
+    let space = Tiling::new()
+        .extents(&[(ROW, 4), (COL, 6)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |level| {
+            level
+                .axis(ROW, Cut::sequential(2))
+                .axis(COL, Cut::sequential(3))
+        })
+        .build();
+    let output = TestInput::builder(client.clone(), shape![4, 6])
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+
+    procedural_copy_kernel::launch::<TestRuntime>(
+        &client,
+        space.cube_count(),
+        space.cube_dim(&client),
+        TileArgLaunch::new(
+            output.clone().binding().into_tensor_arg(),
+            TileSpec::direct(&[ROW, COL]),
+        ),
+        space,
+        recipe,
+        dtype,
+    );
+
+    HostData::from_tensor_handle(&client, output, HostDataType::F32)
+}
+
 #[test]
 fn evaluates_separable_axis_products_after_region_rebase() {
     // The selected region begins at (2, 3), so AxisIndex(ROW) * AxisIndex(COL) is 6.
@@ -69,6 +115,19 @@ fn evaluates_separable_axis_products_after_region_rebase() {
     for row in 0..4 {
         for col in 0..6 {
             assert_eq!(got.get_f32(&[row, col]), 6.0);
+        }
+    }
+}
+
+#[test]
+fn copies_coordinate_varying_values_through_the_tile_transport() {
+    let got = run_copy(ProceduralRecipe::axis_product(vec![
+        ProceduralRecipe::axis_index(ROW),
+        ProceduralRecipe::axis_index(COL),
+    ]));
+    for row in 0..4 {
+        for col in 0..6 {
+            assert_eq!(got.get_f32(&[row, col]), (row * col) as f32);
         }
     }
 }


### PR DESCRIPTION
## Summary

- add coordinate-evaluated procedural tile recipes
- materialize procedural sources through shared-memory staging
- support procedural delivery alongside copy and TMA paths

## Validation

- `cargo test -p cubek-tile --tests`
- `cargo clippy -p cubek-tile --all-targets -- -D warnings`