### PR TITLE
Add a copy op to the tile engine

### DIFF
--- a/crates/cubek-tile/src/ops/copy.rs
+++ b/crates/cubek-tile/src/ops/copy.rs
@@ -1,0 +1,51 @@
+//! The copy reading of a [`Tile`](crate::Tile): `dst.copy(&src)` walks the levels that hand
+//! regions to different cubes, and transports each region it lands on.
+
+use cubecl::prelude::*;
+
+use crate::*;
+
+#[cube]
+impl<T: Numeric> Tile<T> {
+    /// `dst.copy(&src)`: walk while a level spreads regions across cubes, else transport.
+    ///
+    /// The transport ([`copy_from`](Tile::copy_from)) fills a whole tile with every unit of the
+    /// cube, so a level that spreads *inside* a cube is already its own doing and ends the walk.
+    /// A quantized source decodes on the way through, as it does under any read.
+    pub fn copy(&mut self, src: &Tile<T>) {
+        if comptime!(spreads_across_cubes(&self.space)) {
+            let space = self.copy_space(src);
+            for region in Walk::over(space) {
+                let mut dst = self.at(&region);
+                dst.copy(&src.at(&region));
+            }
+        } else {
+            self.copy_from(src);
+        }
+    }
+
+    /// The walk's space: this tile's, with every [`Dynamic`](crate::Extent) axis sized by
+    /// whichever operand [`witnesses`](Tile::witnesses) it. The destination is asked first,
+    /// like [`mma`](Tile::mma) asks its accumulator: an axis it spans is one it writes, so its
+    /// bound is the extent the walk must cover.
+    fn copy_space(&self, src: &Tile<T>) -> Space {
+        witnessed_space(comptime!(self.space.clone()), self, src, src)
+    }
+}
+
+/// Whether this level hands its regions to different cubes: some axis rides a cube dim and none
+/// rides a plane or a unit, so the walk steps exactly what the launch grid separates.
+fn spreads_across_cubes(space: &Space) -> bool {
+    if space.is_final() {
+        return false;
+    }
+    let mut across = false;
+    for axis in space.axes() {
+        match space.partitioner().distribution(axis).scope() {
+            Some(ComputeScope::Cube(_)) => across = true,
+            Some(_) => return false,
+            None => {}
+        }
+    }
+    across
+}

--- a/crates/cubek-tile/src/ops/mod.rs
+++ b/crates/cubek-tile/src/ops/mod.rs
@@ -1,9 +1,10 @@
-//! The verbs a client runs over tiles: [`matmul`] (`mma`) and [`softmax`]. Each reads an
-//! already-structured [`Tile`](crate::Tile) and either walks its levels or runs at the leaf; the
-//! shared machinery they compose lives in [`crate::staging`]. Dequantization is not a verb: a
-//! quantized store dequantizes under the plain [`Tile::copy_from`](crate::Tile::copy_from).
+//! The verbs a client runs over tiles: [`matmul`] (`mma`), [`softmax`] and [`copy`]. Each reads
+//! an already-structured [`Tile`](crate::Tile) and either walks its levels or runs at the leaf;
+//! the shared machinery they compose lives in [`crate::staging`]. Dequantization is not a verb: a
+//! quantized store dequantizes under the plain [`Tile::copy`](crate::Tile::copy).
 
 mod attention;
+mod copy;
 mod matmul;
 mod softmax;
 

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -8,7 +8,7 @@ use cubek_test_utils::{
     ValidationResult, assert_equals_approx,
 };
 use cubek_tile::{
-    Axis, Cut, DequantAt, QuantTileArg, QuantTileArgLaunch, Schedule, Space, TileArg,
+    Axis, CubeAxis, Cut, DequantAt, QuantTileArg, QuantTileArgLaunch, Schedule, Space, TileArg,
     TileArgLaunch, TileSpec, Tiling, WalkOrder,
 };
 
@@ -36,6 +36,48 @@ fn copy_non_quantized_matches_reference() {
         output.arg(),
         space,
         dtype,
+    );
+
+    let input_host = HostData::from_tensor_handle(&client, input.handle(), HostDataType::F32);
+    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    assert_equals_approx(&got, &input_host, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// The op walks the levels that hand regions to different cubes and stops at the plane level,
+/// which the transport spreads over the cube itself. Stepping the plane level would leave every
+/// plane but the first unwritten, since the fill indexes by the flat unit.
+#[test]
+fn copy_spread_across_cubes_and_planes_matches_reference() {
+    let (m, n) = (4, 512);
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = Tiling::new()
+        .extents(&[(M, m), (N, n)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(M, Cut::cube(CubeAxis::Y, 1))
+                .axis(N, Cut::cube(CubeAxis::X, 128))
+        })
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(M, Cut::sequential(1)).axis(N, Cut::plane(32))
+        })
+        .build()
+        .launcher_over(&client, &[]);
+    let space = launch.space().clone();
+
+    let input = TileInput::builder(&client, space.clone())
+        .untiled()
+        .arange();
+    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+
+    plain_copy::launch::<TestRuntime>(
+        &client,
+        launch.cube_count(),
+        launch.cube_dim(),
+        input.arg(),
+        output.arg(),
+        space,
+        f32::elem_type_native(),
     );
 
     let input_host = HostData::from_tensor_handle(&client, input.handle(), HostDataType::F32);
@@ -374,7 +416,7 @@ pub fn plain_copy<E: Numeric>(
 ) {
     let input = input.tile(comptime!(space.clone()));
     let mut output = output.tile(space);
-    output.copy_from(&input);
+    output.copy(&input);
 }
 
 #[cube(launch)]


### PR DESCRIPTION
Reading one tile into another was a hand-written walk at every call site: build the witnessed space, iterate its regions, transport each one. That walk is a property of the tiles, not of the caller. Stacked on #498. It needs the tile path's two-level reads, not the elementwise kernels, so it sits beside #444 rather than above it.

## What changed

`dst.copy(&src)` walks while a level spreads regions across cubes, and transports once it does not. The transport already fills a whole tile with every unit of the cube, so a level that spreads inside a cube is its own doing and ends the walk.

## Testing

The new spread test pins that stopping rule: dropping it leaves three quarters of a multi-plane tile unwritten. Tile quant tests 38 passed.

