### PR TITLE
Route the elementwise dequantize through the tile path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "cubek-interpolate",
  "cubek-matmul",
  "cubek-pool",
+ "cubek-quant",
  "cubek-reduce",
  "cubek-std",
  "cubek-test-utils",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -63,6 +63,9 @@ cubek-matmul = { path = "../crates/cubek-matmul", version = "=0.3.0-pre.2", feat
 cubek-pool = { path = "../crates/cubek-pool", version = "=0.3.0-pre.2", features = [
     "benchmarks",
 ] }
+cubek-quant = { path = "../crates/cubek-quant", version = "=0.3.0-pre.2", features = [
+    "benchmarks",
+] }
 cubek-reduce = { path = "../crates/cubek-reduce", version = "=0.3.0-pre.2", features = [
     "benchmarks",
 ] }
@@ -111,6 +114,10 @@ name = "split_k"
 [[bench]]
 harness = false
 name = "conv2d"
+
+[[bench]]
+harness = false
+name = "dequantize"
 
 [[bench]]
 harness = false

--- a/benchmarks/benches/dequantize.rs
+++ b/benchmarks/benches/dequantize.rs
@@ -1,0 +1,1 @@
+benchmarks::run_bench!(dequantize);

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -13,6 +13,7 @@ pub use cubek_matmul::eval::benchmarks::quantized_matmul;
 pub use cubek_matmul::eval::benchmarks::split_k;
 pub use cubek_matmul::eval::benchmarks::tile_quant_stage;
 pub use cubek_pool::eval::benchmarks as pool;
+pub use cubek_quant::eval::benchmarks::dequantize;
 pub use cubek_reduce::eval::benchmarks as reduce;
 pub use cubek_std::eval::benchmarks::contiguous;
 pub use cubek_std::eval::benchmarks::memcpy_async;
@@ -30,6 +31,7 @@ pub fn all() -> &'static [&'static dyn BenchmarkCategory] {
         &crate::attention_backward::Category,
         &crate::contiguous::Category,
         &crate::conv2d::Category,
+        &crate::dequantize::Category,
         &crate::fft::Category,
         &crate::gemm::Category,
         &crate::gemm_cpu::Category,

--- a/crates/cubek-quant/Cargo.toml
+++ b/crates/cubek-quant/Cargo.toml
@@ -17,11 +17,16 @@ std = []
 
 heavy = []
 extended = ["heavy"]
-full = ["extended"]
+full = ["extended", "benchmarks"]
+
+# Enables `pub mod eval`, the dequantize benchmark catalogue. Off by default;
+# the top-level `benchmarks` crate turns it on.
+benchmarks = ["kernels", "dep:cubek-test-utils", "cubecl/test-runtime"]
 
 [dependencies]
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true, features = ["fp8"] }
+cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.2", default-features = false, optional = true }
 cubek-tile = { path = "../cubek-tile", version = "=0.3.0-pre.2", default-features = false }
 
 half.workspace = true

--- a/crates/cubek-quant/src/dequantize.rs
+++ b/crates/cubek-quant/src/dequantize.rs
@@ -7,7 +7,7 @@ use cubecl::{prelude::*, std::tensor::layout::linear::LinearViewMut};
 use crate::{
     layout::{ScalesView, scales_view},
     scale::Scales,
-    scheme::{QuantMode, QuantScheme, QuantStore, QuantValue},
+    scheme::{BlockSize, QuantMode, QuantScheme, QuantStore, QuantValue, ScaleDtype},
     utils::packed_storage_elem,
 };
 use cubecl::std::quant::check_scale_bindings;
@@ -185,8 +185,16 @@ fn dequantize_symmetric_native_kernel<F: Float, N: Size, FS: Numeric, Q: Numeric
     );
 }
 
-#[allow(clippy::result_large_err)]
 /// Convert the tensor back to a higher precision data type.
+///
+/// `scales` holds one binding per scale level, innermost first. A packed store's `input` is
+/// the stored binding, its packed axis counted in `u32` words.
+///
+/// # Errors
+///
+/// Propagates the kernel's [`LaunchError`]. A scheme neither path can serve panics on the
+/// caller's thread instead, so the plan fails loudly.
+#[allow(clippy::result_large_err)]
 pub fn launch_ref<R: Runtime>(
     client: &ComputeClient<R>,
     input: TensorBinding<R>,
@@ -197,6 +205,115 @@ pub fn launch_ref<R: Runtime>(
 ) -> Result<(), LaunchError> {
     check_scale_bindings(scheme, scales.len());
 
+    let widest_line = client
+        .io_optimized_vector_sizes(size_of::<u32>().max(output_dtype.size()))
+        .next()
+        .unwrap_or(1);
+    match dequant_path(scheme, widest_line, &input.strides, &output.strides) {
+        DequantPath::Tile => launch_tile(client, input, output, scales, scheme, output_dtype),
+        DequantPath::Legacy => launch_legacy(client, input, output, scales, scheme, output_dtype),
+    }
+}
+
+/// Which implementation serves a launch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DequantPath {
+    /// The tile-engine kernel.
+    Tile,
+    /// The elementwise kernels, kept for what the tile path cannot express.
+    Legacy,
+}
+
+/// Route a launch from host data alone, so the routing matrix is unit-tested.
+///
+/// The tile path serves f32-scale symmetric schemes over contiguous innermost dims, with
+/// values stored natively or as innermost-packed `u32` words a device line can cover whole
+/// (`widest_line` is the widest line over the storage word); a FULL dim inside a block is
+/// refused because it would put a zero edge into the scale windowing. Everything else keeps
+/// the legacy kernels.
+fn dequant_path(
+    scheme: &QuantScheme,
+    widest_line: usize,
+    input_strides: &[usize],
+    output_strides: &[usize],
+) -> DequantPath {
+    let store_served = match scheme.store {
+        QuantStore::Native => matches!(
+            scheme.value,
+            QuantValue::Q8F | QuantValue::Q8S | QuantValue::E4M3 | QuantValue::E5M2
+        ),
+        QuantStore::PackedU32(0) => scheme.num_quants() <= widest_line,
+        _ => false,
+    };
+    let block_served = scheme
+        .block_size()
+        .is_none_or(|block| !block.as_slice().contains(&BlockSize::FULL));
+    let contiguous = input_strides.last() == Some(&1) && output_strides.last() == Some(&1);
+
+    if scheme.scale_dtype() == ScaleDtype::F32
+        && scheme.mode == QuantMode::Symmetric
+        && store_served
+        && block_served
+        && contiguous
+    {
+        DequantPath::Tile
+    } else {
+        DequantPath::Legacy
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn launch_tile<R: Runtime>(
+    client: &ComputeClient<R>,
+    input: TensorBinding<R>,
+    output: TensorBinding<R>,
+    scales: &[TensorBinding<R>],
+    scheme: &QuantScheme,
+    output_dtype: ElemType,
+) -> Result<(), LaunchError> {
+    let values = match scheme.store {
+        QuantStore::PackedU32(_) => {
+            packed_binding_in_values(input, &output.shape, scheme.num_quants())
+        }
+        _ => input,
+    };
+    crate::dequantize_tiled::launch_ref(client, values, output, scales, scheme, output_dtype)
+}
+
+/// Re-declare a packed binding from storage to values: the caller counts the packed axis in
+/// `u32` words, while the tile path counts the values they hold, so the innermost extent
+/// widens by `num_quants` and every coarser stride re-expresses in values (the innermost
+/// stays 1; the buffer keeps its storage width).
+fn packed_binding_in_values<R: Runtime>(
+    stored: TensorBinding<R>,
+    output_shape: &[usize],
+    num_quants: usize,
+) -> TensorBinding<R> {
+    let mut values = stored;
+    let rank = values.shape.len();
+    values.shape[rank - 1] *= num_quants;
+    assert_eq!(
+        &values.shape[..],
+        output_shape,
+        "dequantize: the stored shape widened by the packing factor must match the output"
+    );
+    for stride in &mut values.strides[..rank - 1] {
+        *stride *= num_quants;
+    }
+    values
+}
+
+/// The elementwise kernels; [`launch_ref`] falls back here when the tile path cannot serve a
+/// launch.
+#[allow(clippy::result_large_err)]
+pub(crate) fn launch_legacy<R: Runtime>(
+    client: &ComputeClient<R>,
+    input: TensorBinding<R>,
+    output: TensorBinding<R>,
+    scales: &[TensorBinding<R>],
+    scheme: &QuantScheme,
+    output_dtype: ElemType,
+) -> Result<(), LaunchError> {
     let scale_dtype: ElemType = ElemType::from_scale_dtype(scheme.scale_dtype());
     let (scale, global) = (scales[0].clone(), scales.get(1).cloned());
 
@@ -366,4 +483,110 @@ fn dequantize_native<R: Runtime>(
     };
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONTIGUOUS: &[usize] = &[64, 1];
+    const WIDEST_LINE: usize = 4;
+
+    fn path(scheme: QuantScheme) -> DequantPath {
+        dequant_path(&scheme, WIDEST_LINE, CONTIGUOUS, CONTIGUOUS)
+    }
+
+    fn native_q8s() -> QuantScheme {
+        QuantScheme::default()
+            .with_store(QuantStore::Native)
+            .with_value(QuantValue::Q8S)
+    }
+
+    #[test]
+    fn native_per_tensor_takes_the_tile_path() {
+        assert_eq!(path(native_q8s()), DequantPath::Tile);
+    }
+
+    #[test]
+    fn native_block_takes_the_tile_path() {
+        let scheme = native_q8s().per_block([32], ScaleDtype::F32);
+        assert_eq!(path(scheme), DequantPath::Tile);
+    }
+
+    #[test]
+    fn two_level_takes_the_tile_path() {
+        let scheme = native_q8s()
+            .per_block([16], ScaleDtype::F32)
+            .per_tensor(ScaleDtype::F32);
+        assert_eq!(path(scheme), DequantPath::Tile);
+    }
+
+    #[test]
+    fn packed_within_the_device_line_takes_the_tile_path() {
+        let scheme = QuantScheme::default().with_value(QuantValue::Q8S);
+        assert_eq!(scheme.num_quants(), WIDEST_LINE);
+        assert_eq!(path(scheme), DequantPath::Tile);
+    }
+
+    /// A served line covers whole `u32` words or nothing, so a packing factor past the
+    /// device's widest line has no tile plan and must keep the legacy kernel.
+    #[test]
+    fn packed_past_the_device_line_falls_back() {
+        let scheme = QuantScheme::default().with_value(QuantValue::Q4S);
+        assert_eq!(path(scheme), DequantPath::Legacy);
+        assert_eq!(
+            dequant_path(&scheme, 8, CONTIGUOUS, CONTIGUOUS),
+            DequantPath::Tile
+        );
+    }
+
+    #[test]
+    fn non_f32_scales_fall_back() {
+        let scheme = native_q8s().per_tensor(ScaleDtype::F16);
+        assert_eq!(path(scheme), DequantPath::Legacy);
+    }
+
+    #[test]
+    fn native_sub_byte_values_fall_back() {
+        let scheme = QuantScheme::default()
+            .with_store(QuantStore::Native)
+            .with_value(QuantValue::Q4S);
+        assert_eq!(path(scheme), DequantPath::Legacy);
+    }
+
+    #[test]
+    fn global_dim_packing_falls_back() {
+        let scheme = QuantScheme::default()
+            .with_store(QuantStore::PackedU32(1))
+            .with_value(QuantValue::Q8S);
+        assert_eq!(path(scheme), DequantPath::Legacy);
+    }
+
+    #[test]
+    fn packed_native_falls_back() {
+        let scheme = QuantScheme::default()
+            .with_store(QuantStore::PackedNative(0))
+            .with_value(QuantValue::E2M1);
+        assert_eq!(path(scheme), DequantPath::Legacy);
+    }
+
+    #[test]
+    fn a_full_dim_inside_a_block_falls_back() {
+        let scheme = native_q8s().per_block([BlockSize::FULL, 32], ScaleDtype::F32);
+        assert_eq!(path(scheme), DequantPath::Legacy);
+    }
+
+    #[test]
+    fn a_strided_innermost_dim_falls_back() {
+        let strided: &[usize] = &[128, 2];
+        let scheme = native_q8s();
+        assert_eq!(
+            dequant_path(&scheme, WIDEST_LINE, strided, CONTIGUOUS),
+            DequantPath::Legacy
+        );
+        assert_eq!(
+            dequant_path(&scheme, WIDEST_LINE, CONTIGUOUS, strided),
+            DequantPath::Legacy
+        );
+    }
 }

--- a/crates/cubek-quant/src/dequantize.rs
+++ b/crates/cubek-quant/src/dequantize.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)] // pub cube modules
 
+use cubecl::tensor_vector_size_parallel;
 use cubecl::{calculate_cube_count_elemwise, ir::ElemType};
-use cubecl::{features::TypeUsage, tensor_vector_size_parallel};
 use cubecl::{prelude::*, std::tensor::layout::linear::LinearViewMut};
 
 use crate::{
@@ -224,12 +224,7 @@ pub fn launch_ref<R: Runtime>(
             store: QuantStore::PackedNative(_),
             ..
         } => {
-            if !i8::supported_uses(client).contains(TypeUsage::Conversion) {
-                panic!(
-                    "{:?} is not supported for native quantization",
-                    scheme.value
-                );
-            }
+            crate::utils::check_i8_supported(client, scheme);
 
             dequantize_native(
                 client,

--- a/crates/cubek-quant/src/dequantize_tiled.rs
+++ b/crates/cubek-quant/src/dequantize_tiled.rs
@@ -4,14 +4,13 @@ use cubecl::{
     quant::scheme::{QuantScheme, QuantStore, ScaleDtype},
 };
 use cubek_tile::{
-    Axis, CubeAxis, Cut, DequantAt, QuantTileArg, Schedule, Space, TileArg, Tiling, Walk,
-    WalkOrder, witnessed_space,
+    Axis, CubeAxis, Cut, DequantAt, QuantTileArg, Schedule, Space, TileArg, Tiling, WalkOrder,
 };
 
 use crate::utils;
 
 /// Dequantize `values` into `output` through the tile engine: the input tile serves the
-/// output element and decodes on read, so the kernel is a walk of region copies.
+/// output element and decodes on read, so the kernel body is one copy.
 ///
 /// `values` is declared **in values**: for a packed store its shape and strides count the
 /// quantized values (innermost stride 1) while its buffer is narrower by the packing factor.
@@ -114,9 +113,9 @@ pub fn launch_ref<R: Runtime>(
 }
 
 #[cube(launch)]
-/// The input tile serves `O` and dequantizes on read, so each region's body is a plain copy;
-/// `I` (the storage element) only names the binding's element, the scheme recovers the served
-/// value. `VI` is the binding width (served over the packing factor), `VO` the served width.
+/// The input tile serves `O` and dequantizes on read, so the body is a plain copy; `I` (the
+/// storage element) only names the binding's element, the scheme recovers the served value.
+/// `VI` is the binding width (served over the packing factor), `VO` the served width.
 pub fn dequantize<I: Numeric, O: Numeric, VI: Size, VO: Size>(
     input: &QuantTileArg<'_, I, VI>,
     output: &TileArg<'_, O, VO>,
@@ -125,12 +124,8 @@ pub fn dequantize<I: Numeric, O: Numeric, VI: Size, VO: Size>(
     #[define(O)] _output_dtype: ElemType,
 ) {
     let input = input.tile::<O>(comptime!(space.clone()));
-    let output = output.tile(comptime!(space.clone()));
-    let walk = witnessed_space(space, &output, &input, &input);
-    for region in Walk::over(walk) {
-        let mut window = output.at(&region);
-        window.copy_from(&input.at(&region));
-    }
+    let mut output = output.tile(space);
+    output.copy(&input);
 }
 
 /// The unit count one cube aims for; plane counts derive from it per device.

--- a/crates/cubek-quant/src/dequantize_tiled.rs
+++ b/crates/cubek-quant/src/dequantize_tiled.rs
@@ -1,81 +1,111 @@
 use cubecl::{
-    features::TypeUsage,
     ir::ElemType,
     prelude::*,
-    quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype},
+    quant::scheme::{QuantScheme, QuantStore, ScaleDtype},
 };
 use cubek_tile::{
-    Axis, ByAxis, DequantAt, Distribution, Partitioner, QuantTileArg, Space, StridedOperand,
-    TileArg,
+    Axis, CubeAxis, Cut, DequantAt, QuantTileArg, Schedule, Space, TileArg, Tiling, Walk,
+    WalkOrder, witnessed_space,
 };
 
-// Input axes
-const M: Axis = Axis(0);
-const N: Axis = Axis(1);
+use crate::utils;
 
-/// Convert the tensor back to a higher precision data type.
-/// Uses the tile-based implementation for dequantization.
-/// Very WIP and naive implementation for now.
+/// Dequantize `values` into `output` through the tile engine: the input tile serves the
+/// output element and decodes on read, so the kernel is a walk of region copies.
+///
+/// `values` is declared **in values**: for a packed store its shape and strides count the
+/// quantized values (innermost stride 1) while its buffer is narrower by the packing factor.
+/// `scales` holds one binding per scale level, innermost first; a two-level scheme's second
+/// binding is its global, whole-tensor scale.
+///
+/// # Errors
+///
+/// Propagates the kernel's [`LaunchError`]. An unsupported scheme (a non-f32 param, a store
+/// that is neither native nor packed-u32, a packing factor no device line covers, or a FULL
+/// dim inside a block) panics on the caller's thread instead, so the plan fails loudly.
+#[allow(clippy::result_large_err)]
 pub fn launch_ref<R: Runtime>(
     client: &ComputeClient<R>,
-    input: TensorBinding<R>,
+    values: TensorBinding<R>,
     output: TensorBinding<R>,
-    scales: TensorBinding<R>,
+    scales: &[TensorBinding<R>],
     scheme: &QuantScheme,
     output_dtype: ElemType,
 ) -> Result<(), LaunchError> {
-    assert!(
-        scheme.store == QuantStore::Native,
-        "only native quantization is supported for now."
-    );
-    assert!(
-        scheme.num_levels() == 1 && scheme.block_size().is_none(),
-        "only per tensor quantization is supported for now."
-    );
+    let input_dtype = match scheme.store {
+        QuantStore::Native => {
+            utils::check_i8_supported(client, scheme);
+            ElemType::from_quant_value(scheme.value)
+        }
+        QuantStore::PackedU32(_) => utils::packed_storage_elem(scheme),
+        other => panic!("dequantize_tiled: unsupported storage {other:?} (native or packed-u32)"),
+    };
     assert!(
         scheme.scale_dtype() == ScaleDtype::F32,
         "only f32 scales are supported for now."
     );
-    check_i8_supported(client, scheme);
-
-    // One space for the whole kernel; both operands span all of it. Geometry reads the
-    // concrete extents; the kernel gets the dynamic form, so m and n resolve in-kernel
-    // from the tensor's own shape and never fork the compiled kernel.
-    // The space is read off the first two dims, so a deeper buffer would be described by its grid
-    // dims rather than its extents. Both operands are plain 2-D tensors: every axis untiled, one
-    // physical axis apiece, which is what the source builder derives below.
-    assert!(
-        input.shape.len() == 2 && output.shape.len() == 2,
-        "dequantize_tiled: both operands must be plain 2-D tensors, got {:?} and {:?}",
-        input.shape,
-        output.shape
+    assert_eq!(
+        scales.len(),
+        scheme.num_levels(),
+        "dequantize_tiled: one scale binding per level, innermost first"
     );
-    let space = sequential_space(&[(M, input.shape[0]), (N, input.shape[1])]);
-    let cube_count = space.cube_count();
-    let cube_dim = space.cube_dim(client);
-    let input_dtype = ElemType::from_quant_value(scheme.value);
-    // Both operands through the source builder, which derives the storage from the binding's own
-    // dims and validates the scheme against this space. One tile covers each axis, so nothing
-    // overhangs and the checks stay off.
-    let input_op = StridedOperand::source(input)
-        .space(&space)
-        .subspace(&[M, N])
-        .checked(false)
-        // Nothing stages this operand, so its read is what decodes it.
-        .quantized(&[scales], *scheme, DequantAt::Read)
+    let rank = output.shape.len();
+    assert!(rank >= 1, "dequantize_tiled: a scalar binding has no axes");
+    assert_eq!(
+        &values.shape[..],
+        &output.shape[..],
+        "dequantize_tiled: the values binding is declared in values, so both shapes agree"
+    );
+
+    let inner_block = inner_block_edge(scheme, rank);
+    let inner_extent = output.shape[rank - 1];
+    let type_size = input_dtype.size().max(output_dtype.size());
+    let width = served_width(
+        client.io_optimized_vector_sizes(type_size),
+        inner_extent,
+        inner_block,
+        scheme.num_quants(),
+        &[&values.strides, &output.strides],
+    );
+    assert!(
+        width.is_multiple_of(scheme.num_quants()),
+        "dequantize_tiled: a served line may not split a u32, and no width covering the \
+         {}-value packing factor qualifies here",
+        scheme.num_quants()
+    );
+    let plane_size = client.properties().hardware.plane_size_max as usize;
+    let geometry = Geometry::of(width, plane_size, inner_extent, inner_block);
+
+    let axes: Vec<Axis> = (0..rank).map(|p| Axis(p as u8)).collect();
+    let extents: Vec<(Axis, usize)> = axes
+        .iter()
+        .zip(output.shape.iter())
+        .map(|(&axis, &extent)| (axis, extent))
+        .collect();
+    let space = geometry.space(&extents);
+    let launch = space.launcher(client);
+
+    let input_op = launch
+        .arg(values)
+        .subspace(&axes)
+        .vectorize(geometry.width)
+        .quantized(scales, *scheme, DequantAt::Read)
         .build();
-    let output_op = StridedOperand::source(output)
-        .space(&space)
-        .subspace(&[M, N])
-        .checked(false)
+    let output_op = launch
+        .arg(output)
+        .subspace(&axes)
+        .vectorize(geometry.width)
         .build();
-    dequantize::launch(
+
+    dequantize::launch::<R>(
         client,
-        cube_count,
-        cube_dim,
+        launch.cube_count(),
+        launch.cube_dim(),
+        input_op.bound_width(),
+        output_op.vector_size,
         input_op.arg(),
         output_op.arg(),
-        space.all_dynamic(),
+        launch.space().clone(),
         input_dtype,
         output_dtype,
     );
@@ -83,50 +113,276 @@ pub fn launch_ref<R: Runtime>(
     Ok(())
 }
 
-/// A row-major space whose every axis is `Sequential`: a single cube walks all the tiles.
-/// Each axis is one tile covering its full extent (one tile total).
-fn sequential_space(extents: &[(Axis, usize)]) -> Space {
-    let dists: Vec<(Axis, Distribution)> = extents
-        .iter()
-        .map(|&(a, _)| (a, Distribution::Sequential))
-        .collect();
-    let partitioner = Partitioner::row_major(ByAxis::new(extents), ByAxis::new(&dists)).direct();
-    Space::new(extents).with_partitioner(partitioner)
-}
-
-fn check_i8_supported<R: Runtime>(client: &ComputeClient<R>, scheme: &QuantScheme) {
-    match scheme {
-        QuantScheme {
-            value: QuantValue::Q8F | QuantValue::Q8S | QuantValue::E4M3 | QuantValue::E5M2,
-            store: QuantStore::Native,
-            ..
-        }
-        | QuantScheme {
-            value: QuantValue::E2M1,
-            store: QuantStore::PackedNative(_),
-            ..
-        } if !i8::supported_uses(client).contains(TypeUsage::Conversion) => {
-            panic!(
-                "{:?} is not supported for native quantization",
-                scheme.value
-            );
-        }
-        _ => {}
-    }
-}
-
 #[cube(launch)]
-/// The input tile serves `O` and dequantizes on read, so the body is a plain copy; `I` (the
-/// storage element) only names the binding's element, the scheme recovers the served value.
-/// Scales ride as an ordinary second tensor.
-pub fn dequantize<I: Numeric, O: Numeric>(
-    input: &QuantTileArg<'_, I, Const<1>>,
-    output: &TileArg<'_, O, Const<1>>,
+/// The input tile serves `O` and dequantizes on read, so each region's body is a plain copy;
+/// `I` (the storage element) only names the binding's element, the scheme recovers the served
+/// value. `VI` is the binding width (served over the packing factor), `VO` the served width.
+pub fn dequantize<I: Numeric, O: Numeric, VI: Size, VO: Size>(
+    input: &QuantTileArg<'_, I, VI>,
+    output: &TileArg<'_, O, VO>,
     #[comptime] space: Space,
     #[define(I)] _input_dtype: ElemType,
     #[define(O)] _output_dtype: ElemType,
 ) {
     let input = input.tile::<O>(comptime!(space.clone()));
-    let mut output = output.tile(space);
-    output.copy_from(&input);
+    let output = output.tile(comptime!(space.clone()));
+    let walk = witnessed_space(space, &output, &input, &input);
+    for region in Walk::over(walk) {
+        let mut window = output.at(&region);
+        window.copy_from(&input.at(&region));
+    }
+}
+
+/// The unit count one cube aims for; plane counts derive from it per device.
+const TARGET_UNITS: usize = 256;
+
+/// One launch's innermost-axis plan. Derived host-side so the kernel only walks what was
+/// proven sound: a vectorized plan never overhangs (a checked operand cannot be vectorized)
+/// and every edge tiles whole scale blocks or sits inside one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Geometry {
+    /// Served values per line, `1` when nothing wider qualifies.
+    width: usize,
+    /// The innermost cube-tile edge, in values.
+    cube_edge: usize,
+    /// A second-level plane cut raising the cube's unit count; `None` keeps one plane per cube.
+    plane_edge: Option<usize>,
+}
+
+impl Geometry {
+    fn of(
+        width: usize,
+        plane_size: usize,
+        inner_extent: usize,
+        inner_block: Option<usize>,
+    ) -> Geometry {
+        let fits = |edge: usize| {
+            inner_block.is_none_or(|b| edge.is_multiple_of(b) || b.is_multiple_of(edge))
+        };
+        let plane_edge = plane_size * width;
+        let planes = (TARGET_UNITS / plane_size).max(1);
+        let preferred = planes * plane_edge;
+        if planes > 1
+            && inner_extent.is_multiple_of(preferred)
+            && fits(preferred)
+            && fits(plane_edge)
+        {
+            return Geometry {
+                width,
+                cube_edge: preferred,
+                plane_edge: Some(plane_edge),
+            };
+        }
+        if inner_extent.is_multiple_of(plane_edge) && fits(plane_edge) {
+            return Geometry {
+                width,
+                cube_edge: plane_edge,
+                plane_edge: None,
+            };
+        }
+        if width > 1 {
+            // Divides the extent and sits inside a block by served_width's own gates.
+            return Geometry {
+                width,
+                cube_edge: width,
+                plane_edge: None,
+            };
+        }
+        // Scalar with a masked overhang; the edge still tiles whole blocks.
+        let cube_edge = inner_block.map_or(plane_size, |b| b * plane_size.div_ceil(b));
+        Geometry {
+            width: 1,
+            cube_edge,
+            plane_edge: None,
+        }
+    }
+
+    /// The level stack over `extents` (one axis per tensor dim, innermost last): innermost
+    /// tiles ride one-per-cube on X, the next axis on Y and every remaining global axis on Z,
+    /// one element per cube. The plane level, when present, cuts nothing the walk visits; it
+    /// only raises the cube's unit count for the cooperative fill.
+    fn space(&self, extents: &[(Axis, usize)]) -> Space {
+        let rank = extents.len();
+        let inner = extents[rank - 1].0;
+        let global: Vec<Axis> = extents[..rank - 1].iter().map(|&(axis, _)| axis).collect();
+        let mut tiling =
+            Tiling::new()
+                .extents(extents)
+                .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+                    let mut l = l.axis(inner, Cut::cube(CubeAxis::X, self.cube_edge));
+                    if let Some((&y, zs)) = global.split_last() {
+                        l = l
+                            .axis(y, Cut::cube(CubeAxis::Y, 1))
+                            .axes(zs, Cut::cube(CubeAxis::Z, 1));
+                    }
+                    l
+                });
+        if let Some(plane_edge) = self.plane_edge {
+            tiling = tiling.level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+                l.axis(inner, Cut::plane(plane_edge))
+                    .axes(&global, Cut::sequential(1))
+            });
+        }
+        tiling.build()
+    }
+}
+
+/// The widest qualifying served line: it must tile the innermost extent, ride contiguous
+/// innermost dims (coarser strides re-express in lines), cover whole packed words, and sit
+/// inside the innermost scale block. `1` when nothing wider qualifies.
+fn served_width(
+    candidates: impl Iterator<Item = usize>,
+    inner_extent: usize,
+    inner_block: Option<usize>,
+    num_quants: usize,
+    operands: &[&[usize]],
+) -> usize {
+    candidates
+        .filter(|&v| {
+            v == 1
+                || (inner_extent.is_multiple_of(v)
+                    && v.is_multiple_of(num_quants)
+                    && inner_block.is_none_or(|b| b.is_multiple_of(v))
+                    && operands.iter().all(|strides| {
+                        strides.last() == Some(&1)
+                            && strides[..strides.len() - 1]
+                                .iter()
+                                .all(|&s| s.is_multiple_of(v))
+                    }))
+        })
+        .max()
+        .unwrap_or(1)
+}
+
+/// The innermost axis's block edge in values, `None` for a per-tensor scheme. A block scheme
+/// holding a FULL (0) dim would put a zero edge into the scale windowing, so it is refused.
+fn inner_block_edge(scheme: &QuantScheme, rank: usize) -> Option<usize> {
+    let block = scheme.block_size()?;
+    let dims = block.to_dim_vec(rank);
+    assert!(
+        dims.iter().all(|&b| b != 0),
+        "dequantize_tiled: a FULL (0) dim inside a block scheme is not supported, got {dims:?}"
+    );
+    Some(dims[rank - 1] as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CANDIDATES: [usize; 4] = [8, 4, 2, 1];
+
+    fn width(inner_extent: usize, inner_block: Option<usize>, strides: &[usize]) -> usize {
+        served_width(
+            CANDIDATES.iter().copied(),
+            inner_extent,
+            inner_block,
+            1,
+            &[strides, strides],
+        )
+    }
+
+    #[test]
+    fn served_width_takes_the_widest_qualifying_line() {
+        assert_eq!(width(128, None, &[128, 1]), 8);
+    }
+
+    /// An extent no candidate divides serves scalar; the checked path takes over from there.
+    #[test]
+    fn served_width_falls_to_scalar_on_an_awkward_extent() {
+        assert_eq!(width(127, None, &[127, 1]), 1);
+    }
+
+    /// A line may not straddle a scale block, so the block caps the width.
+    #[test]
+    fn served_width_sits_inside_the_inner_block() {
+        assert_eq!(width(128, Some(4), &[128, 1]), 4);
+        assert_eq!(width(128, Some(6), &[128, 1]), 2);
+    }
+
+    /// A sliced view keeps its parent's coarser strides; a width they cannot re-express in
+    /// lines would truncate them.
+    #[test]
+    fn served_width_respects_strides() {
+        assert_eq!(width(128, None, &[128, 2]), 1); // innermost not contiguous
+        assert_eq!(width(64, None, &[132, 1]), 4); // coarser stride caps the width
+    }
+
+    /// Packing constrains from below: a served line covers whole `u32` words or nothing.
+    #[test]
+    fn served_width_covers_whole_packed_words() {
+        let w = served_width(CANDIDATES.iter().copied(), 128, None, 4, &[&[128, 1]]);
+        assert_eq!(w, 8);
+        // No candidate reaches the packing factor: scalar comes back and the caller refuses it.
+        let w = served_width([2usize, 1].into_iter(), 128, None, 4, &[&[128, 1]]);
+        assert_eq!(w, 1);
+    }
+
+    #[test]
+    fn geometry_prefers_a_multi_plane_cube() {
+        let g = Geometry::of(4, 32, 4096, None);
+        assert_eq!(
+            g,
+            Geometry {
+                width: 4,
+                cube_edge: 1024,
+                plane_edge: Some(128)
+            }
+        );
+    }
+
+    #[test]
+    fn geometry_falls_back_to_one_plane_per_cube() {
+        let g = Geometry::of(4, 32, 128, None);
+        assert_eq!(
+            g,
+            Geometry {
+                width: 4,
+                cube_edge: 128,
+                plane_edge: None
+            }
+        );
+    }
+
+    /// A vectorized width always has a dividing edge (itself), so a shape the plane edge does
+    /// not divide narrows the cube rather than degrading to scalar.
+    #[test]
+    fn geometry_narrows_the_cube_before_giving_up_the_width() {
+        let g = Geometry::of(4, 32, 64, None);
+        assert_eq!(
+            g,
+            Geometry {
+                width: 4,
+                cube_edge: 4,
+                plane_edge: None
+            }
+        );
+    }
+
+    #[test]
+    fn geometry_scalar_fallback_overhangs_at_the_plane_size() {
+        let g = Geometry::of(1, 32, 127, None);
+        assert_eq!(
+            g,
+            Geometry {
+                width: 1,
+                cube_edge: 32,
+                plane_edge: None
+            }
+        );
+    }
+
+    /// The scalar edge still tiles whole blocks: a straddling cut would misaddress scales.
+    #[test]
+    fn geometry_scalar_fallback_rounds_the_edge_to_whole_blocks() {
+        let g = Geometry::of(1, 32, 96, Some(48));
+        assert_eq!(
+            g,
+            Geometry {
+                width: 1,
+                cube_edge: 48,
+                plane_edge: None
+            }
+        );
+    }
 }

--- a/crates/cubek-quant/src/eval/benchmarks/dequantize/benchmark.rs
+++ b/crates/cubek-quant/src/eval/benchmarks/dequantize/benchmark.rs
@@ -1,0 +1,199 @@
+use std::sync::Arc;
+
+use cubecl::{
+    Runtime, TestRuntime,
+    benchmark::{Benchmark, ProfileDuration, TimingMethod},
+    bytes::Bytes,
+    client::ComputeClient,
+    features::TypeUsage,
+    future,
+    ir::ElemType,
+    prelude::*,
+    std::tensor::TensorHandle,
+    zspace::Shape,
+};
+use cubek_test_utils::{RunSamples, TestInput};
+
+use super::problem::DequantizeProblem;
+use super::strategy::DequantizePath;
+use crate::scheme::{QuantScheme, QuantStore};
+
+const SEED: u64 = 0x1;
+
+pub fn bench(
+    strategy: &DequantizePath,
+    problem: &DequantizeProblem,
+    num_samples: usize,
+) -> Result<RunSamples, String> {
+    let device = <TestRuntime as Runtime>::Device::default();
+    let client = <TestRuntime as Runtime>::client(&device);
+    let scheme = problem.scheme;
+
+    if *strategy == DequantizePath::Legacy && scheme.num_levels() > 1 {
+        return Err("the legacy kernels serve one scale level".into());
+    }
+    if scheme.store == QuantStore::Native
+        && !i8::supported_uses(&client).contains(TypeUsage::Conversion)
+    {
+        return Err("the backend has no native i8 conversion".into());
+    }
+    if *strategy == DequantizePath::Tile && matches!(scheme.store, QuantStore::PackedU32(_)) {
+        let widest = client
+            .io_optimized_vector_sizes(size_of::<u32>())
+            .next()
+            .unwrap_or(1);
+        if scheme.num_quants() > widest {
+            return Err(format!(
+                "device lines cap at {widest}, below the packing factor {}",
+                scheme.num_quants()
+            ));
+        }
+    }
+
+    let bench = DequantizeBench {
+        m: problem.m,
+        n: problem.n,
+        scheme,
+        path: *strategy,
+        client,
+        samples: num_samples,
+    };
+
+    let durations = bench
+        .run(TimingMethod::Device)
+        .map_err(|e| format!("benchmark failed: {e}"))?
+        .durations;
+
+    Ok(RunSamples::new(durations))
+}
+
+struct DequantizeBench {
+    m: usize,
+    n: usize,
+    scheme: QuantScheme,
+    path: DequantizePath,
+    client: ComputeClient<TestRuntime>,
+    samples: usize,
+}
+
+/// One problem's device tensors. The quantized buffer is declared twice because the two
+/// entries disagree on units: the legacy kernels take a packed store in `u32` words, the
+/// tile entry the same buffer counted in the values it holds (for a native store the two
+/// declarations coincide).
+struct Inputs {
+    stored: TensorHandle<TestRuntime>,
+    values: TensorHandle<TestRuntime>,
+    /// One tensor per scale level, innermost first.
+    scales: Vec<TensorHandle<TestRuntime>>,
+    output: TensorHandle<TestRuntime>,
+}
+
+impl Benchmark for DequantizeBench {
+    type Input = Arc<Inputs>;
+    type Output = ();
+
+    fn prepare(&self) -> Self::Input {
+        let shape = vec![self.m, self.n];
+        let (stored, values) = match self.scheme.store {
+            QuantStore::PackedU32(_) => {
+                let pack = self.scheme.num_quants();
+                let words: Vec<u32> = (0..self.m * self.n / pack)
+                    .map(|i| (i as u32).wrapping_mul(0x9E3779B9))
+                    .collect();
+                let handle = self.client.create(Bytes::from_elems(words));
+                let stored = TensorHandle::new_contiguous(
+                    vec![self.m, self.n / pack],
+                    handle.clone(),
+                    u32::elem_type_native(),
+                );
+                let values =
+                    TensorHandle::new_contiguous(shape.clone(), handle, u32::elem_type_native());
+                (stored, values)
+            }
+            _ => {
+                let range = self.scheme.value.range();
+                let input = TestInput::builder(self.client.clone(), Shape::from(shape.clone()))
+                    .dtype(ElemType::from_quant_value(self.scheme.value))
+                    .uniform(SEED, range.0, range.1)
+                    .generate_without_host_data();
+                (input.clone(), input)
+            }
+        };
+
+        // One scale tensor per level, innermost first: the block level grids over the shape, the
+        // per-tensor level holds a single scale.
+        let scales = self
+            .scheme
+            .block_scale()
+            .map(|block| block.size.grid(&[self.m, self.n]))
+            .into_iter()
+            .chain(self.scheme.tensor_scale().map(|_| vec![1, 1]))
+            .map(|grid| {
+                let count = grid.iter().product();
+                let scale_values: Vec<f32> =
+                    (0..count).map(|k| 0.05 * ((k % 64) + 1) as f32).collect();
+                TestInput::builder(self.client.clone(), Shape::from(grid))
+                    .custom(scale_values)
+                    .generate_without_host_data()
+            })
+            .collect();
+
+        let output = TensorHandle::zeros(&self.client, Shape::from(shape), f32::elem_type_native());
+        Arc::new(Inputs {
+            stored,
+            values,
+            scales,
+            output,
+        })
+    }
+
+    fn execute(&self, args: Self::Input) -> Result<(), String> {
+        let scales: Vec<_> = args.scales.iter().map(|s| s.clone().binding()).collect();
+        let output_dtype = f32::elem_type_native();
+        match self.path {
+            DequantizePath::Legacy => crate::dequantize::launch_legacy(
+                &self.client,
+                args.stored.clone().binding(),
+                args.output.clone().binding(),
+                &scales,
+                &self.scheme,
+                output_dtype,
+            ),
+            DequantizePath::Tile => crate::dequantize_tiled::launch_ref(
+                &self.client,
+                args.values.clone().binding(),
+                args.output.clone().binding(),
+                &scales,
+                &self.scheme,
+                output_dtype,
+            ),
+        }
+        .map_err(|e| format!("{e:?}"))
+    }
+
+    fn num_samples(&self) -> usize {
+        self.samples
+    }
+
+    fn name(&self) -> String {
+        format!(
+            "dequantize-{}-{:?}-m{}-n{}",
+            <TestRuntime as Runtime>::name(&self.client),
+            self.path,
+            self.m,
+            self.n,
+        )
+        .to_lowercase()
+    }
+
+    fn sync(&self) {
+        future::block_on(self.client.sync()).unwrap()
+    }
+
+    fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
+        self.client
+            .profile(|| self.execute(args), "dequantize-bench")
+            .map(|it| it.1)
+            .map_err(|it| format!("{it:?}"))
+    }
+}

--- a/crates/cubek-quant/src/eval/benchmarks/dequantize/mod.rs
+++ b/crates/cubek-quant/src/eval/benchmarks/dequantize/mod.rs
@@ -1,0 +1,51 @@
+//! Elementwise dequantize: the legacy kernels against the tile engine.
+//!
+//! Every problem runs under both strategies in one process, so each pair of numbers is an
+//! interleaved A/B on the same device state. The two-level problem runs tile-only: the
+//! legacy kernels serve one scale level.
+
+mod benchmark;
+mod problem;
+mod strategy;
+
+pub use benchmark::bench;
+pub use problem::{DequantizeProblem, problems};
+pub use strategy::{DequantizePath, strategies};
+
+use cubek_test_utils::{CatalogEntry, RunSamples};
+
+pub struct Category;
+
+impl cubek_test_utils::Category for Category {
+    type Problem = DequantizeProblem;
+    type Strategy = DequantizePath;
+
+    fn id(&self) -> &'static str {
+        "dequantize"
+    }
+
+    fn label(&self) -> &'static str {
+        "Quant: elementwise dequantize"
+    }
+
+    fn timing_method(&self) -> cubecl::benchmark::TimingMethod {
+        cubecl::benchmark::TimingMethod::Device
+    }
+
+    fn problems(&self) -> Vec<CatalogEntry<DequantizeProblem>> {
+        problems()
+    }
+
+    fn strategies(&self) -> Vec<CatalogEntry<DequantizePath>> {
+        strategies()
+    }
+
+    fn bench(
+        &self,
+        strategy: &DequantizePath,
+        problem: &DequantizeProblem,
+        num_samples: usize,
+    ) -> Result<RunSamples, String> {
+        bench(strategy, problem, num_samples)
+    }
+}

--- a/crates/cubek-quant/src/eval/benchmarks/dequantize/problem.rs
+++ b/crates/cubek-quant/src/eval/benchmarks/dequantize/problem.rs
@@ -1,0 +1,54 @@
+use cubek_test_utils::CatalogEntry;
+
+use crate::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype};
+
+/// One dequantize launch: an `[m, n]` q8s tensor restored to f32 under `scheme`.
+pub struct DequantizeProblem {
+    pub m: usize,
+    pub n: usize,
+    pub scheme: QuantScheme,
+}
+
+/// One decoder-weight-sized matrix for every case: the op is memory-bound, so the sweep
+/// varies the scale layout and the store, not the shape.
+const M: usize = 4096;
+const N: usize = 4096;
+
+fn q8s(store: QuantStore) -> QuantScheme {
+    QuantScheme::default()
+        .with_value(QuantValue::Q8S)
+        .with_store(store)
+}
+
+fn problem(scheme: QuantScheme) -> DequantizeProblem {
+    DequantizeProblem { m: M, n: N, scheme }
+}
+
+pub fn problems() -> Vec<CatalogEntry<DequantizeProblem>> {
+    vec![
+        CatalogEntry::new(
+            "native_tensor",
+            "native q8s per-tensor 4096x4096",
+            problem(q8s(QuantStore::Native).per_tensor(ScaleDtype::F32)),
+        ),
+        CatalogEntry::new(
+            "native_block32",
+            "native q8s [32]-block 4096x4096",
+            problem(q8s(QuantStore::Native).per_block([32], ScaleDtype::F32)),
+        ),
+        CatalogEntry::new(
+            "packed_block32",
+            "packed-u32 q8s [32]-block 4096x4096",
+            problem(q8s(QuantStore::PackedU32(0)).per_block([32], ScaleDtype::F32)),
+        ),
+        CatalogEntry::new(
+            "two_level_block16",
+            "native q8s [16]-block + tensor 4096x4096",
+            problem(
+                q8s(QuantStore::Native)
+                    .per_block([16], ScaleDtype::F32)
+                    .per_tensor(ScaleDtype::F32),
+            ),
+        ),
+    ]
+}

--- a/crates/cubek-quant/src/eval/benchmarks/dequantize/strategy.rs
+++ b/crates/cubek-quant/src/eval/benchmarks/dequantize/strategy.rs
@@ -1,0 +1,22 @@
+use cubek_test_utils::CatalogEntry;
+
+/// Which dequantize implementation a run measures, the two arms `dequantize::launch_ref`
+/// routes between.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum DequantizePath {
+    /// The legacy elementwise kernels, one scale level only.
+    Legacy,
+    /// The tile-engine kernel behind `dequantize_tiled`.
+    Tile,
+}
+
+pub fn strategies() -> Vec<CatalogEntry<DequantizePath>> {
+    vec![
+        CatalogEntry::new(
+            "legacy",
+            "legacy elementwise kernel",
+            DequantizePath::Legacy,
+        ),
+        CatalogEntry::new("tile", "tile engine", DequantizePath::Tile),
+    ]
+}

--- a/crates/cubek-quant/src/eval/benchmarks/mod.rs
+++ b/crates/cubek-quant/src/eval/benchmarks/mod.rs
@@ -1,0 +1,1 @@
+pub mod dequantize;

--- a/crates/cubek-quant/src/eval/mod.rs
+++ b/crates/cubek-quant/src/eval/mod.rs
@@ -1,0 +1,3 @@
+//! Benchmark catalogues for `cubek-quant`.
+
+pub mod benchmarks;

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -21,8 +21,33 @@ pub use cubecl_common::quant::scheme;
 
 #[cfg(feature = "kernels")]
 pub(crate) mod utils {
-    use crate::scheme::{QuantScheme, QuantStore};
+    use crate::scheme::{QuantScheme, QuantStore, QuantValue};
+    use cubecl::features::TypeUsage;
     use cubecl::ir::{ElemType, UIntKind};
+    use cubecl::prelude::*;
+
+    /// Panic when the scheme stores natively but the device cannot convert the storage
+    /// element (`i8` under the hood for the 8-bit values and fp8).
+    pub(crate) fn check_i8_supported<R: Runtime>(client: &ComputeClient<R>, scheme: &QuantScheme) {
+        match scheme {
+            QuantScheme {
+                value: QuantValue::Q8F | QuantValue::Q8S | QuantValue::E4M3 | QuantValue::E5M2,
+                store: QuantStore::Native,
+                ..
+            }
+            | QuantScheme {
+                value: QuantValue::E2M1,
+                store: QuantStore::PackedNative(_),
+                ..
+            } if !i8::supported_uses(client).contains(TypeUsage::Conversion) => {
+                panic!(
+                    "{:?} is not supported for native quantization",
+                    scheme.value
+                );
+            }
+            _ => {}
+        }
+    }
 
     pub(crate) fn check_block_size_compat(scheme: &QuantScheme, div: usize) {
         // Validate block size compatibility

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -11,6 +11,9 @@ pub mod dequantize_tiled;
 #[cfg(feature = "kernels")]
 pub mod quantize;
 
+#[cfg(feature = "benchmarks")]
+pub mod eval;
+
 #[cfg(feature = "kernels")]
 pub mod layout;
 

--- a/crates/cubek-quant/tests/quant/tiled.rs
+++ b/crates/cubek-quant/tests/quant/tiled.rs
@@ -4,8 +4,9 @@ use cubecl::{
 };
 use cubek_quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype};
 use cubek_test_utils::{
-    HostData, HostDataType, HostDataVec, StridedLayout, TestInput, assert_equals_approx,
+    HostData, HostDataType, HostDataVec, StridedLayout, TestInput, TileInput, assert_equals_approx,
 };
+use cubek_tile::{Axis, DequantAt, Space};
 
 const SCALE: f32 = 0.05;
 const SEED: u64 = 0x1;
@@ -13,6 +14,152 @@ const SEED: u64 = 0x1;
 #[test]
 fn dequantize_tiled_native_per_tensor_matches_reference() {
     dequantize_tiled_native_per_tensor(&[128, 128]);
+}
+
+/// An extent nothing divides serves scalar (bounds-checked where the cube tile overhangs);
+/// same numbers as the vectorized launch, only the plan degrades.
+#[test]
+fn dequantize_tiled_native_per_tensor_awkward_shape_matches_reference() {
+    dequantize_tiled_native_per_tensor(&[6, 127]);
+}
+
+#[test]
+fn dequantize_tiled_native_per_tensor_rank_3_matches_reference() {
+    dequantize_tiled_native_per_tensor(&[3, 5, 64]);
+}
+
+/// An innermost extent the preferred multi-plane cube divides: the launch raises the cube's
+/// unit count through the plane level instead of multiplying cubes.
+#[test]
+fn dequantize_tiled_native_per_tensor_multi_plane_matches_reference() {
+    dequantize_tiled_native_per_tensor(&[4, 4096]);
+}
+
+/// A `[32]`-block scheme reads each innermost 32-value group through its own scale.
+#[test]
+fn dequantize_tiled_native_block_matches_reference() {
+    let client = TestRuntime::client(&Default::default());
+    if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
+        return; // backend has no native i8 (e.g. wgpu); native dequant can't run here
+    }
+    let (m, n, bn) = (64, 128, 32);
+
+    let scheme = QuantScheme::default()
+        .per_block([bn as u8], ScaleDtype::F32)
+        .with_store(QuantStore::Native)
+        .with_value(QuantValue::Q8S);
+
+    let shape = Shape::from(vec![m, n]);
+    let input_dtype = ElemType::from_quant_value(scheme.value);
+    let input_range = scheme.value.range();
+    let (input, input_host) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .uniform(SEED, input_range.0, input_range.1)
+        .generate_with_f32_host_data();
+
+    let sn = n / bn;
+    let scale_vals: Vec<f32> = (0..m * sn).map(|k| 0.05 * (k + 1) as f32).collect();
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![m, sn]))
+        .custom(scale_vals.clone())
+        .generate_without_host_data();
+
+    let output = TensorHandle::zeros(&client, shape.clone(), f32::elem_type_native());
+    cubek_quant::dequantize_tiled::launch_ref::<TestRuntime>(
+        &client,
+        input.binding(),
+        output.clone().binding(),
+        &[scales.binding()],
+        &scheme,
+        f32::elem_type_native(),
+    )
+    .unwrap();
+
+    let got = HostData::from_tensor_handle(&client, output, HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            input_host
+                .iter_indices()
+                .map(|idx| input_host.get_f32(&idx) * scale_vals[idx[0] * sn + idx[1] / bn])
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// Packed-u32 Q8S with a `[32]`-block: the binding is a `u32` declared in values, so this
+/// runs on every backend, no native i8 needed.
+#[test]
+fn dequantize_tiled_packed_block_matches_reference() {
+    let client = TestRuntime::client(&Default::default());
+    let (m, n, bn) = (16, 64, 32);
+
+    let scheme = QuantScheme::default()
+        .per_block([bn as u8], ScaleDtype::F32)
+        .with_store(QuantStore::PackedU32(0))
+        .with_value(QuantValue::Q8S);
+    let pack = scheme.num_quants();
+    let max_width = client.properties().hardware.max_vector_size;
+    if pack > max_width {
+        return; // no served line can cover a whole u32 word here
+    }
+
+    let space = Space::new(&[(Axis(0), m), (Axis(1), n)]);
+    let input = TileInput::builder(&client, space)
+        .untiled()
+        .packed(&scheme, DequantAt::Read)
+        .arange();
+
+    let sn = n / bn;
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![m, sn]))
+        .custom(input.scale_values.clone())
+        .generate_without_host_data();
+
+    let shape = Shape::from(vec![m, n]);
+    let output = TensorHandle::zeros(&client, shape.clone(), f32::elem_type_native());
+    cubek_quant::dequantize_tiled::launch_ref::<TestRuntime>(
+        &client,
+        input.tile.handle().binding(),
+        output.clone().binding(),
+        &[scales.binding()],
+        &scheme,
+        f32::elem_type_native(),
+    )
+    .unwrap();
+
+    let got = HostData::from_tensor_handle(&client, output, HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            (0..m * n)
+                .map(|k| {
+                    let (i, j) = (k / n, k % n);
+                    input.q[k] as f32 * input.scale_values[i * sn + j / bn]
+                })
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// Two-level: block scales normalized by one per-tensor scale, both folded into every value.
+/// The expectation carries the global, so an implementation that drops it fails by that factor.
+#[test]
+fn dequantize_tiled_native_two_level_matches_reference() {
+    dequantize_tiled_native_two_level(0.5);
+}
+
+/// A zero per-tensor scale zeroes every reconstruction, so the global provably participates
+/// in each value rather than defaulting to one.
+#[test]
+fn dequantize_tiled_native_two_level_zero_global_zeroes_output() {
+    dequantize_tiled_native_two_level(0.0);
 }
 
 fn dequantize_tiled_native_per_tensor(tensor_shape: &[usize]) {
@@ -58,6 +205,65 @@ fn dequantize_tiled_native_per_tensor(tensor_shape: &[usize]) {
             input_host
                 .iter_indices()
                 .map(|idx| input_host.get_f32(&idx) * SCALE)
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+fn dequantize_tiled_native_two_level(global: f32) {
+    let client = TestRuntime::client(&Default::default());
+    if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
+        return; // backend has no native i8 (e.g. wgpu); native dequant can't run here
+    }
+    let (m, n, bn) = (32, 64, 16);
+
+    let scheme = QuantScheme::default()
+        .per_block([bn as u8], ScaleDtype::F32)
+        .per_tensor(ScaleDtype::F32)
+        .with_store(QuantStore::Native)
+        .with_value(QuantValue::Q8S);
+
+    let shape = Shape::from(vec![m, n]);
+    let input_dtype = ElemType::from_quant_value(scheme.value);
+    let input_range = scheme.value.range();
+    let (input, input_host) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .uniform(SEED, input_range.0, input_range.1)
+        .generate_with_f32_host_data();
+
+    let sn = n / bn;
+    let scale_vals: Vec<f32> = (0..m * sn).map(|k| 0.05 * (k + 1) as f32).collect();
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![m, sn]))
+        .custom(scale_vals.clone())
+        .generate_without_host_data();
+    let global_scale = TestInput::builder(client.clone(), Shape::from(vec![1usize]))
+        .custom(vec![global])
+        .generate_without_host_data();
+
+    let output = TensorHandle::zeros(&client, shape.clone(), f32::elem_type_native());
+    cubek_quant::dequantize_tiled::launch_ref::<TestRuntime>(
+        &client,
+        input.binding(),
+        output.clone().binding(),
+        &[scales.binding(), global_scale.binding()],
+        &scheme,
+        f32::elem_type_native(),
+    )
+    .unwrap();
+
+    let got = HostData::from_tensor_handle(&client, output, HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            input_host
+                .iter_indices()
+                .map(|idx| {
+                    input_host.get_f32(&idx) * scale_vals[idx[0] * sn + idx[1] / bn] * global
+                })
                 .collect(),
         ),
         strides: StridedLayout::RowMajor.compute_strides(&shape),

--- a/crates/cubek-quant/tests/quant/tiled.rs
+++ b/crates/cubek-quant/tests/quant/tiled.rs
@@ -46,7 +46,7 @@ fn dequantize_tiled_native_per_tensor(tensor_shape: &[usize]) {
         &client,
         input.binding(),
         output.clone().binding(),
-        scales.binding(),
+        &[scales.binding()],
         &scheme,
         output_dtype,
     )

--- a/crates/cubek-tile/src/ops/copy.rs
+++ b/crates/cubek-tile/src/ops/copy.rs
@@ -1,0 +1,51 @@
+//! The copy reading of a [`Tile`](crate::Tile): `dst.copy(&src)` walks the levels that hand
+//! regions to different cubes, and transports each region it lands on.
+
+use cubecl::prelude::*;
+
+use crate::*;
+
+#[cube]
+impl<T: Numeric> Tile<T> {
+    /// `dst.copy(&src)`: walk while a level spreads regions across cubes, else transport.
+    ///
+    /// The transport ([`copy_from`](Tile::copy_from)) fills a whole tile with every unit of the
+    /// cube, so a level that spreads *inside* a cube is already its own doing and ends the walk.
+    /// A quantized source decodes on the way through, as it does under any read.
+    pub fn copy(&mut self, src: &Tile<T>) {
+        if comptime!(spreads_across_cubes(&self.space)) {
+            let space = self.copy_space(src);
+            for region in Walk::over(space) {
+                let mut dst = self.at(&region);
+                dst.copy(&src.at(&region));
+            }
+        } else {
+            self.copy_from(src);
+        }
+    }
+
+    /// The walk's space: this tile's, with every [`Dynamic`](crate::Extent) axis sized by
+    /// whichever operand [`witnesses`](Tile::witnesses) it. The destination is asked first,
+    /// like [`mma`](Tile::mma) asks its accumulator: an axis it spans is one it writes, so its
+    /// bound is the extent the walk must cover.
+    fn copy_space(&self, src: &Tile<T>) -> Space {
+        witnessed_space(comptime!(self.space.clone()), self, src, src)
+    }
+}
+
+/// Whether this level hands its regions to different cubes: some axis rides a cube dim and none
+/// rides a plane or a unit, so the walk steps exactly what the launch grid separates.
+fn spreads_across_cubes(space: &Space) -> bool {
+    if space.is_final() {
+        return false;
+    }
+    let mut across = false;
+    for axis in space.axes() {
+        match space.partitioner().distribution(axis).scope() {
+            Some(ComputeScope::Cube(_)) => across = true,
+            Some(_) => return false,
+            None => {}
+        }
+    }
+    across
+}

--- a/crates/cubek-tile/src/ops/mod.rs
+++ b/crates/cubek-tile/src/ops/mod.rs
@@ -1,9 +1,10 @@
-//! The verbs a client runs over tiles: [`matmul`] (`mma`) and [`softmax`]. Each reads an
-//! already-structured [`Tile`](crate::Tile) and either walks its levels or runs at the leaf; the
-//! shared machinery they compose lives in [`crate::staging`]. Dequantization is not a verb: a
-//! quantized store dequantizes under the plain [`Tile::copy_from`](crate::Tile::copy_from).
+//! The verbs a client runs over tiles: [`matmul`] (`mma`), [`softmax`] and [`copy`]. Each reads
+//! an already-structured [`Tile`](crate::Tile) and either walks its levels or runs at the leaf;
+//! the shared machinery they compose lives in [`crate::staging`]. Dequantization is not a verb: a
+//! quantized store dequantizes under the plain [`Tile::copy`](crate::Tile::copy).
 
 mod attention;
+mod copy;
 mod matmul;
 mod softmax;
 

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -231,7 +231,8 @@ impl<E: Numeric> TmaTileArg<E> {
 /// ([`ScaleLayout`]), which is the true block only if no window straddles a block edge. Every
 /// window is a level's cut, and its origin is a multiple of that cut, so per axis each level's
 /// edge must tile whole blocks or fit inside one. A line is one read, so it may not straddle
-/// either. Per-tensor's block edges are `1` and divide everything.
+/// either. A per-tensor scale covers every window and line, so only the store and param rules
+/// apply to it.
 pub(crate) fn validate_scheme(space: &Space, vector_size: usize, scheme: QuantScheme) {
     // `Native` holds one element per value; `PackedU32` carries `num_quants` of them per `u32`,
     // which the view unpacks on read. A packed store must pack along the innermost (contiguous,
@@ -265,6 +266,11 @@ pub(crate) fn validate_scheme(space: &Space, vector_size: usize, scheme: QuantSc
         "StridedTileSource::quantized: scales are read as f32, got {:?}",
         scheme.scale_dtype()
     );
+
+    // A per-tensor scale has no edge to straddle, whatever the cuts and the served width.
+    if scheme.block_size().is_none() {
+        return;
+    }
 
     let rank = space.rank();
     let block = block_edges(scheme, rank);

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -8,7 +8,7 @@ use cubek_test_utils::{
     ValidationResult, assert_equals_approx,
 };
 use cubek_tile::{
-    Axis, Cut, DequantAt, QuantTileArg, QuantTileArgLaunch, Schedule, Space, TileArg,
+    Axis, CubeAxis, Cut, DequantAt, QuantTileArg, QuantTileArgLaunch, Schedule, Space, TileArg,
     TileArgLaunch, TileSpec, Tiling, WalkOrder,
 };
 
@@ -36,6 +36,48 @@ fn copy_non_quantized_matches_reference() {
         output.arg(),
         space,
         dtype,
+    );
+
+    let input_host = HostData::from_tensor_handle(&client, input.handle(), HostDataType::F32);
+    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    assert_equals_approx(&got, &input_host, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// The op walks the levels that hand regions to different cubes and stops at the plane level,
+/// which the transport spreads over the cube itself. Stepping the plane level would leave every
+/// plane but the first unwritten, since the fill indexes by the flat unit.
+#[test]
+fn copy_spread_across_cubes_and_planes_matches_reference() {
+    let (m, n) = (4, 512);
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = Tiling::new()
+        .extents(&[(M, m), (N, n)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(M, Cut::cube(CubeAxis::Y, 1))
+                .axis(N, Cut::cube(CubeAxis::X, 128))
+        })
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(M, Cut::sequential(1)).axis(N, Cut::plane(32))
+        })
+        .build()
+        .launcher_over(&client, &[]);
+    let space = launch.space().clone();
+
+    let input = TileInput::builder(&client, space.clone())
+        .untiled()
+        .arange();
+    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+
+    plain_copy::launch::<TestRuntime>(
+        &client,
+        launch.cube_count(),
+        launch.cube_dim(),
+        input.arg(),
+        output.arg(),
+        space,
+        f32::elem_type_native(),
     );
 
     let input_host = HostData::from_tensor_handle(&client, input.handle(), HostDataType::F32);
@@ -374,7 +416,7 @@ pub fn plain_copy<E: Numeric>(
 ) {
     let input = input.tile(comptime!(space.clone()));
     let mut output = output.tile(space);
-    output.copy_from(&input);
+    output.copy(&input);
 }
 
 #[cube(launch)]

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -84,6 +84,7 @@ fn copy_quantized_per_tensor_matches_reference() {
         CubeCount::new_single(),
         CubeDim::new_single(),
         1,
+        1,
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
@@ -104,6 +105,154 @@ fn copy_quantized_per_tensor_matches_reference() {
             input_host
                 .iter_indices()
                 .map(|idx| input_host.get_f32(&idx) * scale)
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// Per-tensor native Q8S served in 4-wide lines, through the builder: one full block covers
+/// every line, so nothing can straddle a scale and the vectorized operand is accepted.
+#[test]
+fn copy_quantized_per_tensor_vectorized_matches_reference() {
+    let (m, n, v) = (8, 8, 4);
+    let scale = 0.05f32;
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
+        TestOutcome::Validated(ValidationResult::Skipped(
+            "backend has no native i8".to_string(),
+        ))
+        .enforce();
+        return;
+    }
+    let max_width = client.properties().hardware.max_vector_size;
+    if v > max_width {
+        TestOutcome::Validated(ValidationResult::Skipped(format!(
+            "device vectors cap at {max_width}, below the {v}-wide served line"
+        )))
+        .enforce();
+        return;
+    }
+
+    let scheme = QuantScheme::default()
+        .per_tensor(ScaleDtype::F32)
+        .with_store(QuantStore::Native)
+        .with_value(QuantValue::Q8S);
+
+    let shape = Shape::from(vec![m, n]);
+    let input_dtype = ElemType::from_quant_value(scheme.value);
+    let (lo, hi) = scheme.value.range();
+    let (input, input_host) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .uniform(0x1, lo, hi)
+        .generate_with_f32_host_data();
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![1usize]))
+        .custom(vec![scale])
+        .generate_without_host_data();
+
+    let space = Space::new(&[(M, m), (N, n)]);
+    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+
+    let launcher = space.launcher_over(&client, &[]);
+    let input_op = launcher
+        .arg(input.binding())
+        .subspace(&[M, N])
+        .vectorize(v)
+        .quantized(&[scales.binding()], scheme, DequantAt::Read)
+        .build();
+
+    let out_dtype = f32::elem_type_native();
+    dequant_copy::launch::<TestRuntime>(
+        &client,
+        launcher.cube_count(),
+        launcher.cube_dim(),
+        input_op.bound_width(),
+        v,
+        input_op.arg(),
+        output.arg(),
+        launcher.space().clone(),
+        input_dtype,
+        out_dtype,
+    );
+
+    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            input_host
+                .iter_indices()
+                .map(|idx| input_host.get_f32(&idx) * scale)
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// Per-tensor packed-u32 Q8S, through the builder: one full block covers whole `pack`-wide
+/// lines. The binding is a `u32`, so this runs on every backend, no native i8 needed.
+#[test]
+fn copy_quantized_per_tensor_packed_matches_reference() {
+    let (m, n) = (8, 8);
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    let scheme = QuantScheme::default()
+        .per_tensor(ScaleDtype::F32)
+        .with_store(QuantStore::PackedU32(0))
+        .with_value(QuantValue::Q8S);
+    let pack = scheme.num_quants();
+
+    let max_width = client.properties().hardware.max_vector_size;
+    if pack > max_width {
+        TestOutcome::Validated(ValidationResult::Skipped(format!(
+            "device vectors cap at {max_width}, below the packing factor ({pack})"
+        )))
+        .enforce();
+        return;
+    }
+
+    let space = Space::new(&[(M, m), (N, n)]);
+    let input = TileInput::builder(&client, space.clone())
+        .untiled()
+        .packed(&scheme, DequantAt::Read)
+        .arange();
+    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+
+    let launcher = space.launcher_over(&client, &[]);
+    let input_op = launcher
+        .arg(input.tile.handle().binding())
+        .subspace(&[M, N])
+        .vectorize(pack)
+        .quantized(&[input.scales_binding()], scheme, DequantAt::Read)
+        .build();
+
+    let input_dtype = u32::elem_type_native();
+    let out_dtype = f32::elem_type_native();
+    dequant_copy::launch::<TestRuntime>(
+        &client,
+        launcher.cube_count(),
+        launcher.cube_dim(),
+        input_op.bound_width(),
+        pack,
+        input_op.arg(),
+        output.arg(),
+        launcher.space().clone(),
+        input_dtype,
+        out_dtype,
+    );
+
+    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    let shape = Shape::from(vec![m, n]);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            (0..m * n)
+                .map(|k| input.q[k] as f32 * input.scale_values[0])
                 .collect(),
         ),
         strides: StridedLayout::RowMajor.compute_strides(&shape),
@@ -186,6 +335,7 @@ fn run_quantized_packed(m: usize, n: usize, value: QuantValue, bm: usize, bn: us
         &client,
         CubeCount::new_single(),
         CubeDim::new_single(),
+        1,
         pack,
         input.arg(),
         output.arg(),
@@ -229,10 +379,11 @@ pub fn plain_copy<E: Numeric>(
 
 #[cube(launch)]
 /// `I` names the binding's element only: the arg's scheme recovers the served value, so a
-/// quantized input dequantizes with nothing threaded through the body.
-pub fn dequant_copy<I: Numeric, O: Numeric, V: Size>(
-    input: &QuantTileArg<'_, I, Const<1>>,
-    output: &TileArg<'_, O, V>,
+/// quantized input dequantizes with nothing threaded through the body. `VI` is the binding
+/// width (served ÷ packing factor), `VO` the served width the copy writes at.
+pub fn dequant_copy<I: Numeric, O: Numeric, VI: Size, VO: Size>(
+    input: &QuantTileArg<'_, I, VI>,
+    output: &TileArg<'_, O, VO>,
     #[comptime] space: Space,
     #[define(I)] _input_dtype: ElemType,
     #[define(O)] _output_dtype: ElemType,
@@ -358,6 +509,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, global: Option<
         &client,
         CubeCount::new_single(),
         CubeDim::new_single(),
+        1,
         1,
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),


### PR DESCRIPTION
Routes `dequantize::launch_ref` through the tile engine, and makes the tiled dequantize a real multi-cube kernel. Stacked on #444.

## What changed

- The tiled dequantize plans its geometry host-side: the widest served line that tiles the innermost extent, rides contiguous strides, covers whole packed words and sits inside one scale block, then a cube tile edge and an optional plane cut to fill a cube. The kernel only walks what was proven sound, so a vectorized plan never overhangs.
- `dequantize::launch_ref` routes per launch. The tile path takes f32-scale symmetric schemes over contiguous innermost dims, stored natively or as innermost-packed `u32` words a device line covers whole. Everything else keeps the elementwise kernels. The routing matrix is unit tested from host data alone.
- A per-tensor scale now serves vectorized and packed reads. Its block edges are stated as `usize::MAX`, so the straddling rules are skipped where there is nothing to straddle, instead of rejecting every vectorized per-tensor operand.
- `Tile::copy` becomes an op. `dst.copy(&src)` walks the levels that hand regions to different cubes and transports each region it lands on, so the dequantize kernel body is one copy rather than a hand-written walk over the space.
- Adds a benchmark running the legacy elementwise dequantize against the tile path over the same schemes.

## Notes

Kernel time is at parity with the legacy path. The benchmark's device timing brackets a single launch on an otherwise idle GPU, so it also counts host dispatch, which is where the two paths differ.

## Testing

Covers the tiled dequantize's schemes and its fallbacks, including the shapes and strides that send a launch back to the elementwise kernels. `cubek-tile` quant tests 38 passed, `cubek-quant` 39 passed on an RTX 4070 Ti SUPER.
