### PR TITLE
fix(matmul): keep the naive load's unroll bound constant

### DIFF
--- a/crates/cubek-matmul/src/components/batch/naive/matmul.rs
+++ b/crates/cubek-matmul/src/components/batch/naive/matmul.rs
@@ -176,8 +176,14 @@ fn load_unrolled<I: Numeric, N: Size, N2: Size>(
     } else {
         let (row, col) = pos;
         let mut out = Vector::empty();
+        // Cast host-side: `as` inside `#[cube]` emits an IR cast, whose result is not a constant,
+        // and an unrolled range rejects a non-constant bound.
         #[unroll]
-        for i in range_stepped(0, vector_size as u32, view_vector_size as u32) {
+        for i in range_stepped(
+            0u32,
+            comptime!(vector_size as u32),
+            comptime!(view_vector_size as u32),
+        ) {
             let pos = match layout {
                 MatrixLayout::RowMajor => (row, col + i),
                 MatrixLayout::ColMajor => (row + i, col),


### PR DESCRIPTION
`as` inside `#[cube]` emits an IR cast, so `vector_size as u32` reached the unrolled range as a variable rather than a constant and expansion panicked with "Only constant end can be unrolled". The kernel was then never built and the matmul wrote nothing, so a quantized lhs came back as zeros.

Only the path where the view's vector size differs from the register's takes that branch, which is why it showed up on Q8 packed into u32 and not on Q4, Q2, or a native store, where the two agree and the fast path runs instead.

Fixes test_matmul_quantized_{lhs,lhs_batched,lhs_q8f,lhs_rect}.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
