### PR TITLE
Add a tiled dequantize kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
+source = "git+https://github.com/tracel-ai/cubecl?rev=2d058e53a691645ec1d964beb69ddac0601e27e1#2d058e53a691645ec1d964beb69ddac0601e27e1"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
+source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=03d79521e29f93c6ff230ccac32fc81cfabb0462#03d79521e29f93c6ff230ccac32fc81cfabb0462"
+source = "git+https://github.com/tracel-ai/cubecl?rev=bdf991825e25a4708ce817a32cac6452dd792465#bdf991825e25a4708ce817a32cac6452dd792465"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=088dd7053c039775f73cf4d1645d30706d0ddf7d#088dd7053c039775f73cf4d1645d30706d0ddf7d"
+source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -721,7 +721,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -798,7 +798,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -826,7 +826,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -877,7 +877,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -936,7 +936,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "darling 0.23.0",
  "inflections",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -988,7 +988,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1016,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1061,7 +1061,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=9b9ce8ee3294618e394d0b939b1fe93f3bcfce30#9b9ce8ee3294618e394d0b939b1fe93f3bcfce30"
+source = "git+https://github.com/tracel-ai/cubecl?rev=7eead27c2976d2660d59ff6db87dea3baa94c9f4#7eead27c2976d2660d59ff6db87dea3baa94c9f4"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,13 @@ version = "0.3.0-pre.2"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
+# cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
+# cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
+# cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
+### For the cubecl feat/quant-scale-levels branch. ###
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "9b9ce8ee3294618e394d0b939b1fe93f3bcfce30", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "9b9ce8ee3294618e394d0b939b1fe93f3bcfce30", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "9b9ce8ee3294618e394d0b939b1fe93f3bcfce30", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.2", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ version = "0.3.0-pre.2"
 # cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
 # cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
 ### For the cubecl feat/quant-scale-levels branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "03d79521e29f93c6ff230ccac32fc81cfabb0462", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "03d79521e29f93c6ff230ccac32fc81cfabb0462", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "03d79521e29f93c6ff230ccac32fc81cfabb0462", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "bdf991825e25a4708ce817a32cac6452dd792465", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "bdf991825e25a4708ce817a32cac6452dd792465", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "bdf991825e25a4708ce817a32cac6452dd792465", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.2", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ version = "0.3.0-pre.2"
 # cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
 # cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
 ### For the cubecl feat/quant-scale-levels branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "7eead27c2976d2660d59ff6db87dea3baa94c9f4", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "7eead27c2976d2660d59ff6db87dea3baa94c9f4", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "7eead27c2976d2660d59ff6db87dea3baa94c9f4", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "03d79521e29f93c6ff230ccac32fc81cfabb0462", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "03d79521e29f93c6ff230ccac32fc81cfabb0462", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "03d79521e29f93c6ff230ccac32fc81cfabb0462", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.2", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ version = "0.3.0-pre.2"
 # cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
 # cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
 ### For the cubecl feat/quant-scale-levels branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "bdf991825e25a4708ce817a32cac6452dd792465", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "bdf991825e25a4708ce817a32cac6452dd792465", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "bdf991825e25a4708ce817a32cac6452dd792465", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "2d058e53a691645ec1d964beb69ddac0601e27e1", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "2d058e53a691645ec1d964beb69ddac0601e27e1", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "2d058e53a691645ec1d964beb69ddac0601e27e1", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.2", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ version = "0.3.0-pre.2"
 # cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
 # cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "088dd7053c039775f73cf4d1645d30706d0ddf7d", default-features = false }
 ### For the cubecl feat/quant-scale-levels branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "9b9ce8ee3294618e394d0b939b1fe93f3bcfce30", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "9b9ce8ee3294618e394d0b939b1fe93f3bcfce30", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "9b9ce8ee3294618e394d0b939b1fe93f3bcfce30", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "7eead27c2976d2660d59ff6db87dea3baa94c9f4", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "7eead27c2976d2660d59ff6db87dea3baa94c9f4", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "7eead27c2976d2660d59ff6db87dea3baa94c9f4", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.2", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.2", default-features = false }

--- a/crates/cubek-matmul/src/args.rs
+++ b/crates/cubek-matmul/src/args.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use cubecl::prelude::*;
 use cubecl::std::tensor::{
     View, ViewMut,
-    launch::ViewArg,
+    launch::{ScaleBindings, ViewArg},
     layout::{Coords1d, VirtualLayout, VirtualLayoutLaunch},
 };
 use cubecl::unexpanded;
@@ -225,7 +225,7 @@ impl<Lhs: CubePrimitive, Rhs: CubePrimitive, Acc: CubePrimitive, A: BatchMatmulR
                     scale.into_tensor_arg(),
                     scales_layout,
                 );
-                ViewArg::new_quantized(data_view, scales_view, scheme)
+                ViewArg::new_quantized(data_view, ScaleBindings::one(scales_view), scheme)
             }
         };
         let batch_layout = |handle: &InputBinding<R>| match handle {

--- a/crates/cubek-matmul/src/components/batch/naive/setup.rs
+++ b/crates/cubek-matmul/src/components/batch/naive/setup.rs
@@ -138,7 +138,7 @@ impl BatchMatmulFamily<()> for NaiveBatchMatmulFamily {
         }
 
         if let Some(scheme) = problem.lhs_scheme
-            && scheme.levels().len() == 1
+            && scheme.num_levels() == 1
             && let Some(block_size) = scheme.block_size()
         {
             let vector_size = vector_sizes.lhs * scheme.num_quants();
@@ -152,7 +152,7 @@ impl BatchMatmulFamily<()> for NaiveBatchMatmulFamily {
         }
 
         if let Some(scheme) = problem.rhs_scheme
-            && scheme.levels().len() == 1
+            && scheme.num_levels() == 1
             && let Some(block_size) = scheme.block_size()
         {
             let vector_size = vector_sizes.rhs * scheme.num_quants();

--- a/crates/cubek-matmul/src/components/batch/naive/setup.rs
+++ b/crates/cubek-matmul/src/components/batch/naive/setup.rs
@@ -2,7 +2,6 @@ use cubecl::{
     CubeCount, CubeDim, Runtime,
     client::ComputeClient,
     ir::{AddressType, DeviceProperties},
-    quant::scheme::QuantLevel,
     server::LaunchError,
 };
 use cubek_std::MatrixLayout;
@@ -139,9 +138,11 @@ impl BatchMatmulFamily<()> for NaiveBatchMatmulFamily {
         }
 
         if let Some(scheme) = problem.lhs_scheme
-            && let QuantLevel::Block(block_size) = scheme.level
+            && scheme.levels().len() == 1
+            && !scheme.block_size().is_full()
         {
             let vector_size = vector_sizes.lhs * scheme.num_quants();
+            let block_size = scheme.block_size();
             let block_size = block_size.to_dim_vec(2.max(block_size.len()));
             let block_width = block_size[block_size.len() - 1] as usize;
             if !block_width.is_multiple_of(vector_size) {
@@ -152,9 +153,11 @@ impl BatchMatmulFamily<()> for NaiveBatchMatmulFamily {
         }
 
         if let Some(scheme) = problem.rhs_scheme
-            && let QuantLevel::Block(block_size) = scheme.level
+            && scheme.levels().len() == 1
+            && !scheme.block_size().is_full()
         {
             let vector_size = vector_sizes.rhs * scheme.num_quants();
+            let block_size = scheme.block_size();
             let block_size = block_size.to_dim_vec(2.max(block_size.len()));
             let block_width = block_size[block_size.len() - 2] as usize;
             if !block_width.is_multiple_of(vector_size) {

--- a/crates/cubek-matmul/src/components/batch/naive/setup.rs
+++ b/crates/cubek-matmul/src/components/batch/naive/setup.rs
@@ -139,10 +139,9 @@ impl BatchMatmulFamily<()> for NaiveBatchMatmulFamily {
 
         if let Some(scheme) = problem.lhs_scheme
             && scheme.levels().len() == 1
-            && !scheme.block_size().is_full()
+            && let Some(block_size) = scheme.block_size()
         {
             let vector_size = vector_sizes.lhs * scheme.num_quants();
-            let block_size = scheme.block_size();
             let block_size = block_size.to_dim_vec(2.max(block_size.len()));
             let block_width = block_size[block_size.len() - 1] as usize;
             if !block_width.is_multiple_of(vector_size) {
@@ -154,10 +153,9 @@ impl BatchMatmulFamily<()> for NaiveBatchMatmulFamily {
 
         if let Some(scheme) = problem.rhs_scheme
             && scheme.levels().len() == 1
-            && !scheme.block_size().is_full()
+            && let Some(block_size) = scheme.block_size()
         {
             let vector_size = vector_sizes.rhs * scheme.num_quants();
-            let block_size = scheme.block_size();
             let block_size = block_size.to_dim_vec(2.max(block_size.len()));
             let block_width = block_size[block_size.len() - 2] as usize;
             if !block_width.is_multiple_of(vector_size) {

--- a/crates/cubek-matmul/src/components/global/memory/layout.rs
+++ b/crates/cubek-matmul/src/components/global/memory/layout.rs
@@ -262,11 +262,9 @@ impl<R: Runtime> GlobalLayoutLaunch<R> {
                 );
             }
 
-            let block_size = scheme.block_size();
-            if block_size.is_full() {
-                GlobalScaleLayoutArgs::PerTensor { shape }
-            } else {
-                {
+            match scheme.block_size() {
+                None => GlobalScaleLayoutArgs::PerTensor { shape },
+                Some(block_size) => {
                     let [block_row, block_col] = block_size.as_dim();
                     // Scales are never vectorized because we require that `block_size >= vector_size * num_quants`.
                     let scales_layout =

--- a/crates/cubek-matmul/src/components/global/memory/layout.rs
+++ b/crates/cubek-matmul/src/components/global/memory/layout.rs
@@ -6,7 +6,7 @@ use cubecl::std::{
     },
 };
 use cubecl::zspace::Shape;
-use cubecl_common::quant::scheme::{QuantLevel, QuantScheme};
+use cubecl_common::quant::scheme::QuantScheme;
 use cubek_std::MatrixLayout;
 
 use crate::{
@@ -255,9 +255,18 @@ impl<R: Runtime> GlobalLayoutLaunch<R> {
         let scales_layout = {
             let shape = (rows as u32, cols as u32);
 
-            match scheme.level {
-                QuantLevel::Tensor => GlobalScaleLayoutArgs::PerTensor { shape },
-                QuantLevel::Block(block_size) => {
+            let levels = scheme.scale_levels();
+            if levels.len() > 1 {
+                unimplemented!(
+                    "two-level quantization is not supported by the quantized matmul, got {levels:?}"
+                );
+            }
+
+            let block_size = scheme.block_size();
+            if block_size.is_full() {
+                GlobalScaleLayoutArgs::PerTensor { shape }
+            } else {
+                {
                     let [block_row, block_col] = block_size.as_dim();
                     // Scales are never vectorized because we require that `block_size >= vector_size * num_quants`.
                     let scales_layout =
@@ -268,10 +277,6 @@ impl<R: Runtime> GlobalLayoutLaunch<R> {
                         (block_row as u32, block_col as u32),
                     ))
                 }
-                QuantLevel::BlockTensor { .. } => unimplemented!(
-                    "two-level quantization is not supported by the quantized matmul, got {:?}",
-                    scheme.level
-                ),
             }
         };
 

--- a/crates/cubek-matmul/src/components/global/memory/layout.rs
+++ b/crates/cubek-matmul/src/components/global/memory/layout.rs
@@ -255,10 +255,9 @@ impl<R: Runtime> GlobalLayoutLaunch<R> {
         let scales_layout = {
             let shape = (rows as u32, cols as u32);
 
-            let levels = scheme.scale_levels();
-            if levels.len() > 1 {
+            if scheme.num_levels() > 1 {
                 unimplemented!(
-                    "two-level quantization is not supported by the quantized matmul, got {levels:?}"
+                    "two-level quantization is not supported by the quantized matmul, got {scheme:?}"
                 );
             }
 

--- a/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/benchmark.rs
@@ -119,9 +119,8 @@ struct QuantMatmulInputs {
 }
 
 fn scales_shape(scheme: &QuantScheme, shape: &[usize]) -> Vec<usize> {
-    let levels = scheme.scale_levels();
-    if levels.len() > 1 {
-        unimplemented!("two-level quantization is not supported here, got {levels:?}");
+    if scheme.num_levels() > 1 {
+        unimplemented!("two-level quantization is not supported here, got {scheme:?}");
     }
 
     let Some(block) = scheme.block_size() else {

--- a/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/benchmark.rs
@@ -124,10 +124,9 @@ fn scales_shape(scheme: &QuantScheme, shape: &[usize]) -> Vec<usize> {
         unimplemented!("two-level quantization is not supported here, got {levels:?}");
     }
 
-    let block = scheme.block_size();
-    if block.is_full() {
+    let Some(block) = scheme.block_size() else {
         return vec![1; shape.len()];
-    }
+    };
 
     let block_dims = block.to_dim_vec(shape.len());
     shape
@@ -337,7 +336,7 @@ fn validate_spec(problem: &QuantizedMatmulProblem) -> Result<(), String> {
                 "{label} pack axis={last} incompatible with num_quants={nq}"
             ));
         }
-        if !scheme.block_size().is_full() {
+        if scheme.block_size().is_some() {
             let scales = scales_shape(&scheme, shape);
             if scales.contains(&0) {
                 return Err(format!("{label} block size exceeds a dim in {shape:?}"));

--- a/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/benchmark.rs
@@ -11,7 +11,7 @@ use cubecl::{
 };
 use cubek_quant::{
     quantize,
-    scheme::{QuantLevel, QuantScheme, QuantStore},
+    scheme::{QuantScheme, QuantStore},
 };
 use cubek_std::InputBinding;
 use cubek_test_utils::{RunSamples, TestInput};
@@ -119,22 +119,22 @@ struct QuantMatmulInputs {
 }
 
 fn scales_shape(scheme: &QuantScheme, shape: &[usize]) -> Vec<usize> {
-    match &scheme.level {
-        QuantLevel::Tensor => vec![1; shape.len()],
-        QuantLevel::Block(block) => {
-            let rank = shape.len();
-            let block_dims = block.to_dim_vec(rank);
-            shape
-                .iter()
-                .zip(block_dims.iter())
-                .map(|(d, b)| d / (*b as usize))
-                .collect()
-        }
-        QuantLevel::BlockTensor { .. } => unimplemented!(
-            "two-level quantization is not supported here, got {:?}",
-            scheme.level
-        ),
+    let levels = scheme.scale_levels();
+    if levels.len() > 1 {
+        unimplemented!("two-level quantization is not supported here, got {levels:?}");
     }
+
+    let block = scheme.block_size();
+    if block.is_full() {
+        return vec![1; shape.len()];
+    }
+
+    let block_dims = block.to_dim_vec(shape.len());
+    shape
+        .iter()
+        .zip(block_dims.iter())
+        .map(|(d, b)| d / (*b as usize))
+        .collect()
 }
 
 fn quantize_operand(
@@ -337,7 +337,7 @@ fn validate_spec(problem: &QuantizedMatmulProblem) -> Result<(), String> {
                 "{label} pack axis={last} incompatible with num_quants={nq}"
             ));
         }
-        if let QuantLevel::Block(_) = &scheme.level {
+        if !scheme.block_size().is_full() {
             let scales = scales_shape(&scheme, shape);
             if scales.contains(&0) {
                 return Err(format!("{label} block size exceeds a dim in {shape:?}"));

--- a/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/problem.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/problem.rs
@@ -1,6 +1,4 @@
-use cubek_quant::scheme::{
-    QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels,
-};
+use cubek_quant::scheme::{QuantMode, QuantScheme, QuantStore, QuantValue, ScaleDtype};
 use cubek_test_utils::CatalogEntry;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,13 +57,13 @@ pub struct QuantizedMatmulProblem {
 fn scheme_tensor(value: QuantValue) -> QuantScheme {
     QuantScheme::default()
         .with_mode(QuantMode::Symmetric)
-        .with_scales(ScaleLevels::tensor(QuantParam::F32))
+        .per_tensor(ScaleDtype::F32)
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
 }
 
 fn scheme_block(value: QuantValue, block: u8) -> QuantScheme {
-    scheme_tensor(value).with_scales(ScaleLevels::block([block], QuantParam::F32))
+    scheme_tensor(value).per_block([block], ScaleDtype::F32)
 }
 
 fn quant_schemes() -> Vec<(&'static str, QuantScheme)> {

--- a/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/problem.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/problem.rs
@@ -1,4 +1,6 @@
-use cubek_quant::scheme::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue};
+use cubek_quant::scheme::{
+    QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels,
+};
 use cubek_test_utils::CatalogEntry;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,14 +59,13 @@ pub struct QuantizedMatmulProblem {
 fn scheme_tensor(value: QuantValue) -> QuantScheme {
     QuantScheme::default()
         .with_mode(QuantMode::Symmetric)
-        .with_level(QuantLevel::Tensor)
+        .with_scales(ScaleLevels::tensor(QuantParam::F32))
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
-        .with_param(QuantParam::F32)
 }
 
 fn scheme_block(value: QuantValue, block: u8) -> QuantScheme {
-    scheme_tensor(value).with_level(QuantLevel::block([block]))
+    scheme_tensor(value).with_scales(ScaleLevels::block([block], QuantParam::F32))
 }
 
 fn quant_schemes() -> Vec<(&'static str, QuantScheme)> {

--- a/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/problem.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/quantized_matmul/problem.rs
@@ -63,7 +63,11 @@ fn scheme_tensor(value: QuantValue) -> QuantScheme {
 }
 
 fn scheme_block(value: QuantValue, block: u8) -> QuantScheme {
-    scheme_tensor(value).per_block([block], ScaleDtype::F32)
+    QuantScheme::default()
+        .with_mode(QuantMode::Symmetric)
+        .per_block([block], ScaleDtype::F32)
+        .with_value(value)
+        .with_store(QuantStore::PackedU32(0))
 }
 
 fn quant_schemes() -> Vec<(&'static str, QuantScheme)> {

--- a/crates/cubek-matmul/src/eval/benchmarks/tile_quant_stage/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/tile_quant_stage/benchmark.rs
@@ -6,7 +6,7 @@ use cubecl::{
     client::ComputeClient,
     future,
     prelude::*,
-    quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue},
+    quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels},
 };
 use cubek_test_utils::{QuantizedTileInput, RunSamples, TileInput};
 use cubek_tile::*;
@@ -44,10 +44,9 @@ pub fn bench(
     let client = <TestRuntime as Runtime>::client(&device);
 
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([1, problem.bn as u8]))
+        .with_scales(ScaleLevels::block([1, problem.bn as u8], QuantParam::F32))
         .with_store(QuantStore::PackedU32(0))
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
     let pack = scheme.num_quants();
     let max_width = client.properties().hardware.max_vector_size;
     if pack > max_width {

--- a/crates/cubek-matmul/src/eval/benchmarks/tile_quant_stage/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/tile_quant_stage/benchmark.rs
@@ -145,7 +145,7 @@ impl Benchmark for TileQuantStageBench {
             .arg(b.tile.handle().binding())
             .subspace(&[K, N])
             .vectorize(self.pack)
-            .quantized(b.scales_arg(), self.scheme, DequantAt::Read)
+            .quantized(&[b.scales_binding()], self.scheme, DequantAt::Read)
             .build();
         // The register microkernel lines the accumulator at the RHS's served width.
         let c = launcher

--- a/crates/cubek-matmul/src/eval/benchmarks/tile_quant_stage/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/tile_quant_stage/benchmark.rs
@@ -6,7 +6,7 @@ use cubecl::{
     client::ComputeClient,
     future,
     prelude::*,
-    quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels},
+    quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype},
 };
 use cubek_test_utils::{QuantizedTileInput, RunSamples, TileInput};
 use cubek_tile::*;
@@ -44,7 +44,7 @@ pub fn bench(
     let client = <TestRuntime as Runtime>::client(&device);
 
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([1, problem.bn as u8], QuantParam::F32))
+        .per_block([1, problem.bn as u8], ScaleDtype::F32)
         .with_store(QuantStore::PackedU32(0))
         .with_value(QuantValue::Q8S);
     let pack = scheme.num_quants();

--- a/crates/cubek-matmul/tests/matmul/extended/cpu_gemm/mod.rs
+++ b/crates/cubek-matmul/tests/matmul/extended/cpu_gemm/mod.rs
@@ -333,7 +333,7 @@ fn transposed_lhs_m_not_vector_multiple() {
         MatrixLayout::RowMajor,
         None,
         None,
-        MatmulElems::from_single_dtype(f32::as_type_native_unchecked()).as_global_elems(),
+        MatmulElems::from_single_dtype(f32::elem_type_native()).as_global_elems(),
         AddressType::U32,
     );
     test_matmul_strategy(
@@ -362,7 +362,7 @@ fn transposed_lhs_batched() {
         MatrixLayout::RowMajor,
         None,
         None,
-        MatmulElems::from_single_dtype(f32::as_type_native_unchecked()).as_global_elems(),
+        MatmulElems::from_single_dtype(f32::elem_type_native()).as_global_elems(),
         AddressType::U32,
     );
     test_matmul_strategy(

--- a/crates/cubek-matmul/tests/matmul/extended/quantization.rs
+++ b/crates/cubek-matmul/tests/matmul/extended/quantization.rs
@@ -70,7 +70,11 @@ fn tensor_scheme_store(value: QuantValue, store: QuantStore) -> QuantScheme {
 }
 
 fn block_scheme(value: QuantValue, block_size: impl AsRef<[u8]>) -> QuantScheme {
-    tensor_scheme(value).per_block(block_size, ScaleDtype::F32)
+    QuantScheme::default()
+        .with_mode(QuantMode::Symmetric)
+        .per_block(block_size, ScaleDtype::F32)
+        .with_value(value)
+        .with_store(QuantStore::PackedU32(0))
 }
 
 /// Skips a test when the runtime lacks `i8` conversion support, which

--- a/crates/cubek-matmul/tests/matmul/extended/quantization.rs
+++ b/crates/cubek-matmul/tests/matmul/extended/quantization.rs
@@ -5,9 +5,7 @@ use cubek_matmul::{
     launch::launch_ref,
     strategy::Strategy,
 };
-use cubek_quant::scheme::{
-    QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels,
-};
+use cubek_quant::scheme::{QuantMode, QuantScheme, QuantStore, QuantValue, ScaleDtype};
 use cubek_std::{InputBinding, MatrixLayout};
 use cubek_test_utils::{
     ExecutionOutcome, HostData, HostDataType, InputDataType, TestInput, TestOutcome, TestTensor,
@@ -62,7 +60,7 @@ fn tolerance_for(scheme: &QuantScheme, k: usize, scale: f32) -> f32 {
 fn tensor_scheme(value: QuantValue) -> QuantScheme {
     QuantScheme::default()
         .with_mode(QuantMode::Symmetric)
-        .with_scales(ScaleLevels::tensor(QuantParam::F32))
+        .per_tensor(ScaleDtype::F32)
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
 }
@@ -72,7 +70,7 @@ fn tensor_scheme_store(value: QuantValue, store: QuantStore) -> QuantScheme {
 }
 
 fn block_scheme(value: QuantValue, block_size: impl AsRef<[u8]>) -> QuantScheme {
-    tensor_scheme(value).with_scales(ScaleLevels::block(block_size, QuantParam::F32))
+    tensor_scheme(value).per_block(block_size, ScaleDtype::F32)
 }
 
 /// Skips a test when the runtime lacks `i8` conversion support, which

--- a/crates/cubek-matmul/tests/matmul/extended/quantization.rs
+++ b/crates/cubek-matmul/tests/matmul/extended/quantization.rs
@@ -5,7 +5,9 @@ use cubek_matmul::{
     launch::launch_ref,
     strategy::Strategy,
 };
-use cubek_quant::scheme::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue};
+use cubek_quant::scheme::{
+    QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels,
+};
 use cubek_std::{InputBinding, MatrixLayout};
 use cubek_test_utils::{
     ExecutionOutcome, HostData, HostDataType, InputDataType, TestInput, TestOutcome, TestTensor,
@@ -60,10 +62,9 @@ fn tolerance_for(scheme: &QuantScheme, k: usize, scale: f32) -> f32 {
 fn tensor_scheme(value: QuantValue) -> QuantScheme {
     QuantScheme::default()
         .with_mode(QuantMode::Symmetric)
-        .with_level(QuantLevel::Tensor)
+        .with_scales(ScaleLevels::tensor(QuantParam::F32))
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
-        .with_param(QuantParam::F32)
 }
 
 fn tensor_scheme_store(value: QuantValue, store: QuantStore) -> QuantScheme {
@@ -71,7 +72,7 @@ fn tensor_scheme_store(value: QuantValue, store: QuantStore) -> QuantScheme {
 }
 
 fn block_scheme(value: QuantValue, block_size: impl AsRef<[u8]>) -> QuantScheme {
-    tensor_scheme(value).with_level(QuantLevel::block(block_size))
+    tensor_scheme(value).with_scales(ScaleLevels::block(block_size, QuantParam::F32))
 }
 
 /// Skips a test when the runtime lacks `i8` conversion support, which

--- a/crates/cubek-quant/src/dequantize.rs
+++ b/crates/cubek-quant/src/dequantize.rs
@@ -6,7 +6,7 @@ use cubecl::{prelude::*, std::tensor::layout::linear::LinearViewMut};
 
 use crate::{
     layout::{ScalesView, scales_view},
-    scheme::{QuantLevel, QuantMode, QuantScheme, QuantStore, QuantValue},
+    scheme::{QuantMode, QuantScheme, QuantStore, QuantValue},
     utils::packed_storage_elem,
 };
 use cubecl::std::tensor::{
@@ -200,7 +200,7 @@ pub fn launch_ref<R: Runtime>(
     scheme: &QuantScheme,
     output_dtype: ElemType,
 ) -> Result<(), LaunchError> {
-    let scale_dtype: ElemType = ElemType::from_quant_param(scheme.param);
+    let scale_dtype: ElemType = ElemType::from_quant_param(scheme.param());
 
     match scheme {
         QuantScheme {
@@ -288,11 +288,10 @@ fn dequantize_packed<R: Runtime>(
 
     match scheme {
         QuantScheme {
-            level: QuantLevel::Tensor | QuantLevel::Block(_),
             store: QuantStore::PackedU32(_),
             mode: QuantMode::Symmetric,
             ..
-        } => unsafe {
+        } if scheme.levels().len() == 1 => unsafe {
             dequantize_symmetric_packed_kernel::launch_unchecked(
                 client,
                 cube_count,
@@ -339,11 +338,10 @@ fn dequantize_native<R: Runtime>(
 
     match scheme {
         QuantScheme {
-            level: QuantLevel::Tensor | QuantLevel::Block(_),
             mode: QuantMode::Symmetric,
             store: QuantStore::Native,
             ..
-        } => {
+        } if scheme.levels().len() == 1 => {
             let address_type = input
                 .required_address_type(input_dtype.size())
                 .max(scale.required_address_type(scale_dtype.size()))

--- a/crates/cubek-quant/src/dequantize.rs
+++ b/crates/cubek-quant/src/dequantize.rs
@@ -200,7 +200,7 @@ pub fn launch_ref<R: Runtime>(
     scheme: &QuantScheme,
     output_dtype: ElemType,
 ) -> Result<(), LaunchError> {
-    let scale_dtype: ElemType = ElemType::from_quant_param(scheme.param());
+    let scale_dtype: ElemType = ElemType::from_scale_dtype(scheme.scale_dtype());
 
     match scheme {
         QuantScheme {
@@ -291,7 +291,7 @@ fn dequantize_packed<R: Runtime>(
             store: QuantStore::PackedU32(_),
             mode: QuantMode::Symmetric,
             ..
-        } if scheme.levels().len() == 1 => unsafe {
+        } if scheme.num_levels() == 1 => unsafe {
             dequantize_symmetric_packed_kernel::launch_unchecked(
                 client,
                 cube_count,
@@ -341,7 +341,7 @@ fn dequantize_native<R: Runtime>(
             mode: QuantMode::Symmetric,
             store: QuantStore::Native,
             ..
-        } if scheme.levels().len() == 1 => {
+        } if scheme.num_levels() == 1 => {
             let address_type = input
                 .required_address_type(input_dtype.size())
                 .max(scale.required_address_type(scale_dtype.size()))

--- a/crates/cubek-quant/src/dequantize.rs
+++ b/crates/cubek-quant/src/dequantize.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)] // pub cube modules
 
+use cubecl::tensor_vector_size_parallel;
 use cubecl::{calculate_cube_count_elemwise, ir::ElemType};
-use cubecl::{features::TypeUsage, tensor_vector_size_parallel};
 use cubecl::{prelude::*, std::tensor::layout::linear::LinearViewMut};
 
 use crate::{
@@ -225,12 +225,7 @@ pub fn launch_ref<R: Runtime>(
             store: QuantStore::PackedNative(_),
             ..
         } => {
-            if !i8::supported_uses(client).contains(TypeUsage::Conversion) {
-                panic!(
-                    "{:?} is not supported for native quantization",
-                    scheme.value
-                );
-            }
+            crate::utils::check_i8_supported(client, scheme);
 
             dequantize_native(
                 client,

--- a/crates/cubek-quant/src/dequantize_tiled.rs
+++ b/crates/cubek-quant/src/dequantize_tiled.rs
@@ -2,7 +2,7 @@ use cubecl::{
     features::TypeUsage,
     ir::ElemType,
     prelude::*,
-    quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue},
+    quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype},
 };
 use cubek_tile::{
     Axis, ByAxis, DequantAt, Distribution, Partitioner, QuantTileArg, Space, StridedOperand,
@@ -29,11 +29,11 @@ pub fn launch_ref<R: Runtime>(
         "only native quantization is supported for now."
     );
     assert!(
-        scheme.levels().len() == 1 && scheme.block_size().is_none(),
+        scheme.num_levels() == 1 && scheme.block_size().is_none(),
         "only per tensor quantization is supported for now."
     );
     assert!(
-        scheme.param() == QuantParam::F32,
+        scheme.scale_dtype() == ScaleDtype::F32,
         "only f32 scales are supported for now."
     );
     check_i8_supported(client, scheme);

--- a/crates/cubek-quant/src/dequantize_tiled.rs
+++ b/crates/cubek-quant/src/dequantize_tiled.rs
@@ -2,7 +2,7 @@ use cubecl::{
     features::TypeUsage,
     ir::ElemType,
     prelude::*,
-    quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue},
+    quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue},
 };
 use cubek_tile::{
     Axis, ByAxis, DequantAt, Distribution, Partitioner, QuantTileArg, Space, StridedOperand,
@@ -29,11 +29,11 @@ pub fn launch_ref<R: Runtime>(
         "only native quantization is supported for now."
     );
     assert!(
-        scheme.level == QuantLevel::Tensor,
+        scheme.levels().len() == 1 && scheme.block_size().is_full(),
         "only per tensor quantization is supported for now."
     );
     assert!(
-        scheme.param == QuantParam::F32,
+        scheme.param() == QuantParam::F32,
         "only f32 scales are supported for now."
     );
     check_i8_supported(client, scheme);

--- a/crates/cubek-quant/src/dequantize_tiled.rs
+++ b/crates/cubek-quant/src/dequantize_tiled.rs
@@ -29,7 +29,7 @@ pub fn launch_ref<R: Runtime>(
         "only native quantization is supported for now."
     );
     assert!(
-        scheme.levels().len() == 1 && scheme.block_size().is_full(),
+        scheme.levels().len() == 1 && scheme.block_size().is_none(),
         "only per tensor quantization is supported for now."
     );
     assert!(

--- a/crates/cubek-quant/src/dequantize_tiled.rs
+++ b/crates/cubek-quant/src/dequantize_tiled.rs
@@ -62,7 +62,7 @@ pub fn launch_ref<R: Runtime>(
         .subspace(&[M, N])
         .checked(false)
         // Nothing stages this operand, so its read is what decodes it.
-        .quantized(scales.into_tensor_arg(), *scheme, DequantAt::Read)
+        .quantized(&[scales], *scheme, DequantAt::Read)
         .build();
     let output_op = StridedOperand::source(output)
         .space(&space)

--- a/crates/cubek-quant/src/dequantize_tiled.rs
+++ b/crates/cubek-quant/src/dequantize_tiled.rs
@@ -1,81 +1,110 @@
 use cubecl::{
-    features::TypeUsage,
     ir::ElemType,
     prelude::*,
-    quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype},
+    quant::scheme::{QuantScheme, QuantStore, ScaleDtype},
 };
 use cubek_tile::{
-    Axis, ByAxis, DequantAt, Distribution, Partitioner, QuantTileArg, Space, StridedOperand,
-    TileArg,
+    Axis, CubeAxis, Cut, DequantAt, QuantTileArg, Schedule, Space, TileArg, Tiling, WalkOrder,
 };
 
-// Input axes
-const M: Axis = Axis(0);
-const N: Axis = Axis(1);
+use crate::utils;
 
-/// Convert the tensor back to a higher precision data type.
-/// Uses the tile-based implementation for dequantization.
-/// Very WIP and naive implementation for now.
+/// Dequantize `values` into `output` through the tile engine: the input tile serves the
+/// output element and decodes on read, so the kernel body is one copy.
+///
+/// `values` is declared **in values**: for a packed store its shape and strides count the
+/// quantized values (innermost stride 1) while its buffer is narrower by the packing factor.
+/// `scales` holds one binding per scale level, innermost first; a two-level scheme's second
+/// binding is its global, whole-tensor scale.
+///
+/// # Errors
+///
+/// Propagates the kernel's [`LaunchError`]. An unsupported scheme (a non-f32 param, a store
+/// that is neither native nor packed-u32, a packing factor no device line covers, or a FULL
+/// dim inside a block) panics on the caller's thread instead, so the plan fails loudly.
+#[allow(clippy::result_large_err)]
 pub fn launch_ref<R: Runtime>(
     client: &ComputeClient<R>,
-    input: TensorBinding<R>,
+    values: TensorBinding<R>,
     output: TensorBinding<R>,
-    scales: TensorBinding<R>,
+    scales: &[TensorBinding<R>],
     scheme: &QuantScheme,
     output_dtype: ElemType,
 ) -> Result<(), LaunchError> {
-    assert!(
-        scheme.store == QuantStore::Native,
-        "only native quantization is supported for now."
-    );
-    assert!(
-        scheme.num_levels() == 1 && scheme.block_size().is_none(),
-        "only per tensor quantization is supported for now."
-    );
+    let input_dtype = match scheme.store {
+        QuantStore::Native => {
+            utils::check_i8_supported(client, scheme);
+            ElemType::from_quant_value(scheme.value)
+        }
+        QuantStore::PackedU32(_) => utils::packed_storage_elem(scheme),
+        other => panic!("dequantize_tiled: unsupported storage {other:?} (native or packed-u32)"),
+    };
     assert!(
         scheme.scale_dtype() == ScaleDtype::F32,
         "only f32 scales are supported for now."
     );
-    check_i8_supported(client, scheme);
-
-    // One space for the whole kernel; both operands span all of it. Geometry reads the
-    // concrete extents; the kernel gets the dynamic form, so m and n resolve in-kernel
-    // from the tensor's own shape and never fork the compiled kernel.
-    // The space is read off the first two dims, so a deeper buffer would be described by its grid
-    // dims rather than its extents. Both operands are plain 2-D tensors: every axis untiled, one
-    // physical axis apiece, which is what the source builder derives below.
-    assert!(
-        input.shape.len() == 2 && output.shape.len() == 2,
-        "dequantize_tiled: both operands must be plain 2-D tensors, got {:?} and {:?}",
-        input.shape,
-        output.shape
+    assert_eq!(
+        scales.len(),
+        scheme.num_levels(),
+        "dequantize_tiled: one scale binding per level, innermost first"
     );
-    let space = sequential_space(&[(M, input.shape[0]), (N, input.shape[1])]);
-    let cube_count = space.cube_count();
-    let cube_dim = space.cube_dim(client);
-    let input_dtype = ElemType::from_quant_value(scheme.value);
-    // Both operands through the source builder, which derives the storage from the binding's own
-    // dims and validates the scheme against this space. One tile covers each axis, so nothing
-    // overhangs and the checks stay off.
-    let input_op = StridedOperand::source(input)
-        .space(&space)
-        .subspace(&[M, N])
-        .checked(false)
-        // Nothing stages this operand, so its read is what decodes it.
-        .quantized(&[scales], *scheme, DequantAt::Read)
+    let rank = output.shape.len();
+    assert!(rank >= 1, "dequantize_tiled: a scalar binding has no axes");
+    assert_eq!(
+        &values.shape[..],
+        &output.shape[..],
+        "dequantize_tiled: the values binding is declared in values, so both shapes agree"
+    );
+
+    let inner_block = inner_block_edge(scheme, rank);
+    let inner_extent = output.shape[rank - 1];
+    let type_size = input_dtype.size().max(output_dtype.size());
+    let width = served_width(
+        client.io_optimized_vector_sizes(type_size),
+        inner_extent,
+        inner_block,
+        scheme.num_quants(),
+        &[&values.strides, &output.strides],
+    );
+    assert!(
+        width.is_multiple_of(scheme.num_quants()),
+        "dequantize_tiled: a served line may not split a u32, and no width covering the \
+         {}-value packing factor qualifies here",
+        scheme.num_quants()
+    );
+    let plane_size = client.properties().hardware.plane_size_max as usize;
+    let geometry = Geometry::of(width, plane_size, inner_extent, inner_block);
+
+    let axes: Vec<Axis> = (0..rank).map(|p| Axis(p as u8)).collect();
+    let extents: Vec<(Axis, usize)> = axes
+        .iter()
+        .zip(output.shape.iter())
+        .map(|(&axis, &extent)| (axis, extent))
+        .collect();
+    let space = geometry.space(&extents);
+    let launch = space.launcher(client);
+
+    let input_op = launch
+        .arg(values)
+        .subspace(&axes)
+        .vectorize(geometry.width)
+        .quantized(scales, *scheme, DequantAt::Read)
         .build();
-    let output_op = StridedOperand::source(output)
-        .space(&space)
-        .subspace(&[M, N])
-        .checked(false)
+    let output_op = launch
+        .arg(output)
+        .subspace(&axes)
+        .vectorize(geometry.width)
         .build();
-    dequantize::launch(
+
+    dequantize::launch::<R>(
         client,
-        cube_count,
-        cube_dim,
+        launch.cube_count(),
+        launch.cube_dim(),
+        input_op.bound_width(),
+        output_op.vector_size,
         input_op.arg(),
         output_op.arg(),
-        space.all_dynamic(),
+        launch.space().clone(),
         input_dtype,
         output_dtype,
     );
@@ -83,50 +112,272 @@ pub fn launch_ref<R: Runtime>(
     Ok(())
 }
 
-/// A row-major space whose every axis is `Sequential`: a single cube walks all the tiles.
-/// Each axis is one tile covering its full extent (one tile total).
-fn sequential_space(extents: &[(Axis, usize)]) -> Space {
-    let dists: Vec<(Axis, Distribution)> = extents
-        .iter()
-        .map(|&(a, _)| (a, Distribution::Sequential))
-        .collect();
-    let partitioner = Partitioner::row_major(ByAxis::new(extents), ByAxis::new(&dists)).direct();
-    Space::new(extents).with_partitioner(partitioner)
-}
-
-fn check_i8_supported<R: Runtime>(client: &ComputeClient<R>, scheme: &QuantScheme) {
-    match scheme {
-        QuantScheme {
-            value: QuantValue::Q8F | QuantValue::Q8S | QuantValue::E4M3 | QuantValue::E5M2,
-            store: QuantStore::Native,
-            ..
-        }
-        | QuantScheme {
-            value: QuantValue::E2M1,
-            store: QuantStore::PackedNative(_),
-            ..
-        } if !i8::supported_uses(client).contains(TypeUsage::Conversion) => {
-            panic!(
-                "{:?} is not supported for native quantization",
-                scheme.value
-            );
-        }
-        _ => {}
-    }
-}
-
 #[cube(launch)]
 /// The input tile serves `O` and dequantizes on read, so the body is a plain copy; `I` (the
 /// storage element) only names the binding's element, the scheme recovers the served value.
-/// Scales ride as an ordinary second tensor.
-pub fn dequantize<I: Numeric, O: Numeric>(
-    input: &QuantTileArg<'_, I, Const<1>>,
-    output: &TileArg<'_, O, Const<1>>,
+/// `VI` is the binding width (served over the packing factor), `VO` the served width.
+pub fn dequantize<I: Numeric, O: Numeric, VI: Size, VO: Size>(
+    input: &QuantTileArg<'_, I, VI>,
+    output: &TileArg<'_, O, VO>,
     #[comptime] space: Space,
     #[define(I)] _input_dtype: ElemType,
     #[define(O)] _output_dtype: ElemType,
 ) {
     let input = input.tile::<O>(comptime!(space.clone()));
     let mut output = output.tile(space);
-    output.copy_from(&input);
+    output.copy(&input);
+}
+
+/// The unit count one cube aims for; plane counts derive from it per device.
+const TARGET_UNITS: usize = 256;
+
+/// One launch's innermost-axis plan. Derived host-side so the kernel only walks what was
+/// proven sound: a vectorized plan never overhangs (a checked operand cannot be vectorized)
+/// and every edge tiles whole scale blocks or sits inside one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Geometry {
+    /// Served values per line, `1` when nothing wider qualifies.
+    width: usize,
+    /// The innermost cube-tile edge, in values.
+    cube_edge: usize,
+    /// A second-level plane cut raising the cube's unit count; `None` keeps one plane per cube.
+    plane_edge: Option<usize>,
+}
+
+impl Geometry {
+    fn of(
+        width: usize,
+        plane_size: usize,
+        inner_extent: usize,
+        inner_block: Option<usize>,
+    ) -> Geometry {
+        let fits = |edge: usize| {
+            inner_block.is_none_or(|b| edge.is_multiple_of(b) || b.is_multiple_of(edge))
+        };
+        let plane_edge = plane_size * width;
+        let planes = (TARGET_UNITS / plane_size).max(1);
+        let preferred = planes * plane_edge;
+        if planes > 1
+            && inner_extent.is_multiple_of(preferred)
+            && fits(preferred)
+            && fits(plane_edge)
+        {
+            return Geometry {
+                width,
+                cube_edge: preferred,
+                plane_edge: Some(plane_edge),
+            };
+        }
+        if inner_extent.is_multiple_of(plane_edge) && fits(plane_edge) {
+            return Geometry {
+                width,
+                cube_edge: plane_edge,
+                plane_edge: None,
+            };
+        }
+        if width > 1 {
+            // Divides the extent and sits inside a block by served_width's own gates.
+            return Geometry {
+                width,
+                cube_edge: width,
+                plane_edge: None,
+            };
+        }
+        // Scalar with a masked overhang; the edge still tiles whole blocks.
+        let cube_edge = inner_block.map_or(plane_size, |b| b * plane_size.div_ceil(b));
+        Geometry {
+            width: 1,
+            cube_edge,
+            plane_edge: None,
+        }
+    }
+
+    /// The level stack over `extents` (one axis per tensor dim, innermost last): innermost
+    /// tiles ride one-per-cube on X, the next axis on Y and every remaining global axis on Z,
+    /// one element per cube. The plane level, when present, cuts nothing the walk visits; it
+    /// only raises the cube's unit count for the cooperative fill.
+    fn space(&self, extents: &[(Axis, usize)]) -> Space {
+        let rank = extents.len();
+        let inner = extents[rank - 1].0;
+        let global: Vec<Axis> = extents[..rank - 1].iter().map(|&(axis, _)| axis).collect();
+        let mut tiling =
+            Tiling::new()
+                .extents(extents)
+                .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+                    let mut l = l.axis(inner, Cut::cube(CubeAxis::X, self.cube_edge));
+                    if let Some((&y, zs)) = global.split_last() {
+                        l = l
+                            .axis(y, Cut::cube(CubeAxis::Y, 1))
+                            .axes(zs, Cut::cube(CubeAxis::Z, 1));
+                    }
+                    l
+                });
+        if let Some(plane_edge) = self.plane_edge {
+            tiling = tiling.level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+                l.axis(inner, Cut::plane(plane_edge))
+                    .axes(&global, Cut::sequential(1))
+            });
+        }
+        tiling.build()
+    }
+}
+
+/// The widest qualifying served line: it must tile the innermost extent, ride contiguous
+/// innermost dims (coarser strides re-express in lines), cover whole packed words, and sit
+/// inside the innermost scale block. `1` when nothing wider qualifies.
+fn served_width(
+    candidates: impl Iterator<Item = usize>,
+    inner_extent: usize,
+    inner_block: Option<usize>,
+    num_quants: usize,
+    operands: &[&[usize]],
+) -> usize {
+    candidates
+        .filter(|&v| {
+            v == 1
+                || (inner_extent.is_multiple_of(v)
+                    && v.is_multiple_of(num_quants)
+                    && inner_block.is_none_or(|b| b.is_multiple_of(v))
+                    && operands.iter().all(|strides| {
+                        strides.last() == Some(&1)
+                            && strides[..strides.len() - 1]
+                                .iter()
+                                .all(|&s| s.is_multiple_of(v))
+                    }))
+        })
+        .max()
+        .unwrap_or(1)
+}
+
+/// The innermost axis's block edge in values, `None` for a per-tensor scheme. A block scheme
+/// holding a FULL (0) dim would put a zero edge into the scale windowing, so it is refused.
+fn inner_block_edge(scheme: &QuantScheme, rank: usize) -> Option<usize> {
+    let block = scheme.block_size()?;
+    let dims = block.to_dim_vec(rank);
+    assert!(
+        dims.iter().all(|&b| b != 0),
+        "dequantize_tiled: a FULL (0) dim inside a block scheme is not supported, got {dims:?}"
+    );
+    Some(dims[rank - 1] as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CANDIDATES: [usize; 4] = [8, 4, 2, 1];
+
+    fn width(inner_extent: usize, inner_block: Option<usize>, strides: &[usize]) -> usize {
+        served_width(
+            CANDIDATES.iter().copied(),
+            inner_extent,
+            inner_block,
+            1,
+            &[strides, strides],
+        )
+    }
+
+    #[test]
+    fn served_width_takes_the_widest_qualifying_line() {
+        assert_eq!(width(128, None, &[128, 1]), 8);
+    }
+
+    /// An extent no candidate divides serves scalar; the checked path takes over from there.
+    #[test]
+    fn served_width_falls_to_scalar_on_an_awkward_extent() {
+        assert_eq!(width(127, None, &[127, 1]), 1);
+    }
+
+    /// A line may not straddle a scale block, so the block caps the width.
+    #[test]
+    fn served_width_sits_inside_the_inner_block() {
+        assert_eq!(width(128, Some(4), &[128, 1]), 4);
+        assert_eq!(width(128, Some(6), &[128, 1]), 2);
+    }
+
+    /// A sliced view keeps its parent's coarser strides; a width they cannot re-express in
+    /// lines would truncate them.
+    #[test]
+    fn served_width_respects_strides() {
+        assert_eq!(width(128, None, &[128, 2]), 1); // innermost not contiguous
+        assert_eq!(width(64, None, &[132, 1]), 4); // coarser stride caps the width
+    }
+
+    /// Packing constrains from below: a served line covers whole `u32` words or nothing.
+    #[test]
+    fn served_width_covers_whole_packed_words() {
+        let w = served_width(CANDIDATES.iter().copied(), 128, None, 4, &[&[128, 1]]);
+        assert_eq!(w, 8);
+        // No candidate reaches the packing factor: scalar comes back and the caller refuses it.
+        let w = served_width([2usize, 1].into_iter(), 128, None, 4, &[&[128, 1]]);
+        assert_eq!(w, 1);
+    }
+
+    #[test]
+    fn geometry_prefers_a_multi_plane_cube() {
+        let g = Geometry::of(4, 32, 4096, None);
+        assert_eq!(
+            g,
+            Geometry {
+                width: 4,
+                cube_edge: 1024,
+                plane_edge: Some(128)
+            }
+        );
+    }
+
+    #[test]
+    fn geometry_falls_back_to_one_plane_per_cube() {
+        let g = Geometry::of(4, 32, 128, None);
+        assert_eq!(
+            g,
+            Geometry {
+                width: 4,
+                cube_edge: 128,
+                plane_edge: None
+            }
+        );
+    }
+
+    /// A vectorized width always has a dividing edge (itself), so a shape the plane edge does
+    /// not divide narrows the cube rather than degrading to scalar.
+    #[test]
+    fn geometry_narrows_the_cube_before_giving_up_the_width() {
+        let g = Geometry::of(4, 32, 64, None);
+        assert_eq!(
+            g,
+            Geometry {
+                width: 4,
+                cube_edge: 4,
+                plane_edge: None
+            }
+        );
+    }
+
+    #[test]
+    fn geometry_scalar_fallback_overhangs_at_the_plane_size() {
+        let g = Geometry::of(1, 32, 127, None);
+        assert_eq!(
+            g,
+            Geometry {
+                width: 1,
+                cube_edge: 32,
+                plane_edge: None
+            }
+        );
+    }
+
+    /// The scalar edge still tiles whole blocks: a straddling cut would misaddress scales.
+    #[test]
+    fn geometry_scalar_fallback_rounds_the_edge_to_whole_blocks() {
+        let g = Geometry::of(1, 32, 96, Some(48));
+        assert_eq!(
+            g,
+            Geometry {
+                width: 1,
+                cube_edge: 48,
+                plane_edge: None
+            }
+        );
+    }
 }

--- a/crates/cubek-quant/src/layout/scales.rs
+++ b/crates/cubek-quant/src/layout/scales.rs
@@ -223,9 +223,8 @@ pub fn scales_layout<R: Runtime>(
 ) -> ScalesLayoutArgs<R> {
     let values_len = values.shape.iter().product::<usize>() * scheme.num_quants();
 
-    let levels = scheme.scale_levels();
-    if levels.len() > 1 {
-        unimplemented!("two-level quantization is not supported here, got {levels:?}");
+    if scheme.num_levels() > 1 {
+        unimplemented!("two-level quantization is not supported here, got {scheme:?}");
     }
 
     match scheme.block_size() {

--- a/crates/cubek-quant/src/layout/scales.rs
+++ b/crates/cubek-quant/src/layout/scales.rs
@@ -228,19 +228,19 @@ pub fn scales_layout<R: Runtime>(
         unimplemented!("two-level quantization is not supported here, got {levels:?}");
     }
 
-    let block_size = scheme.block_size();
-    if block_size.is_full() {
-        ScalesLayoutArgs::PerTensor(PerTensorLayoutLaunch::new(values_len))
-    } else {
-        let tensor_shape = shape_divmod_quant(&values.shape, scheme.num_quants());
-        let scales_strides = strides_seq(&scales.strides);
-        ScalesLayoutArgs::BlockScaled(BlockScaledLayoutLaunch::new(
-            tensor_shape,
-            values_len,
-            scales_strides,
-            block_size.to_dim_vec(values.shape.len()),
-            scales_vector_size,
-        ))
+    match scheme.block_size() {
+        None => ScalesLayoutArgs::PerTensor(PerTensorLayoutLaunch::new(values_len)),
+        Some(block_size) => {
+            let tensor_shape = shape_divmod_quant(&values.shape, scheme.num_quants());
+            let scales_strides = strides_seq(&scales.strides);
+            ScalesLayoutArgs::BlockScaled(BlockScaledLayoutLaunch::new(
+                tensor_shape,
+                values_len,
+                scales_strides,
+                block_size.to_dim_vec(values.shape.len()),
+                scales_vector_size,
+            ))
+        }
     }
 }
 

--- a/crates/cubek-quant/src/layout/scales.rs
+++ b/crates/cubek-quant/src/layout/scales.rs
@@ -7,7 +7,7 @@ use cubecl::std::{
 };
 use cubecl::{prelude::*, std::tensor::launch::ViewArg};
 
-use crate::scheme::{QuantLevel, QuantScheme};
+use crate::scheme::QuantScheme;
 
 /// Layout for quantization scales, indexed by quant element index and returns the corresponding
 /// scale based on the quantization type.
@@ -223,23 +223,24 @@ pub fn scales_layout<R: Runtime>(
 ) -> ScalesLayoutArgs<R> {
     let values_len = values.shape.iter().product::<usize>() * scheme.num_quants();
 
-    match &scheme.level {
-        QuantLevel::Tensor => ScalesLayoutArgs::PerTensor(PerTensorLayoutLaunch::new(values_len)),
-        QuantLevel::Block(block_size) => {
-            let tensor_shape = shape_divmod_quant(&values.shape, scheme.num_quants());
-            let scales_strides = strides_seq(&scales.strides);
-            ScalesLayoutArgs::BlockScaled(BlockScaledLayoutLaunch::new(
-                tensor_shape,
-                values_len,
-                scales_strides,
-                block_size.to_dim_vec(values.shape.len()),
-                scales_vector_size,
-            ))
-        }
-        QuantLevel::BlockTensor { .. } => unimplemented!(
-            "two-level quantization is not supported here, got {:?}",
-            scheme.level
-        ),
+    let levels = scheme.scale_levels();
+    if levels.len() > 1 {
+        unimplemented!("two-level quantization is not supported here, got {levels:?}");
+    }
+
+    let block_size = scheme.block_size();
+    if block_size.is_full() {
+        ScalesLayoutArgs::PerTensor(PerTensorLayoutLaunch::new(values_len))
+    } else {
+        let tensor_shape = shape_divmod_quant(&values.shape, scheme.num_quants());
+        let scales_strides = strides_seq(&scales.strides);
+        ScalesLayoutArgs::BlockScaled(BlockScaledLayoutLaunch::new(
+            tensor_shape,
+            values_len,
+            scales_strides,
+            block_size.to_dim_vec(values.shape.len()),
+            scales_vector_size,
+        ))
     }
 }
 

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -18,8 +18,33 @@ pub use cubecl_common::quant::scheme;
 
 #[cfg(feature = "kernels")]
 pub(crate) mod utils {
-    use crate::scheme::{QuantScheme, QuantStore};
+    use crate::scheme::{QuantScheme, QuantStore, QuantValue};
+    use cubecl::features::TypeUsage;
     use cubecl::ir::{ElemType, UIntKind};
+    use cubecl::prelude::*;
+
+    /// Panic when the scheme stores natively but the device cannot convert the storage
+    /// element (`i8` under the hood for the 8-bit values and fp8).
+    pub(crate) fn check_i8_supported<R: Runtime>(client: &ComputeClient<R>, scheme: &QuantScheme) {
+        match scheme {
+            QuantScheme {
+                value: QuantValue::Q8F | QuantValue::Q8S | QuantValue::E4M3 | QuantValue::E5M2,
+                store: QuantStore::Native,
+                ..
+            }
+            | QuantScheme {
+                value: QuantValue::E2M1,
+                store: QuantStore::PackedNative(_),
+                ..
+            } if !i8::supported_uses(client).contains(TypeUsage::Conversion) => {
+                panic!(
+                    "{:?} is not supported for native quantization",
+                    scheme.value
+                );
+            }
+            _ => {}
+        }
+    }
 
     pub(crate) fn check_block_size_compat(scheme: &QuantScheme, div: usize) {
         assert!(

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -22,6 +22,11 @@ pub(crate) mod utils {
     use cubecl::ir::{ElemType, UIntKind};
 
     pub(crate) fn check_block_size_compat(scheme: &QuantScheme, div: usize) {
+        assert!(
+            scheme.num_levels() <= 1,
+            "two-level quantization is not supported here, got {scheme:?}"
+        );
+
         // Validate block size compatibility
         if let Some(block_size) = scheme.block_size() {
             let block_size = *block_size.as_slice().last().unwrap() as usize;

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -23,8 +23,7 @@ pub(crate) mod utils {
 
     pub(crate) fn check_block_size_compat(scheme: &QuantScheme, div: usize) {
         // Validate block size compatibility
-        let block_size = scheme.block_size();
-        if !block_size.is_full() {
+        if let Some(block_size) = scheme.block_size() {
             let block_size = *block_size.as_slice().last().unwrap() as usize;
             assert!(
                 block_size.is_multiple_of(div),

--- a/crates/cubek-quant/src/lib.rs
+++ b/crates/cubek-quant/src/lib.rs
@@ -18,16 +18,13 @@ pub use cubecl_common::quant::scheme;
 
 #[cfg(feature = "kernels")]
 pub(crate) mod utils {
-    use crate::scheme::{QuantLevel, QuantScheme, QuantStore};
+    use crate::scheme::{QuantScheme, QuantStore};
     use cubecl::ir::{ElemType, UIntKind};
 
     pub(crate) fn check_block_size_compat(scheme: &QuantScheme, div: usize) {
         // Validate block size compatibility
-        if let QuantScheme {
-            level: QuantLevel::Block(block_size),
-            ..
-        } = scheme
-        {
+        let block_size = scheme.block_size();
+        if !block_size.is_full() {
             let block_size = *block_size.as_slice().last().unwrap() as usize;
             assert!(
                 block_size.is_multiple_of(div),

--- a/crates/cubek-quant/src/quantize.rs
+++ b/crates/cubek-quant/src/quantize.rs
@@ -4,7 +4,7 @@ use cubecl::{
     ir::ElemType,
     prelude::*,
     std::{
-        quant::round::round_up_to_param,
+        quant::round::round_up_to_dtype,
         tensor::{
             View, ViewMut, into_contiguous,
             layout::linear::{LinearView, LinearViewMut, linear_view},
@@ -19,7 +19,7 @@ use crate::{
 };
 use crate::{
     layout::{ScalesView, scales_layout},
-    scheme::{QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue},
+    scheme::{QuantMode, QuantScheme, QuantStore, QuantValue, ScaleDtype},
 };
 
 #[cube]
@@ -90,12 +90,12 @@ fn write_scale<F: Float, FS: CubePrimitive>(
     scale: View<F, usize>,
     mut out_scale: ViewMut<FS, usize>,
     scales_layout: ScalesLayout,
-    #[comptime] param: QuantParam,
+    #[comptime] param: ScaleDtype,
 ) -> FS {
     // Rounded up rather than cast to nearest, which can land below the scale calibration asked for
     // and clip every value at the block maximum. The CPU backends round up too, and both have to,
     // or a tensor quantized on one reconstructs differently on the other.
-    let scale = FS::cast_from(round_up_to_param::<F>(scale.read(in_pos), param));
+    let scale = FS::cast_from(round_up_to_dtype::<F>(scale.read(in_pos), param));
 
     // Write the scale into the output buffer
     if scales_layout.is_block_start(in_pos) {
@@ -114,7 +114,7 @@ fn quantize_symmetric_native_kernel<F: Float, N: Size, FS: Numeric, Q: Numeric>(
     mut output: LinearViewMut<'_, Vector<Q, N>>,
     out_scale: ScalesViewMut<'_, FS>,
     scales_layout: ScalesLayout,
-    #[comptime] param: QuantParam,
+    #[comptime] param: ScaleDtype,
     #[define(F, FS, Q)] _dtypes: [ElemType; 3],
 ) {
     if !output.is_in_bounds(ABSOLUTE_POS) {
@@ -154,7 +154,13 @@ fn quantize_symmetric_packed_kernel<F: Float, N: Size, FS: Numeric, QS: Int>(
 
     let num_quants = scheme.num_quants();
     let packed_pos = ABSOLUTE_POS * num_quants;
-    let scale = write_scale(packed_pos, scale, out_scale, scales_layout, scheme.param());
+    let scale = write_scale(
+        packed_pos,
+        scale,
+        out_scale,
+        scales_layout,
+        scheme.scale_dtype(),
+    );
 
     if input.vector_size().comptime() == num_quants {
         output.write(
@@ -201,12 +207,12 @@ pub fn launch_ref<R: Runtime>(
     // Refused here rather than during kernel expansion, where the caller can no longer read the
     // scheme off the error.
     assert!(
-        scheme.param().round_up(1.0).is_some(),
+        scheme.scale_dtype().round_up(1.0).is_some(),
         "{:?} scales have no round-up rule, which quantization requires",
-        scheme.param()
+        scheme.scale_dtype()
     );
 
-    let scale_dtype = ElemType::from_quant_param(scheme.param());
+    let scale_dtype = ElemType::from_scale_dtype(scheme.scale_dtype());
 
     match scheme {
         QuantScheme {
@@ -292,7 +298,7 @@ fn quantize_native<R: Runtime>(
             mode: QuantMode::Symmetric,
             store: QuantStore::Native,
             ..
-        } if scheme.levels().len() == 1 => {
+        } if scheme.num_levels() == 1 => {
             // We could use vector_size = block_size if it's in the supported vector sizes.. but let's keep it simple
             check_block_size_compat(scheme, vector_size as usize);
 
@@ -318,7 +324,7 @@ fn quantize_native<R: Runtime>(
                     linear_view(output.clone()),
                     scales_view(output, out_scale, 1, scheme),
                     scales_layout,
-                    scheme.param(),
+                    scheme.scale_dtype(),
                     [input_dtype, scale_dtype, output_dtype],
                 )
             }
@@ -348,7 +354,7 @@ fn quantize_packed<R: Runtime>(
             mode: QuantMode::Symmetric,
             store: QuantStore::PackedU32(dim),
             ..
-        } if scheme.levels().len() == 1 => {
+        } if scheme.num_levels() == 1 => {
             // Check if packing dim is contiguous
             let ndims = input.shape.len();
             input.strides[ndims - 1 - *dim] == 1

--- a/crates/cubek-quant/src/quantize.rs
+++ b/crates/cubek-quant/src/quantize.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use crate::{
     layout::{ScalesView, scales_layout},
-    scheme::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue},
+    scheme::{QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue},
 };
 
 #[cube]
@@ -154,7 +154,7 @@ fn quantize_symmetric_packed_kernel<F: Float, N: Size, FS: Numeric, QS: Int>(
 
     let num_quants = scheme.num_quants();
     let packed_pos = ABSOLUTE_POS * num_quants;
-    let scale = write_scale(packed_pos, scale, out_scale, scales_layout, scheme.param);
+    let scale = write_scale(packed_pos, scale, out_scale, scales_layout, scheme.param());
 
     if input.vector_size().comptime() == num_quants {
         output.write(
@@ -201,12 +201,12 @@ pub fn launch_ref<R: Runtime>(
     // Refused here rather than during kernel expansion, where the caller can no longer read the
     // scheme off the error.
     assert!(
-        scheme.param.round_up(1.0).is_some(),
+        scheme.param().round_up(1.0).is_some(),
         "{:?} scales have no round-up rule, which quantization requires",
-        scheme.param
+        scheme.param()
     );
 
-    let scale_dtype = ElemType::from_quant_param(scheme.param);
+    let scale_dtype = ElemType::from_quant_param(scheme.param());
 
     match scheme {
         QuantScheme {
@@ -289,11 +289,10 @@ fn quantize_native<R: Runtime>(
 
     match scheme {
         QuantScheme {
-            level: QuantLevel::Tensor | QuantLevel::Block(_),
             mode: QuantMode::Symmetric,
             store: QuantStore::Native,
             ..
-        } => {
+        } if scheme.levels().len() == 1 => {
             // We could use vector_size = block_size if it's in the supported vector sizes.. but let's keep it simple
             check_block_size_compat(scheme, vector_size as usize);
 
@@ -319,7 +318,7 @@ fn quantize_native<R: Runtime>(
                     linear_view(output.clone()),
                     scales_view(output, out_scale, 1, scheme),
                     scales_layout,
-                    scheme.param,
+                    scheme.param(),
                     [input_dtype, scale_dtype, output_dtype],
                 )
             }
@@ -346,11 +345,10 @@ fn quantize_packed<R: Runtime>(
     // Determine if we can use vectorized packing
     let mut can_vectorize = match scheme {
         QuantScheme {
-            level: QuantLevel::Tensor | QuantLevel::Block(_),
             mode: QuantMode::Symmetric,
             store: QuantStore::PackedU32(dim),
             ..
-        } => {
+        } if scheme.levels().len() == 1 => {
             // Check if packing dim is contiguous
             let ndims = input.shape.len();
             input.strides[ndims - 1 - *dim] == 1

--- a/crates/cubek-quant/tests/quant/mod.rs
+++ b/crates/cubek-quant/tests/quant/mod.rs
@@ -1,5 +1,5 @@
 use cubecl::{Runtime, prelude::*};
-use cubek_quant::scheme::{QuantParam, ScaleLevels};
+use cubek_quant::scheme::ScaleDtype;
 mod scale_rounding;
 mod tiled;
 

--- a/crates/cubek-quant/tests/quant/mod.rs
+++ b/crates/cubek-quant/tests/quant/mod.rs
@@ -1,5 +1,5 @@
 use cubecl::{Runtime, prelude::*};
-use cubek_quant::scheme::{QuantLevel, QuantParam};
+use cubek_quant::scheme::{QuantParam, ScaleLevels};
 mod scale_rounding;
 mod tiled;
 

--- a/crates/cubek-quant/tests/quant/scale_rounding.rs
+++ b/crates/cubek-quant/tests/quant/scale_rounding.rs
@@ -12,7 +12,9 @@ use cubecl::{
     std::tensor::TensorHandle,
     {TestRuntime, zspace::shape},
 };
-use cubek_quant::scheme::{QuantLevel, QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue};
+use cubek_quant::scheme::{
+    QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels,
+};
 
 const M: usize = 8;
 const N: usize = 32;
@@ -49,10 +51,9 @@ fn block_scales_are_stored_rounded_up_to_their_storage_precision() {
         .collect();
 
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([BLOCK as u8]))
+        .with_scales(ScaleLevels::block([BLOCK as u8], QuantParam::F16))
         .with_value(QuantValue::Q8S)
         .with_store(QuantStore::PackedU32(0))
-        .with_param(QuantParam::F16)
         .with_mode(QuantMode::Symmetric);
 
     // The scale grid is per axis: shape[i] / block[i], so one block per row here.

--- a/crates/cubek-quant/tests/quant/scale_rounding.rs
+++ b/crates/cubek-quant/tests/quant/scale_rounding.rs
@@ -12,9 +12,7 @@ use cubecl::{
     std::tensor::TensorHandle,
     {TestRuntime, zspace::shape},
 };
-use cubek_quant::scheme::{
-    QuantMode, QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels,
-};
+use cubek_quant::scheme::{QuantMode, QuantScheme, QuantStore, QuantValue, ScaleDtype};
 
 const M: usize = 8;
 const N: usize = 32;
@@ -51,7 +49,7 @@ fn block_scales_are_stored_rounded_up_to_their_storage_precision() {
         .collect();
 
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([BLOCK as u8], QuantParam::F16))
+        .per_block([BLOCK as u8], ScaleDtype::F16)
         .with_value(QuantValue::Q8S)
         .with_store(QuantStore::PackedU32(0))
         .with_mode(QuantMode::Symmetric);

--- a/crates/cubek-quant/tests/quant/symmetric.rs
+++ b/crates/cubek-quant/tests/quant/symmetric.rs
@@ -53,7 +53,7 @@ fn test_quantization_tensor_symmetric(m: usize, n: usize, value: QuantValue) {
     let output_f = TensorHandle::zeros(&client, shape, f32::elem_type_native());
 
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::tensor(QuantParam::F32))
+        .per_tensor(ScaleDtype::F32)
         .with_mode(mode)
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
@@ -194,7 +194,7 @@ fn test_quantization_block_symmetric(m: usize, n: usize, value: QuantValue, bloc
     let output_f = TensorHandle::zeros(&client, shape, f32::elem_type_native());
 
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([block_size as u8], QuantParam::F32))
+        .per_block([block_size as u8], ScaleDtype::F32)
         .with_mode(mode)
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))

--- a/crates/cubek-quant/tests/quant/symmetric.rs
+++ b/crates/cubek-quant/tests/quant/symmetric.rs
@@ -57,7 +57,6 @@ fn test_quantization_tensor_symmetric(m: usize, n: usize, value: QuantValue) {
         .with_mode(mode)
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
-        
         .with_mode(QuantMode::Symmetric);
 
     // The shape is from the POV of packed u32s.
@@ -198,7 +197,6 @@ fn test_quantization_block_symmetric(m: usize, n: usize, value: QuantValue, bloc
         .with_mode(mode)
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
-        
         .with_mode(QuantMode::Symmetric);
 
     // The shape is from the POV of packed u32s.

--- a/crates/cubek-quant/tests/quant/symmetric.rs
+++ b/crates/cubek-quant/tests/quant/symmetric.rs
@@ -53,11 +53,11 @@ fn test_quantization_tensor_symmetric(m: usize, n: usize, value: QuantValue) {
     let output_f = TensorHandle::zeros(&client, shape, f32::elem_type_native());
 
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::Tensor)
+        .with_scales(ScaleLevels::tensor(QuantParam::F32))
         .with_mode(mode)
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
-        .with_param(QuantParam::F32)
+        
         .with_mode(QuantMode::Symmetric);
 
     // The shape is from the POV of packed u32s.
@@ -194,11 +194,11 @@ fn test_quantization_block_symmetric(m: usize, n: usize, value: QuantValue, bloc
     let output_f = TensorHandle::zeros(&client, shape, f32::elem_type_native());
 
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([block_size as u8]))
+        .with_scales(ScaleLevels::block([block_size as u8], QuantParam::F32))
         .with_mode(mode)
         .with_value(value)
         .with_store(QuantStore::PackedU32(0))
-        .with_param(QuantParam::F32)
+        
         .with_mode(QuantMode::Symmetric);
 
     // The shape is from the POV of packed u32s.

--- a/crates/cubek-quant/tests/quant/tiled.rs
+++ b/crates/cubek-quant/tests/quant/tiled.rs
@@ -4,8 +4,9 @@ use cubecl::{
 };
 use cubek_quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype};
 use cubek_test_utils::{
-    HostData, HostDataType, HostDataVec, StridedLayout, TestInput, assert_equals_approx,
+    HostData, HostDataType, HostDataVec, StridedLayout, TestInput, TileInput, assert_equals_approx,
 };
+use cubek_tile::{Axis, DequantAt, Space};
 
 const SCALE: f32 = 0.05;
 const SEED: u64 = 0x1;
@@ -13,6 +14,152 @@ const SEED: u64 = 0x1;
 #[test]
 fn dequantize_tiled_native_per_tensor_matches_reference() {
     dequantize_tiled_native_per_tensor(&[128, 128]);
+}
+
+/// An extent nothing divides serves scalar (bounds-checked where the cube tile overhangs);
+/// same numbers as the vectorized launch, only the plan degrades.
+#[test]
+fn dequantize_tiled_native_per_tensor_awkward_shape_matches_reference() {
+    dequantize_tiled_native_per_tensor(&[6, 127]);
+}
+
+#[test]
+fn dequantize_tiled_native_per_tensor_rank_3_matches_reference() {
+    dequantize_tiled_native_per_tensor(&[3, 5, 64]);
+}
+
+/// An innermost extent the preferred multi-plane cube divides: the launch raises the cube's
+/// unit count through the plane level instead of multiplying cubes.
+#[test]
+fn dequantize_tiled_native_per_tensor_multi_plane_matches_reference() {
+    dequantize_tiled_native_per_tensor(&[4, 4096]);
+}
+
+/// A `[32]`-block scheme reads each innermost 32-value group through its own scale.
+#[test]
+fn dequantize_tiled_native_block_matches_reference() {
+    let client = TestRuntime::client(&Default::default());
+    if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
+        return; // backend has no native i8 (e.g. wgpu); native dequant can't run here
+    }
+    let (m, n, bn) = (64, 128, 32);
+
+    let scheme = QuantScheme::default()
+        .per_block([bn as u8], ScaleDtype::F32)
+        .with_store(QuantStore::Native)
+        .with_value(QuantValue::Q8S);
+
+    let shape = Shape::from(vec![m, n]);
+    let input_dtype = ElemType::from_quant_value(scheme.value);
+    let input_range = scheme.value.range();
+    let (input, input_host) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .uniform(SEED, input_range.0, input_range.1)
+        .generate_with_f32_host_data();
+
+    let sn = n / bn;
+    let scale_vals: Vec<f32> = (0..m * sn).map(|k| 0.05 * (k + 1) as f32).collect();
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![m, sn]))
+        .custom(scale_vals.clone())
+        .generate_without_host_data();
+
+    let output = TensorHandle::zeros(&client, shape.clone(), f32::elem_type_native());
+    cubek_quant::dequantize_tiled::launch_ref::<TestRuntime>(
+        &client,
+        input.binding(),
+        output.clone().binding(),
+        &[scales.binding()],
+        &scheme,
+        f32::elem_type_native(),
+    )
+    .unwrap();
+
+    let got = HostData::from_tensor_handle(&client, output, HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            input_host
+                .iter_indices()
+                .map(|idx| input_host.get_f32(&idx) * scale_vals[idx[0] * sn + idx[1] / bn])
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// Packed-u32 Q8S with a `[32]`-block: the binding is a `u32` declared in values, so this
+/// runs on every backend, no native i8 needed.
+#[test]
+fn dequantize_tiled_packed_block_matches_reference() {
+    let client = TestRuntime::client(&Default::default());
+    let (m, n, bn) = (16, 64, 32);
+
+    let scheme = QuantScheme::default()
+        .per_block([bn as u8], ScaleDtype::F32)
+        .with_store(QuantStore::PackedU32(0))
+        .with_value(QuantValue::Q8S);
+    let pack = scheme.num_quants();
+    let max_width = client.properties().hardware.max_vector_size;
+    if pack > max_width {
+        return; // no served line can cover a whole u32 word here
+    }
+
+    let space = Space::new(&[(Axis(0), m), (Axis(1), n)]);
+    let input = TileInput::builder(&client, space)
+        .untiled()
+        .packed(&scheme, DequantAt::Read)
+        .arange();
+
+    let sn = n / bn;
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![m, sn]))
+        .custom(input.scale_values.clone())
+        .generate_without_host_data();
+
+    let shape = Shape::from(vec![m, n]);
+    let output = TensorHandle::zeros(&client, shape.clone(), f32::elem_type_native());
+    cubek_quant::dequantize_tiled::launch_ref::<TestRuntime>(
+        &client,
+        input.tile.handle().binding(),
+        output.clone().binding(),
+        &[scales.binding()],
+        &scheme,
+        f32::elem_type_native(),
+    )
+    .unwrap();
+
+    let got = HostData::from_tensor_handle(&client, output, HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            (0..m * n)
+                .map(|k| {
+                    let (i, j) = (k / n, k % n);
+                    input.q[k] as f32 * input.scale_values[i * sn + j / bn]
+                })
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// Two-level: block scales normalized by one per-tensor scale, both folded into every value.
+/// The expectation carries the global, so an implementation that drops it fails by that factor.
+#[test]
+fn dequantize_tiled_native_two_level_matches_reference() {
+    dequantize_tiled_native_two_level(0.5);
+}
+
+/// A zero per-tensor scale zeroes every reconstruction, so the global provably participates
+/// in each value rather than defaulting to one.
+#[test]
+fn dequantize_tiled_native_two_level_zero_global_zeroes_output() {
+    dequantize_tiled_native_two_level(0.0);
 }
 
 fn dequantize_tiled_native_per_tensor(tensor_shape: &[usize]) {
@@ -58,6 +205,65 @@ fn dequantize_tiled_native_per_tensor(tensor_shape: &[usize]) {
             input_host
                 .iter_indices()
                 .map(|idx| input_host.get_f32(&idx) * SCALE)
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+fn dequantize_tiled_native_two_level(global: f32) {
+    let client = TestRuntime::client(&Default::default());
+    if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
+        return; // backend has no native i8 (e.g. wgpu); native dequant can't run here
+    }
+    let (m, n, bn) = (32, 64, 16);
+
+    let scheme = QuantScheme::default()
+        .per_block([bn as u8], ScaleDtype::F32)
+        .per_tensor(ScaleDtype::F32)
+        .with_store(QuantStore::Native)
+        .with_value(QuantValue::Q8S);
+
+    let shape = Shape::from(vec![m, n]);
+    let input_dtype = ElemType::from_quant_value(scheme.value);
+    let input_range = scheme.value.range();
+    let (input, input_host) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .uniform(SEED, input_range.0, input_range.1)
+        .generate_with_f32_host_data();
+
+    let sn = n / bn;
+    let scale_vals: Vec<f32> = (0..m * sn).map(|k| 0.05 * (k + 1) as f32).collect();
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![m, sn]))
+        .custom(scale_vals.clone())
+        .generate_without_host_data();
+    let global_scale = TestInput::builder(client.clone(), Shape::from(vec![1usize]))
+        .custom(vec![global])
+        .generate_without_host_data();
+
+    let output = TensorHandle::zeros(&client, shape.clone(), f32::elem_type_native());
+    cubek_quant::dequantize_tiled::launch_ref::<TestRuntime>(
+        &client,
+        input.binding(),
+        output.clone().binding(),
+        &[scales.binding(), global_scale.binding()],
+        &scheme,
+        f32::elem_type_native(),
+    )
+    .unwrap();
+
+    let got = HostData::from_tensor_handle(&client, output, HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            input_host
+                .iter_indices()
+                .map(|idx| {
+                    input_host.get_f32(&idx) * scale_vals[idx[0] * sn + idx[1] / bn] * global
+                })
                 .collect(),
         ),
         strides: StridedLayout::RowMajor.compute_strides(&shape),

--- a/crates/cubek-quant/tests/quant/tiled.rs
+++ b/crates/cubek-quant/tests/quant/tiled.rs
@@ -2,7 +2,7 @@ use cubecl::{
     Runtime, TestRuntime, features::TypeUsage, ir::ElemType, prelude::*, std::tensor::TensorHandle,
     zspace::Shape,
 };
-use cubek_quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels};
+use cubek_quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype};
 use cubek_test_utils::{
     HostData, HostDataType, HostDataVec, StridedLayout, TestInput, assert_equals_approx,
 };
@@ -22,7 +22,7 @@ fn dequantize_tiled_native_per_tensor(tensor_shape: &[usize]) {
     }
 
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::tensor(QuantParam::F32))
+        .per_tensor(ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 

--- a/crates/cubek-quant/tests/quant/tiled.rs
+++ b/crates/cubek-quant/tests/quant/tiled.rs
@@ -46,7 +46,7 @@ fn dequantize_tiled_native_per_tensor(tensor_shape: &[usize]) {
         &client,
         input.binding(),
         output.clone().binding(),
-        scales.binding(),
+        &[scales.binding()],
         &scheme,
         output_dtype,
     )

--- a/crates/cubek-quant/tests/quant/tiled.rs
+++ b/crates/cubek-quant/tests/quant/tiled.rs
@@ -2,7 +2,7 @@ use cubecl::{
     Runtime, TestRuntime, features::TypeUsage, ir::ElemType, prelude::*, std::tensor::TensorHandle,
     zspace::Shape,
 };
-use cubek_quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue};
+use cubek_quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels};
 use cubek_test_utils::{
     HostData, HostDataType, HostDataVec, StridedLayout, TestInput, assert_equals_approx,
 };
@@ -22,10 +22,9 @@ fn dequantize_tiled_native_per_tensor(tensor_shape: &[usize]) {
     }
 
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::Tensor)
+        .with_scales(ScaleLevels::tensor(QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     let shape = Shape::from(tensor_shape.to_vec());
     let input_dtype = ElemType::from_quant_value(scheme.value);

--- a/crates/cubek-std/src/input_binding.rs
+++ b/crates/cubek-std/src/input_binding.rs
@@ -73,7 +73,7 @@ impl<R: Runtime> InputBinding<R> {
                 data.strides.swap(dim0, dim1);
 
                 // Swap dims for scale and block size if block scaled quant is used
-                if !scheme.block_size().is_full() {
+                if scheme.block_size().is_some() {
                     scale.shape.swap(dim0, dim1);
                     scale.strides.swap(dim0, dim1);
                     scheme.swap_block_dims(rank, dim0, dim1);

--- a/crates/cubek-std/src/input_binding.rs
+++ b/crates/cubek-std/src/input_binding.rs
@@ -67,6 +67,10 @@ impl<R: Runtime> InputBinding<R> {
                 data_dtype: _,
                 scale_dtype: _,
             } => {
+                if scheme.num_levels() > 1 {
+                    unimplemented!("two-level quantization is not supported here, got {scheme:?}");
+                }
+
                 let rank = data.shape.len();
 
                 data.shape.swap(dim0, dim1);

--- a/crates/cubek-std/src/input_binding.rs
+++ b/crates/cubek-std/src/input_binding.rs
@@ -1,3 +1,4 @@
+use cubecl::std::tensor::{into_contiguous_packed, into_contiguous_pitched};
 use cubecl::{
     Runtime,
     client::ComputeClient,
@@ -6,10 +7,6 @@ use cubecl::{
     prelude::TensorBinding,
     server::LaunchError,
     zspace::Shape,
-};
-use cubecl::{
-    quant::scheme::{BlockSize, QuantLevel},
-    std::tensor::{into_contiguous_packed, into_contiguous_pitched},
 };
 use cubecl_common::quant::scheme::{QuantScheme, QuantStore, QuantValue};
 
@@ -76,13 +73,10 @@ impl<R: Runtime> InputBinding<R> {
                 data.strides.swap(dim0, dim1);
 
                 // Swap dims for scale and block size if block scaled quant is used
-                if let QuantLevel::Block(block) = &mut scheme.level {
+                if !scheme.block_size().is_full() {
                     scale.shape.swap(dim0, dim1);
                     scale.strides.swap(dim0, dim1);
-
-                    let mut block_size = block.to_dim_vec(rank);
-                    block_size.swap(dim0, dim1);
-                    *block = BlockSize::new_trim(block_size)
+                    scheme.swap_block_dims(rank, dim0, dim1);
                 }
 
                 shape.swap(dim0, dim1);

--- a/crates/cubek-test-utils/src/stubs/quant.rs
+++ b/crates/cubek-test-utils/src/stubs/quant.rs
@@ -1,7 +1,7 @@
 use cubecl::quant::scheme::QuantMode;
 use cubecl_common::{
     e4m3, e5m2,
-    quant::scheme::{QuantLevel, QuantScheme, QuantStore, QuantValue},
+    quant::scheme::{QuantScheme, QuantStore, QuantValue},
 };
 
 pub fn quantize(
@@ -181,18 +181,11 @@ fn quant_mask(size_quant: usize) -> u32 {
 
 /// The scheme's per-axis block edges over `shape`: per-tensor is one block spanning it all.
 pub(crate) fn block_dims(scheme: &QuantScheme, shape: &[usize]) -> Vec<usize> {
-    match scheme.level {
-        QuantLevel::Tensor => shape.to_vec(),
-        QuantLevel::Block(bs) => bs
-            .to_dim_vec(shape.len())
-            .iter()
-            .map(|&b| b as usize)
-            .collect(),
-        QuantLevel::BlockTensor { .. } => unimplemented!(
-            "two-level quantization is not supported here, got {:?}",
-            scheme.level
-        ),
+    let levels = scheme.scale_levels();
+    if levels.len() > 1 {
+        unimplemented!("two-level quantization is not supported here, got {levels:?}");
     }
+    scheme.block_size().resolved_dims(shape)
 }
 
 /// Shape of the per-block scale grid: each dimension divided by its block
@@ -242,21 +235,22 @@ fn scale_index(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cubecl_common::quant::scheme::{QuantLevel, QuantMode, QuantParam, QuantStore, QuantValue};
+    use cubecl_common::quant::scheme::{
+        QuantMode, QuantParam, QuantStore, QuantValue, ScaleLevels,
+    };
 
-    fn scheme(value: QuantValue, store: QuantStore, level: QuantLevel) -> QuantScheme {
+    fn scheme(value: QuantValue, store: QuantStore, levels: ScaleLevels) -> QuantScheme {
         QuantScheme::default()
             .with_mode(QuantMode::Symmetric)
-            .with_level(level)
+            .with_scales(levels)
             .with_value(value)
             .with_store(store)
-            .with_param(QuantParam::F32)
     }
 
     /// Quantize then dequantize and assert the round-trip stays within one
     /// quantization step (`scale`), the worst-case symmetric error.
     fn assert_round_trips(value: QuantValue, store: QuantStore, scale: f32) {
-        let s = scheme(value, store, QuantLevel::Tensor);
+        let s = scheme(value, store, ScaleLevels::tensor(QuantParam::F32));
         let n = 64; // multiple of every num_quants we test (≤16)
         let values: Vec<f32> = (0..n).map(|i| (i as f32 / n as f32) * 2.0 - 1.0).collect();
 
@@ -281,7 +275,11 @@ mod tests {
             &[values.len()],
             &[scale],
             &[values.len()],
-            &scheme(QuantValue::Q8S, QuantStore::Native, QuantLevel::Tensor),
+            &scheme(
+                QuantValue::Q8S,
+                QuantStore::Native,
+                ScaleLevels::tensor(QuantParam::F32),
+            ),
         );
 
         let got: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
@@ -312,7 +310,7 @@ mod tests {
         let s = scheme(
             QuantValue::Q8S,
             QuantStore::Native,
-            QuantLevel::block([4u8]),
+            ScaleLevels::block([4u8], QuantParam::F32),
         );
         let values = vec![
             0.1, 0.2, 0.3, 0.4, // block 0

--- a/crates/cubek-test-utils/src/stubs/quant.rs
+++ b/crates/cubek-test-utils/src/stubs/quant.rs
@@ -185,7 +185,10 @@ pub(crate) fn block_dims(scheme: &QuantScheme, shape: &[usize]) -> Vec<usize> {
     if levels.len() > 1 {
         unimplemented!("two-level quantization is not supported here, got {levels:?}");
     }
-    scheme.block_size().resolved_dims(shape)
+    match scheme.block_size() {
+        None => shape.to_vec(),
+        Some(block) => block.resolved_dims(shape),
+    }
 }
 
 /// Shape of the per-block scale grid: each dimension divided by its block

--- a/crates/cubek-test-utils/src/stubs/quant.rs
+++ b/crates/cubek-test-utils/src/stubs/quant.rs
@@ -181,9 +181,8 @@ fn quant_mask(size_quant: usize) -> u32 {
 
 /// The scheme's per-axis block edges over `shape`: per-tensor is one block spanning it all.
 pub(crate) fn block_dims(scheme: &QuantScheme, shape: &[usize]) -> Vec<usize> {
-    let levels = scheme.scale_levels();
-    if levels.len() > 1 {
-        unimplemented!("two-level quantization is not supported here, got {levels:?}");
+    if scheme.num_levels() > 1 {
+        unimplemented!("two-level quantization is not supported here, got {scheme:?}");
     }
     match scheme.block_size() {
         None => shape.to_vec(),
@@ -238,14 +237,11 @@ fn scale_index(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cubecl_common::quant::scheme::{
-        QuantMode, QuantParam, QuantStore, QuantValue, ScaleLevels,
-    };
+    use cubecl_common::quant::scheme::{QuantMode, QuantStore, QuantValue, ScaleDtype};
 
-    fn scheme(value: QuantValue, store: QuantStore, levels: ScaleLevels) -> QuantScheme {
+    fn scheme(value: QuantValue, store: QuantStore) -> QuantScheme {
         QuantScheme::default()
             .with_mode(QuantMode::Symmetric)
-            .with_scales(levels)
             .with_value(value)
             .with_store(store)
     }
@@ -253,7 +249,7 @@ mod tests {
     /// Quantize then dequantize and assert the round-trip stays within one
     /// quantization step (`scale`), the worst-case symmetric error.
     fn assert_round_trips(value: QuantValue, store: QuantStore, scale: f32) {
-        let s = scheme(value, store, ScaleLevels::tensor(QuantParam::F32));
+        let s = scheme(value, store).per_tensor(ScaleDtype::F32);
         let n = 64; // multiple of every num_quants we test (≤16)
         let values: Vec<f32> = (0..n).map(|i| (i as f32 / n as f32) * 2.0 - 1.0).collect();
 
@@ -278,11 +274,7 @@ mod tests {
             &[values.len()],
             &[scale],
             &[values.len()],
-            &scheme(
-                QuantValue::Q8S,
-                QuantStore::Native,
-                ScaleLevels::tensor(QuantParam::F32),
-            ),
+            &scheme(QuantValue::Q8S, QuantStore::Native).per_tensor(ScaleDtype::F32),
         );
 
         let got: Vec<i8> = bytes.iter().map(|&b| b as i8).collect();
@@ -310,11 +302,7 @@ mod tests {
     #[test]
     fn block_level_uses_per_block_scale() {
         // Two blocks of 4 along the last dim, each with its own scale.
-        let s = scheme(
-            QuantValue::Q8S,
-            QuantStore::Native,
-            ScaleLevels::block([4u8], QuantParam::F32),
-        );
+        let s = scheme(QuantValue::Q8S, QuantStore::Native).per_block([4u8], ScaleDtype::F32);
         let values = vec![
             0.1, 0.2, 0.3, 0.4, // block 0
             10.0, 20.0, 30.0, 40.0, // block 1

--- a/crates/cubek-test-utils/src/test_tensor/quant.rs
+++ b/crates/cubek-test-utils/src/test_tensor/quant.rs
@@ -1,10 +1,6 @@
 use cubecl::{
-    TestRuntime,
-    client::ComputeClient,
-    ir::ElemType,
-    quant::scheme::{QuantLevel, QuantStore},
-    std::tensor::TensorHandle,
-    zspace::Shape,
+    TestRuntime, client::ComputeClient, ir::ElemType, quant::scheme::QuantStore,
+    std::tensor::TensorHandle, zspace::Shape,
 };
 use cubecl_common::quant::scheme::QuantScheme;
 
@@ -26,7 +22,7 @@ pub(crate) fn apply_quantization(
     let original_shape = tensor.handle.shape().clone();
 
     // Derive the scale tensor from the quant value's range. For
-    // `QuantLevel::Tensor` a single scale is used; for `QuantLevel::Block` we
+    // a per-tensor scheme a single scale is used; for a block scheme we
     // compute a per-block scale from the host data so each block fully uses
     // the quant range without clipping.
     let (scales_shape, scales_data, block_dims) = compute_input_scales(&tensor.host, &scheme);
@@ -64,7 +60,7 @@ pub(crate) fn apply_quantization(
         output_storage_type,
     );
 
-    let scale_dtype = ElemType::from_quant_param(scheme.param);
+    let scale_dtype = ElemType::from_quant_param(scheme.param());
     let out_scale_bytes = cast_f32_to_dtype(&scales_data, scale_dtype);
     let out_scale_handle = TensorHandle::new_contiguous(
         scales_shape,
@@ -104,9 +100,9 @@ fn logical_values_f32(host: &HostData) -> Vec<f32> {
 /// Compute the scale tensor shape, values, and per-dimension block extent for a
 /// quantized input.
 ///
-/// For `QuantLevel::Tensor` this returns a single-element scale based on the
+/// For a per-tensor scheme this returns a single-element scale based on the
 /// quant value's range (assumes input in [-1, 1]) and the full shape as the
-/// block. For `QuantLevel::Block` each block gets its own scale derived from
+/// block. For a block scheme each block gets its own scale derived from
 /// `max(|value|)` in that block, matching the reference pattern used by the
 /// cubek-quant symmetric tests.
 fn compute_input_scales(host: &HostData, scheme: &QuantScheme) -> (Shape, Vec<f32>, Vec<usize>) {
@@ -119,9 +115,10 @@ fn compute_input_scales(host: &HostData, scheme: &QuantScheme) -> (Shape, Vec<f3
         .into_iter()
         .collect();
 
-    let scales = match &scheme.level {
-        QuantLevel::Tensor => vec![1.0 / max_abs_q],
-        QuantLevel::Block(_) => {
+    let scales = if scheme.block_size().is_full() {
+        vec![1.0 / max_abs_q]
+    } else {
+        {
             let rank = shape.len();
             let num_blocks: usize = scales_shape.iter().product();
             let block_elem_count: usize = block_dims.iter().product();
@@ -159,10 +156,6 @@ fn compute_input_scales(host: &HostData, scheme: &QuantScheme) -> (Shape, Vec<f3
             }
             scales
         }
-        QuantLevel::BlockTensor { .. } => unimplemented!(
-            "two-level quantization is not supported here, got {:?}",
-            scheme.level
-        ),
     };
 
     (scales_shape, scales, block_dims)

--- a/crates/cubek-test-utils/src/test_tensor/quant.rs
+++ b/crates/cubek-test-utils/src/test_tensor/quant.rs
@@ -60,7 +60,7 @@ pub(crate) fn apply_quantization(
         output_storage_type,
     );
 
-    let scale_dtype = ElemType::from_quant_param(scheme.param());
+    let scale_dtype = ElemType::from_scale_dtype(scheme.scale_dtype());
     let out_scale_bytes = cast_f32_to_dtype(&scales_data, scale_dtype);
     let out_scale_handle = TensorHandle::new_contiguous(
         scales_shape,

--- a/crates/cubek-test-utils/src/test_tensor/quant.rs
+++ b/crates/cubek-test-utils/src/test_tensor/quant.rs
@@ -115,7 +115,7 @@ fn compute_input_scales(host: &HostData, scheme: &QuantScheme) -> (Shape, Vec<f3
         .into_iter()
         .collect();
 
-    let scales = if scheme.block_size().is_full() {
+    let scales = if scheme.block_size().is_none() {
         vec![1.0 / max_abs_q]
     } else {
         {

--- a/crates/cubek-test-utils/src/tile_input.rs
+++ b/crates/cubek-test-utils/src/tile_input.rs
@@ -7,7 +7,7 @@
 
 use cubecl::prelude::{Numeric, Size};
 use cubecl::{
-    TestRuntime, bytes::Bytes, client::ComputeClient, prelude::TensorArg,
+    TestRuntime, bytes::Bytes, client::ComputeClient, prelude::TensorArg, prelude::TensorBinding,
     quant::scheme::QuantScheme, zspace::Shape,
 };
 use cubecl::{
@@ -384,9 +384,9 @@ pub struct QuantizedTileInput {
 }
 
 impl QuantizedTileInput {
-    /// Launch arg for the scales tensor.
-    pub fn scales_arg(&self) -> TensorArg<TestRuntime> {
-        self.scales.clone().binding().into_tensor_arg()
+    /// Binding for the innermost level's scales tensor.
+    pub fn scales_binding(&self) -> TensorBinding<TestRuntime> {
+        self.scales.clone().binding()
     }
 
     /// The quantized tile as one launch argument: values, scales, spec, scheme, and how far the
@@ -394,7 +394,7 @@ impl QuantizedTileInput {
     pub fn arg<E: Numeric, V: Size>(&self) -> QuantTileArgLaunch<'static, E, V, TestRuntime> {
         QuantTileArgLaunch::new(
             self.tile.tensor_arg(1),
-            self.scales_arg(),
+            self.scales_binding().into_tensor_arg(),
             None.into(),
             self.tile.spec(),
             self.scheme,

--- a/crates/cubek-test-utils/src/tile_input.rs
+++ b/crates/cubek-test-utils/src/tile_input.rs
@@ -395,6 +395,7 @@ impl QuantizedTileInput {
         QuantTileArgLaunch::new(
             self.tile.tensor_arg(1),
             self.scales_arg(),
+            None.into(),
             self.tile.spec(),
             self.scheme,
             self.dequant_at,

--- a/crates/cubek-tile/src/ops/copy.rs
+++ b/crates/cubek-tile/src/ops/copy.rs
@@ -1,0 +1,51 @@
+//! The copy reading of a [`Tile`](crate::Tile): `dst.copy(&src)` walks the levels that hand
+//! regions to different cubes, and transports each region it lands on.
+
+use cubecl::prelude::*;
+
+use crate::*;
+
+#[cube]
+impl<T: Numeric> Tile<T> {
+    /// `dst.copy(&src)`: walk while a level spreads regions across cubes, else transport.
+    ///
+    /// The transport ([`copy_from`](Tile::copy_from)) fills a whole tile with every unit of the
+    /// cube, so a level that spreads *inside* a cube is already its own doing and ends the walk.
+    /// A quantized source decodes on the way through, as it does under any read.
+    pub fn copy(&mut self, src: &Tile<T>) {
+        if comptime!(spreads_across_cubes(&self.space)) {
+            let space = self.copy_space(src);
+            for region in Walk::over(space) {
+                let mut dst = self.at(&region);
+                dst.copy(&src.at(&region));
+            }
+        } else {
+            self.copy_from(src);
+        }
+    }
+
+    /// The walk's space: this tile's, with every [`Dynamic`](crate::Extent) axis sized by
+    /// whichever operand [`witnesses`](Tile::witnesses) it. The destination is asked first,
+    /// like [`mma`](Tile::mma) asks its accumulator: an axis it spans is one it writes, so its
+    /// bound is the extent the walk must cover.
+    fn copy_space(&self, src: &Tile<T>) -> Space {
+        witnessed_space(comptime!(self.space.clone()), self, src, src)
+    }
+}
+
+/// Whether this level hands its regions to different cubes: some axis rides a cube dim and none
+/// rides a plane or a unit, so the walk steps exactly what the launch grid separates.
+fn spreads_across_cubes(space: &Space) -> bool {
+    if space.is_final() {
+        return false;
+    }
+    let mut across = false;
+    for axis in space.axes() {
+        match space.partitioner().distribution(axis).scope() {
+            Some(ComputeScope::Cube(_)) => across = true,
+            Some(_) => return false,
+            None => {}
+        }
+    }
+    across
+}

--- a/crates/cubek-tile/src/ops/mod.rs
+++ b/crates/cubek-tile/src/ops/mod.rs
@@ -1,9 +1,10 @@
-//! The verbs a client runs over tiles: [`matmul`] (`mma`) and [`softmax`]. Each reads an
-//! already-structured [`Tile`](crate::Tile) and either walks its levels or runs at the leaf; the
-//! shared machinery they compose lives in [`crate::staging`]. Dequantization is not a verb: a
-//! quantized store dequantizes under the plain [`Tile::copy_from`](crate::Tile::copy_from).
+//! The verbs a client runs over tiles: [`matmul`] (`mma`), [`softmax`] and [`copy`]. Each reads
+//! an already-structured [`Tile`](crate::Tile) and either walks its levels or runs at the leaf;
+//! the shared machinery they compose lives in [`crate::staging`]. Dequantization is not a verb: a
+//! quantized store dequantizes under the plain [`Tile::copy`](crate::Tile::copy).
 
 mod attention;
+mod copy;
 mod matmul;
 mod softmax;
 

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -231,7 +231,8 @@ impl<E: Numeric> TmaTileArg<E> {
 /// ([`ScaleLayout`]), which is the true block only if no window straddles a block edge. Every
 /// window is a level's cut, and its origin is a multiple of that cut, so per axis each level's
 /// edge must tile whole blocks or fit inside one. A line is one read, so it may not straddle
-/// either. Per-tensor's block edges are `1` and divide everything.
+/// either. A per-tensor scale covers every window and line, so only the store and param rules
+/// apply to it.
 pub(crate) fn validate_scheme(space: &Space, vector_size: usize, scheme: QuantScheme) {
     // `Native` holds one element per value; `PackedU32` carries `num_quants` of them per `u32`,
     // which the view unpacks on read. A packed store must pack along the innermost (contiguous,
@@ -265,6 +266,11 @@ pub(crate) fn validate_scheme(space: &Space, vector_size: usize, scheme: QuantSc
         "StridedTileSource::quantized: scales are read as f32, got {:?}",
         scheme.scale_dtype()
     );
+
+    // A per-tensor scale has no edge to straddle, whatever the cuts and the served width.
+    if scheme.block_size().is_none() {
+        return;
+    }
 
     let rank = space.rank();
     let block = block_edges(scheme, rank);

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -157,9 +157,9 @@ impl<'a, E: Numeric, V: Size> TileArg<'a, E, V> {
 pub struct QuantTileArg<'a, E: Numeric, V: Size> {
     pub values: &'a Tensor<Vector<E, V>>,
     pub scales: &'a Tensor<f32>,
-    /// The outer level's whole-tensor scale in its first element, bound exactly when the scheme
+    /// The global level's whole-tensor scale in its first element, bound exactly when the scheme
     /// has a second level.
-    pub outer: ComptimeOption<LinearView<'static, f32>>,
+    pub global: ComptimeOption<LinearView<'static, f32>>,
     #[cube(comptime)]
     pub spec: TileSpec,
     #[cube(comptime)]
@@ -178,11 +178,11 @@ impl<'a, E: Numeric, V: Size> QuantTileArg<'a, E, V> {
         // contract too, but a hand-built `QuantTileArgLaunch` reaches here without it.
         comptime!(cubecl::std::quant::check_scale_bindings(
             &self.scheme,
-            1 + self.outer.is_some() as usize
+            1 + self.global.is_some() as usize
         ));
         // One read for the whole kernel; every window below shares the register.
-        let outer = if comptime!(self.outer.is_some()) {
-            let buffer = self.outer.unwrap();
+        let global = if comptime!(self.global.is_some()) {
+            let buffer = self.global.unwrap();
             ComptimeOption::new_Some(buffer.read(0))
         } else {
             ComptimeOption::new_None()
@@ -190,7 +190,7 @@ impl<'a, E: Numeric, V: Size> QuantTileArg<'a, E, V> {
         Tile::<O>::of_dequant(
             self.values,
             self.scales,
-            outer,
+            global,
             comptime!(self.scheme),
             comptime!(self.dequant_at),
             space,

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -157,9 +157,9 @@ impl<'a, E: Numeric, V: Size> TileArg<'a, E, V> {
 pub struct QuantTileArg<'a, E: Numeric, V: Size> {
     pub values: &'a Tensor<Vector<E, V>>,
     pub scales: &'a Tensor<f32>,
-    /// Per-tensor scale of a two-level scheme in its first element, bound exactly when the
-    /// scheme's level has one.
-    pub global: ComptimeOption<LinearView<'static, f32>>,
+    /// The outer level's whole-tensor scale in its first element, bound exactly when the scheme
+    /// has a second level.
+    pub outer: ComptimeOption<LinearView<'static, f32>>,
     #[cube(comptime)]
     pub spec: TileSpec,
     #[cube(comptime)]
@@ -178,11 +178,11 @@ impl<'a, E: Numeric, V: Size> QuantTileArg<'a, E, V> {
         // contract too, but a hand-built `QuantTileArgLaunch` reaches here without it.
         comptime!(cubecl::std::quant::check_scale_bindings(
             &self.scheme,
-            1 + self.global.is_some() as usize
+            1 + self.outer.is_some() as usize
         ));
         // One read for the whole kernel; every window below shares the register.
-        let global = if comptime!(self.global.is_some()) {
-            let buffer = self.global.unwrap();
+        let outer = if comptime!(self.outer.is_some()) {
+            let buffer = self.outer.unwrap();
             ComptimeOption::new_Some(buffer.read(0))
         } else {
             ComptimeOption::new_None()
@@ -190,7 +190,7 @@ impl<'a, E: Numeric, V: Size> QuantTileArg<'a, E, V> {
         Tile::<O>::of_dequant(
             self.values,
             self.scales,
-            global,
+            outer,
             comptime!(self.scheme),
             comptime!(self.dequant_at),
             space,

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -176,9 +176,9 @@ impl<'a, E: Numeric, V: Size> QuantTileArg<'a, E, V> {
     pub fn tile<O: Numeric>(&self, #[comptime] space: Space) -> Tile<O> {
         // The engine's own backstop, like `validate_dequant_at`: the builder checks the binding
         // contract too, but a hand-built `QuantTileArgLaunch` reaches here without it.
-        comptime!(cubecl::std::quant::check_global_bindings(
-            self.scheme.level,
-            self.global.is_some()
+        comptime!(cubecl::std::quant::check_scale_bindings(
+            &self.scheme,
+            1 + self.global.is_some() as usize
         ));
         // One read for the whole kernel; every window below shares the register.
         let global = if comptime!(self.global.is_some()) {
@@ -261,9 +261,9 @@ pub(crate) fn validate_scheme(space: &Space, vector_size: usize, scheme: QuantSc
     // The scales ride a plain `f32` tensor read straight through, so a narrower param
     // would reinterpret its bytes.
     assert!(
-        scheme.param == QuantParam::F32,
+        scheme.param() == QuantParam::F32,
         "StridedTileSource::quantized: scales are read as f32, got {:?}",
-        scheme.param
+        scheme.param()
     );
 
     let rank = space.rank();

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -6,7 +6,7 @@ use cubecl::prelude::*;
 use cubecl::quant::scheme::{QuantParam, QuantScheme, QuantStore};
 use cubecl::std::tensor::{
     ViewMut,
-    layout::{CoordsDyn, Layout, LayoutExpand},
+    layout::{CoordsDyn, Layout, LayoutExpand, linear::LinearView},
     view::launch::ViewArg,
 };
 
@@ -157,6 +157,9 @@ impl<'a, E: Numeric, V: Size> TileArg<'a, E, V> {
 pub struct QuantTileArg<'a, E: Numeric, V: Size> {
     pub values: &'a Tensor<Vector<E, V>>,
     pub scales: &'a Tensor<f32>,
+    /// Per-tensor scale of a two-level scheme in its first element, bound exactly when the
+    /// scheme's level has one.
+    pub global: ComptimeOption<LinearView<'static, f32>>,
     #[cube(comptime)]
     pub spec: TileSpec,
     #[cube(comptime)]
@@ -171,9 +174,23 @@ impl<'a, E: Numeric, V: Size> QuantTileArg<'a, E, V> {
     /// Serve the operand as a [`Tile`] of the served type `O`: the kernel's one `space`
     /// projected onto this operand's `spec` axes, reads dequantizing per the scheme.
     pub fn tile<O: Numeric>(&self, #[comptime] space: Space) -> Tile<O> {
+        // The engine's own backstop, like `validate_dequant_at`: the builder checks the binding
+        // contract too, but a hand-built `QuantTileArgLaunch` reaches here without it.
+        comptime!(cubecl::std::quant::check_global_bindings(
+            self.scheme.level,
+            self.global.is_some()
+        ));
+        // One read for the whole kernel; every window below shares the register.
+        let global = if comptime!(self.global.is_some()) {
+            let buffer = self.global.unwrap();
+            ComptimeOption::new_Some(buffer.read(0))
+        } else {
+            ComptimeOption::new_None()
+        };
         Tile::<O>::of_dequant(
             self.values,
             self.scales,
+            global,
             comptime!(self.scheme),
             comptime!(self.dequant_at),
             space,

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -3,7 +3,7 @@
 //! (a tensor map cannot ride a plain tensor binding, so it keeps its own carrier).
 
 use cubecl::prelude::*;
-use cubecl::quant::scheme::{QuantParam, QuantScheme, QuantStore};
+use cubecl::quant::scheme::{QuantScheme, QuantStore, ScaleDtype};
 use cubecl::std::tensor::{
     ViewMut,
     layout::{CoordsDyn, Layout, LayoutExpand, linear::LinearView},
@@ -261,9 +261,9 @@ pub(crate) fn validate_scheme(space: &Space, vector_size: usize, scheme: QuantSc
     // The scales ride a plain `f32` tensor read straight through, so a narrower param
     // would reinterpret its bytes.
     assert!(
-        scheme.param() == QuantParam::F32,
+        scheme.scale_dtype() == ScaleDtype::F32,
         "StridedTileSource::quantized: scales are read as f32, got {:?}",
-        scheme.param()
+        scheme.scale_dtype()
     );
 
     let rank = space.rank();

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -246,14 +246,15 @@ pub struct Quantization<R: Runtime> {
 impl<R: Runtime> Quantization<R> {
     /// `scales` holds one binding per scheme level, innermost first. Only the innermost level's
     /// scales are addressed per position; an outer level covers the whole tensor, so its binding
-    /// is read once from its first element.
+    /// is read once from its first element. This only checks the slice holds 1 or 2 bindings;
+    /// whether that count actually matches `scheme`'s own level count is [`validate`](Self::validate)'s
+    /// job, via `check_scale_bindings`.
     pub fn new(scales: &[TensorBinding<R>], scheme: QuantScheme, dequant_at: DequantAt) -> Self {
         let (inner, outer) = match scales {
             [inner] => (inner, None),
             [inner, outer] => (inner, Some(outer.clone())),
             _ => panic!(
-                "StridedTileSource::quantized: {} scale bindings, expected one per level \
-                 (innermost first)",
+                "StridedTileSource::quantized: {} scale bindings, expected 1 or 2 (innermost first)",
                 scales.len()
             ),
         };

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -293,7 +293,7 @@ impl<R: Runtime> Quantization<R> {
     /// operand's cuts and served width, the [`DequantAt`] against the reader that would have to honour
     /// it. Both rules live here because both are facts about this quantization and nothing else.
     pub(crate) fn validate(&self, space: &Space, vector_size: usize, leaf: Leaf) {
-        cubecl::std::quant::check_global_bindings(self.scheme.level, self.global.is_some());
+        cubecl::std::quant::check_scale_bindings(&self.scheme, 1 + self.global.is_some() as usize);
         validate_scheme(space, vector_size, self.scheme);
         validate_dequant_at(self.dequant_at, leaf);
     }

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -7,6 +7,7 @@ use core::marker::PhantomData;
 use cubecl::prelude::*;
 
 use cubecl::quant::scheme::QuantScheme;
+use cubecl::std::tensor::layout::linear::linear_view;
 
 use crate::{
     Axis, Boundary, ConcreteLayout, DequantAt, Leaf, LoadMethod, PhysicalAxis, Projection,
@@ -225,6 +226,24 @@ impl<'a, Sp, Sub, R: Runtime> StridedTileSource<'a, Sp, Sub, Unset, R> {
             _state: PhantomData,
         }
     }
+
+    /// [`quantized`](Self::quantized) for a two-level scheme: `global` holds the per-tensor scale
+    /// the block scales are normalized against, read as f32 from its first element.
+    pub fn quantized_two_level(
+        mut self,
+        scales: TensorArg<R>,
+        global: TensorBinding<R>,
+        scheme: QuantScheme,
+        dequant_at: DequantAt,
+    ) -> StridedTileSource<'a, Sp, Sub, Set, R> {
+        self.data.quant = Some(Quantization::new_two_level(
+            scales, global, scheme, dequant_at,
+        ));
+        StridedTileSource {
+            data: self.data,
+            _state: PhantomData,
+        }
+    }
 }
 
 /// How an operand is quantized: the scales beside its values, the scheme saying how to fold them
@@ -233,6 +252,9 @@ impl<'a, Sp, Sub, R: Runtime> StridedTileSource<'a, Sp, Sub, Unset, R> {
 /// [`DequantAt`] without a scheme has nothing to bound.
 pub struct Quantization<R: Runtime> {
     pub scales: TensorArg<R>,
+    /// Per-tensor scale of a two-level scheme, present exactly when the level has one
+    /// ([`validate`](Self::validate) holds the two together).
+    pub global: Option<TensorBinding<R>>,
     pub scheme: QuantScheme,
     pub dequant_at: DequantAt,
 }
@@ -241,6 +263,22 @@ impl<R: Runtime> Quantization<R> {
     pub fn new(scales: TensorArg<R>, scheme: QuantScheme, dequant_at: DequantAt) -> Self {
         Quantization {
             scales,
+            global: None,
+            scheme,
+            dequant_at,
+        }
+    }
+
+    /// [`new`](Self::new) for a two-level scheme, with the per-tensor scale's tensor.
+    pub fn new_two_level(
+        scales: TensorArg<R>,
+        global: TensorBinding<R>,
+        scheme: QuantScheme,
+        dequant_at: DequantAt,
+    ) -> Self {
+        Quantization {
+            scales,
+            global: Some(global),
             scheme,
             dequant_at,
         }
@@ -255,6 +293,7 @@ impl<R: Runtime> Quantization<R> {
     /// operand's cuts and served width, the [`DequantAt`] against the reader that would have to honour
     /// it. Both rules live here because both are facts about this quantization and nothing else.
     pub(crate) fn validate(&self, space: &Space, vector_size: usize, leaf: Leaf) {
+        cubecl::std::quant::check_global_bindings(self.scheme.level, self.global.is_some());
         validate_scheme(space, vector_size, self.scheme);
         validate_dequant_at(self.dequant_at, leaf);
     }
@@ -300,6 +339,7 @@ impl<R: Runtime> QuantOperand<R> {
         QuantTileArgLaunch::new(
             self.tensor,
             self.quant.scales,
+            self.quant.global.map(linear_view).into(),
             self.spec,
             self.quant.scheme,
             self.quant.dequant_at,

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -209,6 +209,7 @@ impl<'a, Sp, Sub, R: Runtime> StridedTileSource<'a, Sp, Sub, Unset, R> {
     /// Mark the operand as quantized: its binding holds the scheme's storage element (declared
     /// **in values**; a packed store's buffer is narrower than its shape by the packing
     /// factor), and `scales` + `scheme` let reads dequantize into the kernel's served type.
+    /// `scales` holds one binding per scheme level, innermost first.
     /// [`vectorize`](Self::vectorize) still names the *served* width. `dequant_at` says how far the
     /// quantized form travels; it rides here rather than in its own setter because the quantized
     /// form ends at exactly one boundary, so one call says it once by construction. Which values
@@ -216,29 +217,11 @@ impl<'a, Sp, Sub, R: Runtime> StridedTileSource<'a, Sp, Sub, Unset, R> {
     /// refuses one nothing can honour. Flips the typestate: `build` now yields a [`QuantOperand`].
     pub fn quantized(
         mut self,
-        scales: TensorArg<R>,
+        scales: &[TensorBinding<R>],
         scheme: QuantScheme,
         dequant_at: DequantAt,
     ) -> StridedTileSource<'a, Sp, Sub, Set, R> {
         self.data.quant = Some(Quantization::new(scales, scheme, dequant_at));
-        StridedTileSource {
-            data: self.data,
-            _state: PhantomData,
-        }
-    }
-
-    /// [`quantized`](Self::quantized) for a two-level scheme: `global` holds the per-tensor scale
-    /// the block scales are normalized against, read as f32 from its first element.
-    pub fn quantized_two_level(
-        mut self,
-        scales: TensorArg<R>,
-        global: TensorBinding<R>,
-        scheme: QuantScheme,
-        dequant_at: DequantAt,
-    ) -> StridedTileSource<'a, Sp, Sub, Set, R> {
-        self.data.quant = Some(Quantization::new_two_level(
-            scales, global, scheme, dequant_at,
-        ));
         StridedTileSource {
             data: self.data,
             _state: PhantomData,
@@ -251,34 +234,32 @@ impl<'a, Sp, Sub, R: Runtime> StridedTileSource<'a, Sp, Sub, Unset, R> {
 /// none of the three says anything on its own — a scheme without scales cannot be applied, and an
 /// [`DequantAt`] without a scheme has nothing to bound.
 pub struct Quantization<R: Runtime> {
+    /// The innermost level's scales, the only ones addressed per position.
     pub scales: TensorArg<R>,
-    /// Per-tensor scale of a two-level scheme, present exactly when the level has one
-    /// ([`validate`](Self::validate) holds the two together).
-    pub global: Option<TensorBinding<R>>,
+    /// The outer level's scale, one for the whole tensor, present exactly when the scheme has a
+    /// second level ([`validate`](Self::validate) holds the two together).
+    pub outer: Option<TensorBinding<R>>,
     pub scheme: QuantScheme,
     pub dequant_at: DequantAt,
 }
 
 impl<R: Runtime> Quantization<R> {
-    pub fn new(scales: TensorArg<R>, scheme: QuantScheme, dequant_at: DequantAt) -> Self {
+    /// `scales` holds one binding per scheme level, innermost first. Only the innermost level's
+    /// scales are addressed per position; an outer level covers the whole tensor, so its binding
+    /// is read once from its first element.
+    pub fn new(scales: &[TensorBinding<R>], scheme: QuantScheme, dequant_at: DequantAt) -> Self {
+        let (inner, outer) = match scales {
+            [inner] => (inner, None),
+            [inner, outer] => (inner, Some(outer.clone())),
+            _ => panic!(
+                "StridedTileSource::quantized: {} scale bindings, expected one per level \
+                 (innermost first)",
+                scales.len()
+            ),
+        };
         Quantization {
-            scales,
-            global: None,
-            scheme,
-            dequant_at,
-        }
-    }
-
-    /// [`new`](Self::new) for a two-level scheme, with the per-tensor scale's tensor.
-    pub fn new_two_level(
-        scales: TensorArg<R>,
-        global: TensorBinding<R>,
-        scheme: QuantScheme,
-        dequant_at: DequantAt,
-    ) -> Self {
-        Quantization {
-            scales,
-            global: Some(global),
+            scales: inner.clone().into_tensor_arg(),
+            outer,
             scheme,
             dequant_at,
         }
@@ -293,7 +274,7 @@ impl<R: Runtime> Quantization<R> {
     /// operand's cuts and served width, the [`DequantAt`] against the reader that would have to honour
     /// it. Both rules live here because both are facts about this quantization and nothing else.
     pub(crate) fn validate(&self, space: &Space, vector_size: usize, leaf: Leaf) {
-        cubecl::std::quant::check_scale_bindings(&self.scheme, 1 + self.global.is_some() as usize);
+        cubecl::std::quant::check_scale_bindings(&self.scheme, 1 + self.outer.is_some() as usize);
         validate_scheme(space, vector_size, self.scheme);
         validate_dequant_at(self.dequant_at, leaf);
     }
@@ -339,7 +320,7 @@ impl<R: Runtime> QuantOperand<R> {
         QuantTileArgLaunch::new(
             self.tensor,
             self.quant.scales,
-            self.quant.global.map(linear_view).into(),
+            self.quant.outer.map(linear_view).into(),
             self.spec,
             self.quant.scheme,
             self.quant.dequant_at,

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -93,7 +93,7 @@ impl<'a, Sp, Sub, Q, R: Runtime> StridedTileSource<'a, Sp, Sub, Q, R> {
 
     /// The inner block of axes the operand iterates, its `[row, col]` for a matmul (required
     /// unless [`gathered`](Self::gathered) states the mapping instead, non-empty). Complementary
-    /// to [`batches`](Self::batches), the outer dims.
+    /// to [`batches`](Self::batches), the global dims.
     pub fn subspace(mut self, axes: &'a [Axis]) -> StridedTileSource<'a, Sp, Set, Q, R> {
         self.data.subspace = axes;
         StridedTileSource {
@@ -132,7 +132,7 @@ impl<'a, Sp, Sub, Q, R: Runtime> StridedTileSource<'a, Sp, Sub, Q, R> {
         }
     }
 
-    /// The outer (batch) axes in the output's order, right-aligned to this operand's leading
+    /// The global (batch) axes in the output's order, right-aligned to this operand's leading
     /// dims (numpy broadcast): pass the full list, extra leading axes are the ones this operand
     /// omits, and a size-1 dim drops out. Default none (unbatched).
     pub fn batches(mut self, axes: &'a [Axis]) -> Self {
@@ -236,23 +236,23 @@ impl<'a, Sp, Sub, R: Runtime> StridedTileSource<'a, Sp, Sub, Unset, R> {
 pub struct Quantization<R: Runtime> {
     /// The innermost level's scales, the only ones addressed per position.
     pub scales: TensorArg<R>,
-    /// The outer level's scale, one for the whole tensor, present exactly when the scheme has a
+    /// The global level's scale, one for the whole tensor, present exactly when the scheme has a
     /// second level ([`validate`](Self::validate) holds the two together).
-    pub outer: Option<TensorBinding<R>>,
+    pub global: Option<TensorBinding<R>>,
     pub scheme: QuantScheme,
     pub dequant_at: DequantAt,
 }
 
 impl<R: Runtime> Quantization<R> {
     /// `scales` holds one binding per scheme level, innermost first. Only the innermost level's
-    /// scales are addressed per position; an outer level covers the whole tensor, so its binding
+    /// scales are addressed per position; an global level covers the whole tensor, so its binding
     /// is read once from its first element. This only checks the slice holds 1 or 2 bindings;
     /// whether that count actually matches `scheme`'s own level count is [`validate`](Self::validate)'s
     /// job, via `check_scale_bindings`.
     pub fn new(scales: &[TensorBinding<R>], scheme: QuantScheme, dequant_at: DequantAt) -> Self {
-        let (inner, outer) = match scales {
+        let (inner, global) = match scales {
             [inner] => (inner, None),
-            [inner, outer] => (inner, Some(outer.clone())),
+            [inner, global] => (inner, Some(global.clone())),
             _ => panic!(
                 "StridedTileSource::quantized: {} scale bindings, expected 1 or 2 (innermost first)",
                 scales.len()
@@ -260,7 +260,7 @@ impl<R: Runtime> Quantization<R> {
         };
         Quantization {
             scales: inner.clone().into_tensor_arg(),
-            outer,
+            global,
             scheme,
             dequant_at,
         }
@@ -275,7 +275,7 @@ impl<R: Runtime> Quantization<R> {
     /// operand's cuts and served width, the [`DequantAt`] against the reader that would have to honour
     /// it. Both rules live here because both are facts about this quantization and nothing else.
     pub(crate) fn validate(&self, space: &Space, vector_size: usize, leaf: Leaf) {
-        cubecl::std::quant::check_scale_bindings(&self.scheme, 1 + self.outer.is_some() as usize);
+        cubecl::std::quant::check_scale_bindings(&self.scheme, 1 + self.global.is_some() as usize);
         validate_scheme(space, vector_size, self.scheme);
         validate_dequant_at(self.dequant_at, leaf);
     }
@@ -321,7 +321,7 @@ impl<R: Runtime> QuantOperand<R> {
         QuantTileArgLaunch::new(
             self.tensor,
             self.quant.scales,
-            self.quant.outer.map(linear_view).into(),
+            self.quant.global.map(linear_view).into(),
             self.spec,
             self.quant.scheme,
             self.quant.dequant_at,

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -205,6 +205,7 @@ impl<T: Numeric> Tile<T> {
             strides,
             window_start: 0u32,
             block: comptime!(block),
+            extent: comptime!(window_extents(&space.project(spec.axes()), rank)),
             dequant_at: comptime!(dequant_at),
             // A gmem operand reads the tensor's scales in place; only a staged stage grids them.
             scale_shape: comptime!(Vec::new()),
@@ -1245,6 +1246,7 @@ impl<T: Numeric> MemData<T> {
                             info.window_start,
                             comptime!(info.block.clone()),
                             comptime!(self.store.vector_size),
+                            comptime!(info.extent.clone()),
                         ))
                         .view(FlatLayout::new(self.window.extent.clone())),
                     info.global,
@@ -1294,6 +1296,7 @@ impl<T: Numeric> MemData<T> {
                             info.window_start,
                             comptime!(info.block.clone()),
                             comptime!(self.store.vector_size),
+                            comptime!(info.extent.clone()),
                         ))
                         .view(layout),
                     info.global,
@@ -1478,10 +1481,17 @@ impl<T: Numeric> MemData<T> {
                     "MemData::at: a quantized operand cannot carry a negative window origin, its \
                      scale grid is addressed unsigned"
                 ));
+                // A quantized operand is direct (asserted at construction), so the child window's
+                // extent per axis is this level's cut edge.
                 ComptimeOption::new_Some(info.window(
                     &origin_u32,
                     rank,
                     comptime!(self.store.vector_size),
+                    comptime!(
+                        (0..rank)
+                            .map(|p| space.partitioner().edge(space.axis_at(p)))
+                            .collect::<Vec<_>>()
+                    ),
                 ))
             }
             ComptimeOption::None => ComptimeOption::new_None(),
@@ -1779,6 +1789,7 @@ fn smem_quant_info(
         strides,
         window_start: 0u32,
         block: comptime!(block),
+        extent: comptime!(window_extents(&space, rank)),
         // A stage only keeps its quantized form when the read is what decodes it; that is the one
         // path reaching here.
         dequant_at: comptime!(DequantAt::Read),

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -3,7 +3,7 @@
 
 use cubecl::{
     prelude::*,
-    quant::scheme::{QuantLevel, QuantScheme, QuantStore, QuantValue},
+    quant::scheme::{QuantScheme, QuantStore, QuantValue},
     std::quant::view::QuantizedView as DequantView,
     std::tensor::{
         AsView, AsViewExpand, AsViewMut, AsViewMutExpand, View, ViewMut,
@@ -193,7 +193,7 @@ impl<T: Numeric> Tile<T> {
         let mut strides = Coords::<u32>::new();
         #[unroll]
         for p in 0..rank {
-            if comptime!(scheme.level == QuantLevel::Tensor) {
+            if comptime!(scheme.block_size().is_full()) {
                 strides.push(0u32);
             } else {
                 strides.push(scales.stride(p) as u32);
@@ -1253,17 +1253,23 @@ impl<T: Numeric> MemData<T> {
                 let dequant = if comptime!(info.uniform()) {
                     // One scale for the whole window: read once here, so no read below pays
                     // for the scales view at all.
-                    DequantView::<I, WP, f32, T, W, Coords1d>::new_uniform(
+                    DequantView::<I, WP, f32, T, W, Coords1d>::new_with_whole_scale(
                         values,
                         scales,
                         info.uniform_scale(),
+                        comptime!(info.scheme),
+                    )
+                } else if comptime!(info.global.is_some()) {
+                    DequantView::<I, WP, f32, T, W, Coords1d>::new_with_outer_scale(
+                        values,
+                        scales,
+                        info.global.unwrap(),
                         comptime!(info.scheme),
                     )
                 } else {
                     DequantView::<I, WP, f32, T, W, Coords1d>::new(
                         values,
                         scales,
-                        info.global,
                         comptime!(info.scheme),
                     )
                 };
@@ -1317,19 +1323,21 @@ impl<T: Numeric> MemData<T> {
                 let dequant = if comptime!(info.uniform()) {
                     // One scale for the whole window: read once here, so no read below pays
                     // for the scales view at all.
-                    DequantView::<I, WP, f32, T, W, C>::new_uniform(
+                    DequantView::<I, WP, f32, T, W, C>::new_with_whole_scale(
                         values,
                         scales,
                         info.uniform_scale(),
                         comptime!(info.scheme),
                     )
-                } else {
-                    DequantView::<I, WP, f32, T, W, C>::new(
+                } else if comptime!(info.global.is_some()) {
+                    DequantView::<I, WP, f32, T, W, C>::new_with_outer_scale(
                         values,
                         scales,
-                        info.global,
+                        info.global.unwrap(),
                         comptime!(info.scheme),
                     )
+                } else {
+                    DequantView::<I, WP, f32, T, W, C>::new(values, scales, comptime!(info.scheme))
                 };
                 MaskedView::new(dequant.view(), comptime!(self.access.overhang.masks()))
             }
@@ -1835,7 +1843,7 @@ fn smem_scale_grid(
     scheme: QuantScheme,
 ) -> (Vec<usize>, Vec<usize>) {
     let rank = space.rank();
-    let per_tensor = matches!(scheme.level, QuantLevel::Tensor);
+    let per_tensor = scheme.block_size().is_full();
     let nb: Vec<usize> = (0..rank)
         .map(|p| {
             if per_tensor {

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -178,7 +178,7 @@ impl<T: Numeric> Tile<T> {
     pub fn of_dequant<E: CubePrimitive>(
         values: &Tensor<E>,
         scales: &Tensor<f32>,
-        outer: ComptimeOption<f32>,
+        global: ComptimeOption<f32>,
         #[comptime] scheme: QuantScheme,
         #[comptime] dequant_at: DequantAt,
         #[comptime] space: Space,
@@ -200,7 +200,7 @@ impl<T: Numeric> Tile<T> {
         }
         let info = QuantInfo {
             buffer: unsafe { scales.as_slice().as_boxed_unchecked() },
-            outer,
+            global,
             strides,
             window_start: 0u32,
             block: comptime!(block),
@@ -906,11 +906,11 @@ impl<T: Numeric> MemData<T> {
                     .frem(comptime!(nb[p] as u32));
                 src_idx = src_idx.fadd(bi.fmul(sinfo.strides.at(p)));
             }
-            // The grid holds *effective* scales: a two-level source's outer level folds in here,
+            // The grid holds *effective* scales: a two-level source's global level folds in here,
             // once per block per stage, so everything below the stage serves a one-level scheme
-            // and no outer scale threads past this point.
-            if comptime!(sinfo.outer.is_some()) {
-                dst_scales[bl] = src_scales[src_idx.fcast::<usize>()] * sinfo.outer.unwrap();
+            // and no global scale threads past this point.
+            if comptime!(sinfo.global.is_some()) {
+                dst_scales[bl] = src_scales[src_idx.fcast::<usize>()] * sinfo.global.unwrap();
             } else {
                 dst_scales[bl] = src_scales[src_idx.fcast::<usize>()];
             }
@@ -1777,10 +1777,10 @@ fn smem_quant_info(
     }
     ComptimeOption::new_Some(QuantInfo {
         buffer,
-        // The fill folds a two-level source's outer level into the staged grid
+        // The fill folds a two-level source's global level into the staged grid
         // ([`MemData::stage_scales`]), so the stage serves effective scales under the one-level
         // form of the scheme; keeping the two-level level here would fail cubecl's binding check.
-        outer: ComptimeOption::new_None(),
+        global: ComptimeOption::new_None(),
         strides,
         window_start: 0u32,
         block: comptime!(block),
@@ -1943,7 +1943,7 @@ fn storage_layout(#[comptime] form: StageForm) -> (Coords<u32>, Coords<u32>) {
 
 /// The storage-tiling nesting a stage over `space` gets: the blocks its buffer lays down
 /// contiguously, coarse to fine, each dividing the one before it (`space` is the implicit
-/// outermost). Empty is a plain row-major buffer.
+/// globalmost). Empty is a plain row-major buffer.
 ///
 /// A `Tiled` stage groups the final tile, the block a cmma transaction reads unstrided. A final
 /// space has no grid left to tile, so it stays plain whatever the layout asks for.
@@ -1960,10 +1960,10 @@ fn stage_nesting(space: &Space, stage: StageStorage) -> Vec<Space> {
 fn storage_extents(space: &Space, vector_size: usize, nesting: &[Space]) -> Vec<usize> {
     let rank = space.rank();
     let mut extents = Vec::new();
-    let mut outer = space;
+    let mut global = space;
     for block in nesting {
         for p in 0..rank {
-            let (e, b) = (outer.extent_at(p), block.extent_at(p));
+            let (e, b) = (global.extent_at(p), block.extent_at(p));
             assert!(
                 e.is_multiple_of(b),
                 "MemData::smem: a {b}-element storage block must divide the {e}-element block \
@@ -1971,10 +1971,10 @@ fn storage_extents(space: &Space, vector_size: usize, nesting: &[Space]) -> Vec<
             );
             extents.push(e / b);
         }
-        outer = block;
+        global = block;
     }
     for p in 0..rank {
-        extents.push(outer.extent_at(p));
+        extents.push(global.extent_at(p));
     }
     let last = extents.len() - 1;
     extents[last] /= vector_size;
@@ -2041,7 +2041,7 @@ impl Layout for GmemLayout {
                 let term = comptime!(map.terms()[t]);
                 let p = comptime!(self.projection.position(term.axis));
                 let (finer, modulo) = comptime!(self.projection.digit(pa, term.axis));
-                // Strip the finer digits, then take this one. The outermost fragment of an axis
+                // Strip the finer digits, then take this one. The globalmost fragment of an axis
                 // (and any untiled axis) has no radix and keeps the full quotient.
                 let quot = pos[p].fdiv(self.physical_shape.fproduct(comptime!(finer.to_vec())));
                 let digit = match comptime!(modulo) {

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -179,7 +179,7 @@ impl<T: Numeric> Tile<T> {
     pub fn of_dequant<E: CubePrimitive>(
         values: &Tensor<E>,
         scales: &Tensor<f32>,
-        global: ComptimeOption<f32>,
+        outer: ComptimeOption<f32>,
         #[comptime] scheme: QuantScheme,
         #[comptime] dequant_at: DequantAt,
         #[comptime] space: Space,
@@ -201,7 +201,7 @@ impl<T: Numeric> Tile<T> {
         }
         let info = QuantInfo {
             buffer: unsafe { scales.as_slice().as_boxed_unchecked() },
-            global,
+            outer,
             strides,
             window_start: 0u32,
             block: comptime!(block),
@@ -907,11 +907,11 @@ impl<T: Numeric> MemData<T> {
                     .frem(comptime!(nb[p] as u32));
                 src_idx = src_idx.fadd(bi.fmul(sinfo.strides.at(p)));
             }
-            // The grid holds *effective* scales: a two-level source's per-tensor factor folds in
-            // here, once per block per stage, so everything below the stage serves a one-level
-            // scheme and no global threads past this point.
-            if comptime!(sinfo.global.is_some()) {
-                dst_scales[bl] = src_scales[src_idx.fcast::<usize>()] * sinfo.global.unwrap();
+            // The grid holds *effective* scales: a two-level source's outer level folds in here,
+            // once per block per stage, so everything below the stage serves a one-level scheme
+            // and no outer scale threads past this point.
+            if comptime!(sinfo.outer.is_some()) {
+                dst_scales[bl] = src_scales[src_idx.fcast::<usize>()] * sinfo.outer.unwrap();
             } else {
                 dst_scales[bl] = src_scales[src_idx.fcast::<usize>()];
             }
@@ -1259,11 +1259,11 @@ impl<T: Numeric> MemData<T> {
                         info.uniform_scale(),
                         comptime!(info.scheme),
                     )
-                } else if comptime!(info.global.is_some()) {
+                } else if comptime!(info.outer.is_some()) {
                     DequantView::<I, WP, f32, T, W, Coords1d>::new_with_outer_scale(
                         values,
                         scales,
-                        info.global.unwrap(),
+                        info.outer.unwrap(),
                         comptime!(info.scheme),
                     )
                 } else {
@@ -1329,11 +1329,11 @@ impl<T: Numeric> MemData<T> {
                         info.uniform_scale(),
                         comptime!(info.scheme),
                     )
-                } else if comptime!(info.global.is_some()) {
+                } else if comptime!(info.outer.is_some()) {
                     DequantView::<I, WP, f32, T, W, C>::new_with_outer_scale(
                         values,
                         scales,
-                        info.global.unwrap(),
+                        info.outer.unwrap(),
                         comptime!(info.scheme),
                     )
                 } else {
@@ -1818,10 +1818,10 @@ fn smem_quant_info(
     }
     ComptimeOption::new_Some(QuantInfo {
         buffer,
-        // The fill folds a two-level source's global into the staged grid
+        // The fill folds a two-level source's outer level into the staged grid
         // ([`MemData::stage_scales`]), so the stage serves effective scales under the one-level
         // form of the scheme; keeping the two-level level here would fail cubecl's binding check.
-        global: ComptimeOption::new_None(),
+        outer: ComptimeOption::new_None(),
         strides,
         window_start: 0u32,
         block: comptime!(block),

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -4,7 +4,6 @@
 use cubecl::{
     prelude::*,
     quant::scheme::{QuantScheme, QuantStore, QuantValue},
-    std::quant::view::QuantizedView as DequantView,
     std::tensor::{
         AsView, AsViewExpand, AsViewMut, AsViewMutExpand, View, ViewMut,
         layout::{Coordinates, Coords1d, Coords2d, CoordsDyn, Layout, LayoutExpand},
@@ -1250,29 +1249,7 @@ impl<T: Numeric> MemData<T> {
                         comptime!(info.extent.clone()),
                     ))
                     .view(FlatLayout::new(self.window.extent.clone()));
-                let dequant = if comptime!(info.uniform()) {
-                    // One scale for the whole window: read once here, so no read below pays
-                    // for the scales view at all.
-                    DequantView::<I, WP, f32, T, W, Coords1d>::new_with_whole_scale(
-                        values,
-                        scales,
-                        info.uniform_scale(),
-                        comptime!(info.scheme),
-                    )
-                } else if comptime!(info.outer.is_some()) {
-                    DequantView::<I, WP, f32, T, W, Coords1d>::new_with_outer_scale(
-                        values,
-                        scales,
-                        info.outer.unwrap(),
-                        comptime!(info.scheme),
-                    )
-                } else {
-                    DequantView::<I, WP, f32, T, W, Coords1d>::new(
-                        values,
-                        scales,
-                        comptime!(info.scheme),
-                    )
-                };
+                let dequant = info.dequant_view::<I, WP, T, W, Coords1d>(values, scales);
                 FlatView::new(dequant.view(), comptime!(self.access.overhang.masks()))
             }
             ComptimeOption::None => self.flat::<W>(),
@@ -1320,25 +1297,7 @@ impl<T: Numeric> MemData<T> {
                         comptime!(info.extent.clone()),
                     ))
                     .view(layout);
-                let dequant = if comptime!(info.uniform()) {
-                    // One scale for the whole window: read once here, so no read below pays
-                    // for the scales view at all.
-                    DequantView::<I, WP, f32, T, W, C>::new_with_whole_scale(
-                        values,
-                        scales,
-                        info.uniform_scale(),
-                        comptime!(info.scheme),
-                    )
-                } else if comptime!(info.outer.is_some()) {
-                    DequantView::<I, WP, f32, T, W, C>::new_with_outer_scale(
-                        values,
-                        scales,
-                        info.outer.unwrap(),
-                        comptime!(info.scheme),
-                    )
-                } else {
-                    DequantView::<I, WP, f32, T, W, C>::new(values, scales, comptime!(info.scheme))
-                };
+                let dequant = info.dequant_view::<I, WP, T, W, C>(values, scales);
                 MaskedView::new(dequant.view(), comptime!(self.access.overhang.masks()))
             }
             ComptimeOption::None => self.masked::<W, C, L>(layout),

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -1232,29 +1232,43 @@ impl<T: Numeric> MemData<T> {
     ) -> FlatView<'_, Vector<T, W>> {
         #[comptime]
         match &self.store.quant {
-            ComptimeOption::Some(info) => FlatView::new(
-                DequantView::<I, WP, f32, T, W, Coords1d>::new(
-                    // The storage view groups at the *physical* width: a packed buffer holds
-                    // `W / num_quants` elements per served line.
-                    self.lines_storage::<I, WP>()
-                        .view(self.base())
-                        .view(self.window())
-                        .view(FlatLayout::new(self.window.extent.clone())),
-                    info.buffer
-                        .view(ScaleLayout::new(
-                            info.strides.clone(),
-                            info.window_start,
-                            comptime!(info.block.clone()),
-                            comptime!(self.store.vector_size),
-                            comptime!(info.extent.clone()),
-                        ))
-                        .view(FlatLayout::new(self.window.extent.clone())),
-                    info.global,
-                    comptime!(info.scheme),
-                )
-                .view(),
-                comptime!(self.access.overhang.masks()),
-            ),
+            ComptimeOption::Some(info) => {
+                // The storage view groups at the *physical* width: a packed buffer holds
+                // `W / num_quants` elements per served line.
+                let values = self
+                    .lines_storage::<I, WP>()
+                    .view(self.base())
+                    .view(self.window())
+                    .view(FlatLayout::new(self.window.extent.clone()));
+                let scales = info
+                    .buffer
+                    .view(ScaleLayout::new(
+                        info.strides.clone(),
+                        info.window_start,
+                        comptime!(info.block.clone()),
+                        comptime!(self.store.vector_size),
+                        comptime!(info.extent.clone()),
+                    ))
+                    .view(FlatLayout::new(self.window.extent.clone()));
+                let dequant = if comptime!(info.uniform()) {
+                    // One scale for the whole window: read once here, so no read below pays
+                    // for the scales view at all.
+                    DequantView::<I, WP, f32, T, W, Coords1d>::new_uniform(
+                        values,
+                        scales,
+                        info.uniform_scale(),
+                        comptime!(info.scheme),
+                    )
+                } else {
+                    DequantView::<I, WP, f32, T, W, Coords1d>::new(
+                        values,
+                        scales,
+                        info.global,
+                        comptime!(info.scheme),
+                    )
+                };
+                FlatView::new(dequant.view(), comptime!(self.access.overhang.masks()))
+            }
             ComptimeOption::None => self.flat::<W>(),
         }
     }
@@ -1279,32 +1293,46 @@ impl<T: Numeric> MemData<T> {
         match &self.store.quant {
             // A quantized view *is* a view: cubecl's decodes on read and answers as `Vector<T, W>`,
             // so both arms hand back the same masked view and no caller learns the difference.
-            ComptimeOption::Some(info) => MaskedView::new(
-                DequantView::<I, WP, f32, T, W, C>::new(
-                    // The storage view groups at the *physical* width: a packed buffer holds
-                    // `W / num_quants` elements per served line.
-                    self.lines_storage::<I, WP>()
-                        .view(self.base())
-                        .view(self.window())
-                        .view(layout.clone()),
-                    // The scales over this same window: `ScaleLayout` resolves a window coordinate
-                    // to its block's scale, addressed by the same `layout` as the values, so both
-                    // answer the same coordinate.
-                    info.buffer
-                        .view(ScaleLayout::new(
-                            info.strides.clone(),
-                            info.window_start,
-                            comptime!(info.block.clone()),
-                            comptime!(self.store.vector_size),
-                            comptime!(info.extent.clone()),
-                        ))
-                        .view(layout),
-                    info.global,
-                    comptime!(info.scheme),
-                )
-                .view(),
-                comptime!(self.access.overhang.masks()),
-            ),
+            ComptimeOption::Some(info) => {
+                // The storage view groups at the *physical* width: a packed buffer holds
+                // `W / num_quants` elements per served line.
+                let values = self
+                    .lines_storage::<I, WP>()
+                    .view(self.base())
+                    .view(self.window())
+                    .view(layout.clone());
+                // The scales over this same window: `ScaleLayout` resolves a window coordinate
+                // to its block's scale, addressed by the same `layout` as the values, so both
+                // answer the same coordinate.
+                let scales = info
+                    .buffer
+                    .view(ScaleLayout::new(
+                        info.strides.clone(),
+                        info.window_start,
+                        comptime!(info.block.clone()),
+                        comptime!(self.store.vector_size),
+                        comptime!(info.extent.clone()),
+                    ))
+                    .view(layout);
+                let dequant = if comptime!(info.uniform()) {
+                    // One scale for the whole window: read once here, so no read below pays
+                    // for the scales view at all.
+                    DequantView::<I, WP, f32, T, W, C>::new_uniform(
+                        values,
+                        scales,
+                        info.uniform_scale(),
+                        comptime!(info.scheme),
+                    )
+                } else {
+                    DequantView::<I, WP, f32, T, W, C>::new(
+                        values,
+                        scales,
+                        info.global,
+                        comptime!(info.scheme),
+                    )
+                };
+                MaskedView::new(dequant.view(), comptime!(self.access.overhang.masks()))
+            }
             ComptimeOption::None => self.masked::<W, C, L>(layout),
         }
     }

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -193,7 +193,7 @@ impl<T: Numeric> Tile<T> {
         let mut strides = Coords::<u32>::new();
         #[unroll]
         for p in 0..rank {
-            if comptime!(scheme.block_size().is_full()) {
+            if comptime!(scheme.block_size().is_none()) {
                 strides.push(0u32);
             } else {
                 strides.push(scales.stride(p) as u32);
@@ -1843,7 +1843,7 @@ fn smem_scale_grid(
     scheme: QuantScheme,
 ) -> (Vec<usize>, Vec<usize>) {
     let rank = space.rank();
-    let per_tensor = scheme.block_size().is_full();
+    let per_tensor = scheme.block_size().is_none();
     let nb: Vec<usize> = (0..rank)
         .map(|p| {
             if per_tensor {

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -179,6 +179,7 @@ impl<T: Numeric> Tile<T> {
     pub fn of_dequant<E: CubePrimitive>(
         values: &Tensor<E>,
         scales: &Tensor<f32>,
+        global: ComptimeOption<f32>,
         #[comptime] scheme: QuantScheme,
         #[comptime] dequant_at: DequantAt,
         #[comptime] space: Space,
@@ -200,6 +201,7 @@ impl<T: Numeric> Tile<T> {
         }
         let info = QuantInfo {
             buffer: unsafe { scales.as_slice().as_boxed_unchecked() },
+            global,
             strides,
             window_start: 0u32,
             block: comptime!(block),
@@ -904,7 +906,14 @@ impl<T: Numeric> MemData<T> {
                     .frem(comptime!(nb[p] as u32));
                 src_idx = src_idx.fadd(bi.fmul(sinfo.strides.at(p)));
             }
-            dst_scales[bl] = src_scales[src_idx.fcast::<usize>()];
+            // The grid holds *effective* scales: a two-level source's per-tensor factor folds in
+            // here, once per block per stage, so everything below the stage serves a one-level
+            // scheme and no global threads past this point.
+            if comptime!(sinfo.global.is_some()) {
+                dst_scales[bl] = src_scales[src_idx.fcast::<usize>()] * sinfo.global.unwrap();
+            } else {
+                dst_scales[bl] = src_scales[src_idx.fcast::<usize>()];
+            }
             bl += workers;
         }
     }
@@ -1238,8 +1247,7 @@ impl<T: Numeric> MemData<T> {
                             comptime!(self.store.vector_size),
                         ))
                         .view(FlatLayout::new(self.window.extent.clone())),
-                    // No per-tensor scale; see `transparent`.
-                    ComptimeOption::new_None(),
+                    info.global,
                     comptime!(info.scheme),
                 )
                 .view(),
@@ -1288,10 +1296,7 @@ impl<T: Numeric> MemData<T> {
                             comptime!(self.store.vector_size),
                         ))
                         .view(layout),
-                    // No per-tensor scale: a tile's scales are the scheme's own level, and the
-                    // two-level schemes that carry a global on top are rejected before this
-                    // (`block_edges`), so there is never a second factor to fold in here.
-                    ComptimeOption::new_None(),
+                    info.global,
                     comptime!(info.scheme),
                 )
                 .view(),
@@ -1767,6 +1772,10 @@ fn smem_quant_info(
     }
     ComptimeOption::new_Some(QuantInfo {
         buffer,
+        // The fill folds a two-level source's global into the staged grid
+        // ([`MemData::stage_scales`]), so the stage serves effective scales under the one-level
+        // form of the scheme; keeping the two-level level here would fail cubecl's binding check.
+        global: ComptimeOption::new_None(),
         strides,
         window_start: 0u32,
         block: comptime!(block),
@@ -1774,7 +1783,7 @@ fn smem_quant_info(
         // path reaching here.
         dequant_at: comptime!(DequantAt::Read),
         scale_shape: comptime!(nb),
-        scheme: comptime!(scheme),
+        scheme: comptime!(staged_scheme(scheme)),
     })
 }
 

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -102,10 +102,10 @@ pub enum DequantAt {
 #[expand(derive(Clone))]
 pub struct QuantInfo {
     pub(crate) buffer: Box<[f32]>,
-    /// Per-tensor scale of a two-level scheme, already read from its binding. `None` on a staged
+    /// The outer level's whole-tensor scale, already read from its binding. `None` on a staged
     /// side-channel even for a two-level scheme: [`MemData::stage_scales`] folds it into the grid,
     /// so everything below a stage sees a one-level scheme.
-    pub(crate) global: ComptimeOption<f32>,
+    pub(crate) outer: ComptimeOption<f32>,
     pub(crate) strides: Coords<u32>,
     pub(crate) window_start: u32,
     #[cube(comptime)]
@@ -174,8 +174,8 @@ pub(crate) fn window_extents(space: &Space, rank: usize) -> Vec<usize> {
 }
 
 /// The scheme a staged side-channel serves: its grid holds *effective* scales
-/// ([`MemData::stage_scales`] folds the per-tensor factor in), so a two-level scheme stages as
-/// its one-level block form and reads below the stage carry no global.
+/// ([`MemData::stage_scales`] folds the outer level in), so a two-level scheme stages as its
+/// one-level block form and reads below the stage carry no outer scale.
 pub(crate) fn staged_scheme(scheme: QuantScheme) -> QuantScheme {
     match scheme.scale_levels().inner() {
         Some(inner) => scheme.with_scales(inner),
@@ -185,22 +185,22 @@ pub(crate) fn staged_scheme(scheme: QuantScheme) -> QuantScheme {
 
 #[cube]
 impl QuantInfo {
-    /// Re-window the scales onto a tile whose absolute logical origin is `origin`. Per axis the block
-    /// index is `origin / block`, dotted with the scale strides and summed into a flat start (elements
-    /// everywhere, the inner axis scaled back by `vector_size`; per-tensor keeps strides `0`). Folding
-    /// the window's own block index in here lets [`ScaleLayout`] add only the within-window offset,
-    /// sound because a window never straddles a block (`validate_scheme` enforces it).
-    /// The one scale this whole window reconstructs against, per-tensor factor folded in. Only
+    /// The one scale this whole window reconstructs against, outer level folded in. Only
     /// meaningful where [`uniform`](QuantInfoExpand::uniform) holds; one load for the whole tile.
     pub(crate) fn uniform_scale(&self) -> f32 {
         let scale = self.buffer[self.window_start.fcast::<usize>()];
-        if comptime!(self.global.is_some()) {
-            scale * self.global.unwrap()
+        if comptime!(self.outer.is_some()) {
+            scale * self.outer.unwrap()
         } else {
             scale
         }
     }
 
+    /// Re-window the scales onto a tile whose absolute logical origin is `origin`. Per axis the block
+    /// index is `origin / block`, dotted with the scale strides and summed into a flat start (elements
+    /// everywhere, the inner axis scaled back by `vector_size`; per-tensor keeps strides `0`). Folding
+    /// the window's own block index in here lets [`ScaleLayout`] add only the within-window offset,
+    /// sound because a window never straddles a block (`validate_scheme` enforces it).
     pub(crate) fn window(
         &self,
         origin: &Coords<u32>,
@@ -219,7 +219,7 @@ impl QuantInfo {
         }
         QuantInfo {
             buffer: unsafe { self.buffer.as_boxed_unchecked() },
-            global: self.global,
+            outer: self.outer,
             strides: self.strides.clone(),
             window_start: advances.fsum(comptime!((0..rank).collect::<Vec<_>>())),
             block: comptime!(self.block.clone()),

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -176,10 +176,15 @@ pub(crate) fn window_extents(space: &Space, rank: usize) -> Vec<usize> {
 /// ([`MemData::stage_scales`] folds the outer level in), so a two-level scheme stages as its
 /// one-level block form and reads below the stage carry no outer scale.
 pub(crate) fn staged_scheme(scheme: QuantScheme) -> QuantScheme {
-    match scheme.scale_levels().inner() {
-        Some(inner) => scheme.with_scales(inner),
-        None => scheme,
-    }
+    let Some(block) = scheme.block_scale() else {
+        return scheme;
+    };
+    // Rebuilt rather than cleared: the levels are set additively and there is no way to drop one.
+    QuantScheme::default()
+        .with_value(scheme.value)
+        .with_store(scheme.store)
+        .with_mode(scheme.mode)
+        .per_block(block.size.as_slice(), block.dtype)
 }
 
 #[cube]

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -144,6 +144,28 @@ pub(crate) fn block_edges(scheme: QuantScheme, rank: usize) -> Vec<usize> {
     }
 }
 
+/// Whether one scale covers a window of `extent` under `block` edges: every axis fits inside a
+/// block, so there is nothing left for [`ScaleLayout`] to address and the scale can be read once
+/// ([`QuantInfo::uniform_scale`]) instead of per value.
+fn uniform_window(block: &[usize], extent: &[usize]) -> bool {
+    (0..block.len()).all(|p| extent[p] <= block[p])
+}
+
+impl QuantInfo {
+    /// See [`uniform_window`]. Both this and its expand twin exist because a `comptime!` branch
+    /// typechecks as host code as well as expanded.
+    pub(crate) fn uniform(&self) -> bool {
+        uniform_window(&self.block, &self.extent)
+    }
+}
+
+impl QuantInfoExpand {
+    /// See [`uniform_window`].
+    pub(crate) fn uniform(&self) -> bool {
+        uniform_window(&self.block, &self.extent)
+    }
+}
+
 /// Per-axis window extent in elements for a space's own level, [`usize::MAX`] where an axis is
 /// dynamic. What [`QuantInfo`] carries so [`ScaleLayout`] can drop the axes that hold one scale.
 pub(crate) fn window_extents(space: &Space, rank: usize) -> Vec<usize> {
@@ -172,6 +194,17 @@ impl QuantInfo {
     /// everywhere, the inner axis scaled back by `vector_size`; per-tensor keeps strides `0`). Folding
     /// the window's own block index in here lets [`ScaleLayout`] add only the within-window offset,
     /// sound because a window never straddles a block (`validate_scheme` enforces it).
+    /// The one scale this whole window reconstructs against, per-tensor factor folded in. Only
+    /// meaningful where [`uniform`](QuantInfoExpand::uniform) holds; one load for the whole tile.
+    pub(crate) fn uniform_scale(&self) -> f32 {
+        let scale = self.buffer[self.window_start.fcast::<usize>()];
+        if comptime!(self.global.is_some()) {
+            scale * self.global.unwrap()
+        } else {
+            scale
+        }
+    }
+
     pub(crate) fn window(
         &self,
         origin: &Coords<u32>,

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -113,6 +113,11 @@ pub struct QuantInfo {
     pub(crate) window_start: u32,
     #[cube(comptime)]
     pub(crate) block: Vec<usize>,
+    /// Per-axis extent of the window these scales cover, in elements; [`usize::MAX`] where it is
+    /// not comptime (a dynamic top-level axis). An axis whose extent fits inside a block has no
+    /// distinct scales left to address, which is what [`ScaleLayout`] drops its term for.
+    #[cube(comptime)]
+    pub(crate) extent: Vec<usize>,
     /// Where this operand's quantized form ends. Read by [`MemData::smem_like`], which is why no
     /// call site asks an operand whether it is quantized before staging it.
     #[cube(comptime)]
@@ -139,6 +144,17 @@ pub(crate) fn block_edges(scheme: QuantScheme, rank: usize) -> Vec<usize> {
     }
 }
 
+/// Per-axis window extent in elements for a space's own level, [`usize::MAX`] where an axis is
+/// dynamic. What [`QuantInfo`] carries so [`ScaleLayout`] can drop the axes that hold one scale.
+pub(crate) fn window_extents(space: &Space, rank: usize) -> Vec<usize> {
+    (0..rank)
+        .map(|p| match space.extent_raw(space.axis_at(p)) {
+            Extent::Static(e) => e,
+            Extent::Dynamic => usize::MAX,
+        })
+        .collect()
+}
+
 /// The scheme a staged side-channel serves: its grid holds *effective* scales
 /// ([`MemData::stage_scales`] folds the per-tensor factor in), so a two-level scheme stages as
 /// its one-level block form and reads below the stage carry no global.
@@ -161,6 +177,7 @@ impl QuantInfo {
         origin: &Coords<u32>,
         #[comptime] rank: usize,
         #[comptime] vector_size: usize,
+        #[comptime] extent: Vec<usize>,
     ) -> QuantInfo {
         let last = comptime!(rank - 1);
         let mut advances = Coords::<u32>::new();
@@ -177,6 +194,7 @@ impl QuantInfo {
             strides: self.strides.clone(),
             window_start: advances.fsum(comptime!((0..rank).collect::<Vec<_>>())),
             block: comptime!(self.block.clone()),
+            extent: comptime!(extent),
             dequant_at: comptime!(self.dequant_at),
             scale_shape: comptime!(self.scale_shape.clone()),
             scheme: comptime!(self.scheme),

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -133,10 +133,9 @@ pub struct QuantInfo {
 /// tensor, so its edges are an unused placeholder ([`Tile::of_dequant`] pairs them with `0`
 /// strides); a block scheme's edges come straight from the scheme.
 pub(crate) fn block_edges(scheme: QuantScheme, rank: usize) -> Vec<usize> {
-    let block = scheme.block_size();
-    if block.is_full() {
+    let Some(block) = scheme.block_size() else {
         return vec![1; rank];
-    }
+    };
     block.to_dim_vec(rank).iter().map(|&b| b as usize).collect()
 }
 

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -107,10 +107,10 @@ pub enum DequantAt {
 #[expand(derive(Clone))]
 pub struct QuantInfo {
     pub(crate) buffer: Box<[f32]>,
-    /// The outer level's whole-tensor scale, already read from its binding. `None` on a staged
+    /// The global level's whole-tensor scale, already read from its binding. `None` on a staged
     /// side-channel even for a two-level scheme: [`MemData::stage_scales`] folds it into the grid,
     /// so everything below a stage sees a one-level scheme.
-    pub(crate) outer: ComptimeOption<f32>,
+    pub(crate) global: ComptimeOption<f32>,
     pub(crate) strides: Coords<u32>,
     pub(crate) window_start: u32,
     #[cube(comptime)]
@@ -179,8 +179,8 @@ pub(crate) fn window_extents(space: &Space, rank: usize) -> Vec<usize> {
 }
 
 /// The scheme a staged side-channel serves: its grid holds *effective* scales
-/// ([`MemData::stage_scales`] folds the outer level in), so a two-level scheme stages as its
-/// one-level block form and reads below the stage carry no outer scale.
+/// ([`MemData::stage_scales`] folds the global level in), so a two-level scheme stages as its
+/// one-level block form and reads below the stage carry no global scale.
 pub(crate) fn staged_scheme(scheme: QuantScheme) -> QuantScheme {
     let Some(block) = scheme.block_scale() else {
         return scheme;
@@ -195,19 +195,19 @@ pub(crate) fn staged_scheme(scheme: QuantScheme) -> QuantScheme {
 
 #[cube]
 impl QuantInfo {
-    /// The one scale this whole window reconstructs against, outer level folded in. Only
+    /// The one scale this whole window reconstructs against, global level folded in. Only
     /// meaningful where [`uniform`](QuantInfoExpand::uniform) holds; one load for the whole tile.
     pub(crate) fn uniform_scale(&self) -> f32 {
         let scale = self.buffer[self.window_start.fcast::<usize>()];
-        if comptime!(self.outer.is_some()) {
-            scale * self.outer.unwrap()
+        if comptime!(self.global.is_some()) {
+            scale * self.global.unwrap()
         } else {
             scale
         }
     }
 
     /// The [`DequantView`] this info's scale data resolves to for a values/scales view pair over
-    /// the same coordinates: one scale for the whole window, the outer level folded into a
+    /// the same coordinates: one scale for the whole window, the global level folded into a
     /// register, or a per-position lookup, in that preference order. Shared by
     /// [`flat_transparent`](MemData::flat_transparent) and [`transparent`](MemData::transparent).
     pub(crate) fn dequant_view<
@@ -231,11 +231,11 @@ impl QuantInfo {
                 self.uniform_scale(),
                 comptime!(self.scheme),
             )
-        } else if comptime!(self.outer.is_some()) {
-            DequantView::<I, WP, f32, T, W, C>::new_with_outer_scale(
+        } else if comptime!(self.global.is_some()) {
+            DequantView::<I, WP, f32, T, W, C>::new_with_global_scale(
                 values,
                 scales,
-                self.outer.unwrap(),
+                self.global.unwrap(),
                 comptime!(self.scheme),
             )
         } else {
@@ -266,7 +266,7 @@ impl QuantInfo {
         }
         QuantInfo {
             buffer: unsafe { self.buffer.as_boxed_unchecked() },
-            outer: self.outer,
+            global: self.global,
             strides: self.strides.clone(),
             window_start: advances.fsum(comptime!((0..rank).collect::<Vec<_>>())),
             block: comptime!(self.block.clone()),

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -19,7 +19,12 @@ pub use register::*;
 pub use tma::*;
 pub use view::*;
 
-use cubecl::{prelude::*, quant::scheme::QuantScheme};
+use cubecl::{
+    prelude::*,
+    quant::scheme::QuantScheme,
+    std::quant::view::QuantizedView as DequantView,
+    std::tensor::{View, layout::Coordinates},
+};
 
 use crate::*;
 
@@ -130,11 +135,12 @@ pub struct QuantInfo {
 }
 
 /// Per-axis block edges (elements per block) for a scheme. Per-tensor is one scale for the whole
-/// tensor, so its edges are an unused placeholder ([`Tile::of_dequant`] pairs them with `0`
-/// strides); a block scheme's edges come straight from the scheme.
+/// tensor, so every axis reports `usize::MAX`: with `0` strides ([`Tile::of_dequant`]) the value
+/// never addresses a real block, and it makes [`uniform_window`] report the whole window as
+/// uniform, which per-tensor always is. A block scheme's edges come straight from the scheme.
 pub(crate) fn block_edges(scheme: QuantScheme, rank: usize) -> Vec<usize> {
     let Some(block) = scheme.block_size() else {
-        return vec![1; rank];
+        return vec![usize::MAX; rank];
     };
     block.to_dim_vec(rank).iter().map(|&b| b as usize).collect()
 }
@@ -197,6 +203,43 @@ impl QuantInfo {
             scale * self.outer.unwrap()
         } else {
             scale
+        }
+    }
+
+    /// The [`DequantView`] this info's scale data resolves to for a values/scales view pair over
+    /// the same coordinates: one scale for the whole window, the outer level folded into a
+    /// register, or a per-position lookup, in that preference order. Shared by
+    /// [`flat_transparent`](MemData::flat_transparent) and [`transparent`](MemData::transparent).
+    pub(crate) fn dequant_view<
+        'a,
+        I: Numeric,
+        WP: Size,
+        T: Numeric,
+        W: Size,
+        C: Coordinates + 'static,
+    >(
+        &self,
+        values: View<'a, Vector<I, WP>, C>,
+        scales: View<'a, f32, C>,
+    ) -> DequantView<'a, I, WP, f32, T, W, C> {
+        if comptime!(self.uniform()) {
+            // One scale for the whole window: read once here, so no read below pays for the
+            // scales view at all.
+            DequantView::<I, WP, f32, T, W, C>::new_with_whole_scale(
+                values,
+                scales,
+                self.uniform_scale(),
+                comptime!(self.scheme),
+            )
+        } else if comptime!(self.outer.is_some()) {
+            DequantView::<I, WP, f32, T, W, C>::new_with_outer_scale(
+                values,
+                scales,
+                self.outer.unwrap(),
+                comptime!(self.scheme),
+            )
+        } else {
+            DequantView::<I, WP, f32, T, W, C>::new(values, scales, comptime!(self.scheme))
         }
     }
 

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -19,10 +19,7 @@ pub use register::*;
 pub use tma::*;
 pub use view::*;
 
-use cubecl::{
-    prelude::*,
-    quant::scheme::{QuantLevel, QuantScheme},
-};
+use cubecl::{prelude::*, quant::scheme::QuantScheme};
 
 use crate::*;
 
@@ -136,12 +133,11 @@ pub struct QuantInfo {
 /// tensor, so its edges are an unused placeholder ([`Tile::of_dequant`] pairs them with `0`
 /// strides); a block scheme's edges come straight from the scheme.
 pub(crate) fn block_edges(scheme: QuantScheme, rank: usize) -> Vec<usize> {
-    match scheme.level {
-        QuantLevel::Tensor => vec![1; rank],
-        QuantLevel::Block(bs) | QuantLevel::BlockTensor { block: bs, .. } => {
-            bs.to_dim_vec(rank).iter().map(|&b| b as usize).collect()
-        }
+    let block = scheme.block_size();
+    if block.is_full() {
+        return vec![1; rank];
     }
+    block.to_dim_vec(rank).iter().map(|&b| b as usize).collect()
 }
 
 /// Whether one scale covers a window of `extent` under `block` edges: every axis fits inside a
@@ -181,9 +177,9 @@ pub(crate) fn window_extents(space: &Space, rank: usize) -> Vec<usize> {
 /// ([`MemData::stage_scales`] folds the per-tensor factor in), so a two-level scheme stages as
 /// its one-level block form and reads below the stage carry no global.
 pub(crate) fn staged_scheme(scheme: QuantScheme) -> QuantScheme {
-    match scheme.level {
-        QuantLevel::BlockTensor { block, .. } => scheme.with_level(QuantLevel::Block(block)),
-        QuantLevel::Tensor | QuantLevel::Block(_) => scheme,
+    match scheme.scale_levels().inner() {
+        Some(inner) => scheme.with_scales(inner),
+        None => scheme,
     }
 }
 

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -105,6 +105,10 @@ pub enum DequantAt {
 #[expand(derive(Clone))]
 pub struct QuantInfo {
     pub(crate) buffer: Box<[f32]>,
+    /// Per-tensor scale of a two-level scheme, already read from its binding. `None` on a staged
+    /// side-channel even for a two-level scheme: [`MemData::stage_scales`] folds it into the grid,
+    /// so everything below a stage sees a one-level scheme.
+    pub(crate) global: ComptimeOption<f32>,
     pub(crate) strides: Coords<u32>,
     pub(crate) window_start: u32,
     #[cube(comptime)]
@@ -129,13 +133,19 @@ pub struct QuantInfo {
 pub(crate) fn block_edges(scheme: QuantScheme, rank: usize) -> Vec<usize> {
     match scheme.level {
         QuantLevel::Tensor => vec![1; rank],
-        QuantLevel::Block(bs) => bs.to_dim_vec(rank).iter().map(|&b| b as usize).collect(),
-        QuantLevel::BlockTensor { .. } => {
-            unimplemented!(
-                "two-level quantization is not supported here, got {:?}",
-                scheme.level
-            )
+        QuantLevel::Block(bs) | QuantLevel::BlockTensor { block: bs, .. } => {
+            bs.to_dim_vec(rank).iter().map(|&b| b as usize).collect()
         }
+    }
+}
+
+/// The scheme a staged side-channel serves: its grid holds *effective* scales
+/// ([`MemData::stage_scales`] folds the per-tensor factor in), so a two-level scheme stages as
+/// its one-level block form and reads below the stage carry no global.
+pub(crate) fn staged_scheme(scheme: QuantScheme) -> QuantScheme {
+    match scheme.level {
+        QuantLevel::BlockTensor { block, .. } => scheme.with_level(QuantLevel::Block(block)),
+        QuantLevel::Tensor | QuantLevel::Block(_) => scheme,
     }
 }
 
@@ -163,6 +173,7 @@ impl QuantInfo {
         }
         QuantInfo {
             buffer: unsafe { self.buffer.as_boxed_unchecked() },
+            global: self.global,
             strides: self.strides.clone(),
             window_start: advances.fsum(comptime!((0..rank).collect::<Vec<_>>())),
             block: comptime!(self.block.clone()),

--- a/crates/cubek-tile/src/tile/view/quant.rs
+++ b/crates/cubek-tile/src/tile/view/quant.rs
@@ -56,15 +56,6 @@ impl ScaleLayout {
     fn addresses(&self, #[comptime] p: usize) -> comptime_type!(bool) {
         comptime!(self.extent[p] > self.block[p])
     }
-
-    /// How many axes [`addresses`](Self::addresses) keeps, so the sum knows its own arity.
-    fn kept(&self) -> comptime_type!(usize) {
-        comptime!(
-            (0..self.block.len())
-                .filter(|&p| self.extent[p] > self.block[p])
-                .count()
-        )
-    }
 }
 
 #[cube]
@@ -86,7 +77,7 @@ impl Layout for ScaleLayout {
                 terms.push(pos[p].fmul(w).fdiv(block).fmul(self.strides.at(p)));
             }
         }
-        let kept = self.kept();
+        let kept = terms.len();
         if comptime!(kept == 0) {
             // Every axis holds one scale: the window's own, already in `window_start`.
             self.window_start.fcast::<usize>()

--- a/crates/cubek-tile/src/tile/view/quant.rs
+++ b/crates/cubek-tile/src/tile/view/quant.rs
@@ -27,6 +27,9 @@ pub struct ScaleLayout {
     /// the physical line by the packing factor.
     #[cube(comptime)]
     vector_size: usize,
+    /// Per-axis window extent in elements, [`usize::MAX`] where it is not comptime.
+    #[cube(comptime)]
+    extent: Vec<usize>,
 }
 
 #[cube]
@@ -36,13 +39,31 @@ impl ScaleLayout {
         window_start: u32,
         #[comptime] block: Vec<usize>,
         #[comptime] vector_size: usize,
+        #[comptime] extent: Vec<usize>,
     ) -> Self {
         ScaleLayout {
             strides,
             window_start,
             block,
             vector_size,
+            extent,
         }
+    }
+
+    /// Whether axis `p` still distinguishes scales: an extent that fits inside a block leaves one
+    /// scale for the whole window, already folded into `window_start`, so the term is dropped at
+    /// comptime rather than dividing a runtime coordinate that can only answer `0`.
+    fn addresses(&self, #[comptime] p: usize) -> comptime_type!(bool) {
+        comptime!(self.extent[p] > self.block[p])
+    }
+
+    /// How many axes [`addresses`](Self::addresses) keeps, so the sum knows its own arity.
+    fn kept(&self) -> comptime_type!(usize) {
+        comptime!(
+            (0..self.block.len())
+                .filter(|&p| self.extent[p] > self.block[p])
+                .count()
+        )
     }
 }
 
@@ -58,14 +79,22 @@ impl Layout for ScaleLayout {
         let mut terms = Sequence::<u32>::new();
         #[unroll]
         for p in 0..rank {
-            // Only the innermost axis counts lines; blocks are cut in elements, so widen it.
-            let w = comptime!((if p == last { self.vector_size } else { 1 }) as u32);
-            let block = comptime!(self.block[p] as u32);
-            terms.push(pos[p].fmul(w).fdiv(block).fmul(self.strides.at(p)));
+            if self.addresses(p) {
+                // Only the innermost axis counts lines; blocks are cut in elements, so widen it.
+                let w = comptime!((if p == last { self.vector_size } else { 1 }) as u32);
+                let block = comptime!(self.block[p] as u32);
+                terms.push(pos[p].fmul(w).fdiv(block).fmul(self.strides.at(p)));
+            }
         }
-        self.window_start
-            .fadd(terms.fsum(comptime!((0..rank).collect::<Vec<_>>())))
-            .fcast::<usize>()
+        let kept = self.kept();
+        if comptime!(kept == 0) {
+            // Every axis holds one scale: the window's own, already in `window_start`.
+            self.window_start.fcast::<usize>()
+        } else {
+            self.window_start
+                .fadd(terms.fsum(comptime!((0..kept).collect::<Vec<_>>())))
+                .fcast::<usize>()
+        }
     }
 
     fn to_source_pos_checked(&self, pos: Self::Coordinates) -> (Self::SourceCoordinates, bool) {

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -3,7 +3,7 @@
 use cubecl::{
     TestRuntime,
     prelude::*,
-    quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue},
+    quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels},
 };
 use cubek_tile::{
     Axis, Boundary, CubeAxis, Cut, DequantAt, Divisor, Offset, PhysicalAxisMap, Projection, Scale,
@@ -546,12 +546,11 @@ fn quantize(v: usize, scheme: QuantScheme) {
         .build();
 }
 
-fn quant_scheme(level: QuantLevel) -> QuantScheme {
+fn quant_scheme(levels: ScaleLevels) -> QuantScheme {
     QuantScheme::default()
-        .with_level(level)
+        .with_scales(levels)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32)
 }
 
 /// Scale blocks cut by the operand's own tiling: `K` is cut into 16-element tiles, so a 6-element
@@ -560,7 +559,10 @@ fn quant_scheme(level: QuantLevel) -> QuantScheme {
 #[test]
 #[should_panic(expected = "straddle its 6-element scale blocks")]
 fn quantized_block_straddling_a_cut_panics() {
-    quantize(1, quant_scheme(QuantLevel::block([64, 6])));
+    quantize(
+        1,
+        quant_scheme(ScaleLevels::block([64, 6], QuantParam::F32)),
+    );
 }
 
 /// 2-element blocks tile every `K` cut (16, then 4), so the tiling is fine — but a line is one
@@ -568,7 +570,10 @@ fn quantized_block_straddling_a_cut_panics() {
 #[test]
 #[should_panic(expected = "straddles two scales")]
 fn quantized_line_straddling_two_blocks_panics() {
-    quantize(4, quant_scheme(QuantLevel::block([64, 2])));
+    quantize(
+        4,
+        quant_scheme(ScaleLevels::block([64, 2], QuantParam::F32)),
+    );
 }
 
 /// Scales ride an `f32` buffer read straight through, so a narrower param would reinterpret its
@@ -576,10 +581,7 @@ fn quantized_line_straddling_two_blocks_panics() {
 #[test]
 #[should_panic(expected = "scales are read as f32")]
 fn quantized_non_f32_param_panics() {
-    quantize(
-        1,
-        quant_scheme(QuantLevel::Tensor).with_param(QuantParam::F16),
-    );
+    quantize(1, quant_scheme(ScaleLevels::tensor(QuantParam::F16)));
 }
 
 /// A packed store's values are laid down along the innermost axis, so that is the only axis it may
@@ -589,7 +591,7 @@ fn quantized_non_f32_param_panics() {
 fn quantized_packed_store_outer_axis_panics() {
     quantize(
         1,
-        quant_scheme(QuantLevel::Tensor).with_store(QuantStore::PackedU32(2)),
+        quant_scheme(ScaleLevels::tensor(QuantParam::F32)).with_store(QuantStore::PackedU32(2)),
     );
 }
 
@@ -600,6 +602,6 @@ fn quantized_packed_store_outer_axis_panics() {
 fn quantized_packed_store_narrow_line_panics() {
     quantize(
         1,
-        quant_scheme(QuantLevel::Tensor).with_store(QuantStore::PackedU32(0)),
+        quant_scheme(ScaleLevels::tensor(QuantParam::F32)).with_store(QuantStore::PackedU32(0)),
     );
 }

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -3,7 +3,7 @@
 use cubecl::{
     TestRuntime,
     prelude::*,
-    quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels},
+    quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype},
 };
 use cubek_tile::{
     Axis, Boundary, CubeAxis, Cut, DequantAt, Divisor, Offset, PhysicalAxisMap, Projection, Scale,
@@ -542,9 +542,8 @@ fn quantize(v: usize, scheme: QuantScheme) {
         .build();
 }
 
-fn quant_scheme(levels: ScaleLevels) -> QuantScheme {
+fn quant_scheme() -> QuantScheme {
     QuantScheme::default()
-        .with_scales(levels)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S)
 }
@@ -555,10 +554,7 @@ fn quant_scheme(levels: ScaleLevels) -> QuantScheme {
 #[test]
 #[should_panic(expected = "straddle its 6-element scale blocks")]
 fn quantized_block_straddling_a_cut_panics() {
-    quantize(
-        1,
-        quant_scheme(ScaleLevels::block([64, 6], QuantParam::F32)),
-    );
+    quantize(1, quant_scheme().per_block([64, 6], ScaleDtype::F32));
 }
 
 /// 2-element blocks tile every `K` cut (16, then 4), so the tiling is fine — but a line is one
@@ -566,10 +562,7 @@ fn quantized_block_straddling_a_cut_panics() {
 #[test]
 #[should_panic(expected = "straddles two scales")]
 fn quantized_line_straddling_two_blocks_panics() {
-    quantize(
-        4,
-        quant_scheme(ScaleLevels::block([64, 2], QuantParam::F32)),
-    );
+    quantize(4, quant_scheme().per_block([64, 2], ScaleDtype::F32));
 }
 
 /// Scales ride an `f32` buffer read straight through, so a narrower param would reinterpret its
@@ -577,7 +570,7 @@ fn quantized_line_straddling_two_blocks_panics() {
 #[test]
 #[should_panic(expected = "scales are read as f32")]
 fn quantized_non_f32_param_panics() {
-    quantize(1, quant_scheme(ScaleLevels::tensor(QuantParam::F16)));
+    quantize(1, quant_scheme().per_tensor(ScaleDtype::F16));
 }
 
 /// A packed store's values are laid down along the innermost axis, so that is the only axis it may
@@ -587,7 +580,9 @@ fn quantized_non_f32_param_panics() {
 fn quantized_packed_store_outer_axis_panics() {
     quantize(
         1,
-        quant_scheme(ScaleLevels::tensor(QuantParam::F32)).with_store(QuantStore::PackedU32(2)),
+        quant_scheme()
+            .per_tensor(ScaleDtype::F32)
+            .with_store(QuantStore::PackedU32(2)),
     );
 }
 
@@ -598,6 +593,8 @@ fn quantized_packed_store_outer_axis_panics() {
 fn quantized_packed_store_narrow_line_panics() {
     quantize(
         1,
-        quant_scheme(ScaleLevels::tensor(QuantParam::F32)).with_store(QuantStore::PackedU32(0)),
+        quant_scheme()
+            .per_tensor(ScaleDtype::F32)
+            .with_store(QuantStore::PackedU32(0)),
     );
 }

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -538,11 +538,7 @@ fn quantize(v: usize, scheme: QuantScheme) {
         .subspace(&[M, K])
         .vectorize(v)
         .checked(false)
-        .quantized(
-            binding(&client, &[1, 8]).into_tensor_arg(),
-            scheme,
-            DequantAt::Read,
-        )
+        .quantized(&[binding(&client, &[1, 8])], scheme, DequantAt::Read)
         .build();
 }
 

--- a/crates/cubek-tile/tests/tile/matmul.rs
+++ b/crates/cubek-tile/tests/tile/matmul.rs
@@ -1460,6 +1460,7 @@ fn cmma_matmul_quant_per_tensor_8x8x8() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, K]),
             scheme,
             DequantAt::Load,
@@ -2074,6 +2075,7 @@ fn cmma_matmul_quant_block_m_8x8x8() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, K]),
             scheme,
             DequantAt::Load,
@@ -2157,6 +2159,7 @@ fn cmma_matmul_quant_block_k_8x8x8() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, K]),
             scheme,
             DequantAt::Load,
@@ -2272,6 +2275,7 @@ fn mma_matmul_quant_until_read() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, K]).leaf(leaf),
             scheme,
             DequantAt::Read,
@@ -2360,6 +2364,7 @@ fn check_cmma_matmul_quant_k_walk(k: usize, schedule: Schedule) {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, K]).leaf(leaf),
             scheme,
             DequantAt::Load,
@@ -2454,6 +2459,7 @@ fn cmma_matmul_quant_block_m_k_walk() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, K]).leaf(leaf),
             scheme,
             DequantAt::Load,
@@ -2548,6 +2554,7 @@ fn cmma_matmul_quant_block_k_k_walk() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, K]).leaf(leaf),
             scheme,
             DequantAt::Load,
@@ -2642,6 +2649,7 @@ fn cmma_matmul_quant_block_k_k_walk_vectorized() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, K]).leaf(leaf),
             scheme,
             DequantAt::Load,
@@ -2996,6 +3004,7 @@ fn run_register_matmul_quant(
         QuantTileArgLaunch::new(
             a_arg,
             scales_arg,
+            None.into(),
             TileSpec::direct(&[M, K]),
             scheme,
             DequantAt::Load,
@@ -3059,6 +3068,7 @@ fn register_matmul_quant_rhs_packed_q8() {
         QuantValue::Q8S,
         4,
         DequantAt::Read,
+        None,
     );
 }
 
@@ -3073,6 +3083,7 @@ fn register_matmul_quant_rhs_packed_q4() {
         QuantValue::Q4S,
         8,
         DequantAt::Read,
+        None,
     );
 }
 
@@ -3088,6 +3099,7 @@ fn register_matmul_quant_rhs_gemv_row() {
         QuantValue::Q8S,
         4,
         DequantAt::Read,
+        None,
     );
 }
 
@@ -3113,6 +3125,7 @@ fn register_matmul_quant_rhs_gemv_row_multi_cube() {
         QuantValue::Q8S,
         4,
         DequantAt::Read,
+        None,
     );
 }
 
@@ -3134,7 +3147,15 @@ fn register_matmul_quant_rhs_direct_serve_gemv() {
         .build()
         .partitioner()
         .clone();
-    run_register_matmul_quant_rhs(client, (1, 8, 8), plan, QuantValue::Q8S, 4, DequantAt::Read);
+    run_register_matmul_quant_rhs(
+        client,
+        (1, 8, 8),
+        plan,
+        QuantValue::Q8S,
+        4,
+        DequantAt::Read,
+        None,
+    );
 }
 
 /// The Goal path: a `.staged()` packed weight whose smem stage holds the *packed u32 words*, not a
@@ -3163,6 +3184,7 @@ fn register_matmul_quant_rhs_staged_packed_smem() {
         QuantValue::Q8S,
         4,
         DequantAt::Read,
+        None,
     );
 }
 
@@ -3190,6 +3212,61 @@ fn register_matmul_quant_rhs_staged_dequantized_smem() {
         QuantValue::Q8S,
         4,
         DequantAt::Load,
+        None,
+    );
+}
+
+/// Two-level through the staged `DequantAt::Read` path: the stage keeps the packed weight, and
+/// `stage_scales` writes `global * local` into the smem scale grid, so the reads below see
+/// effective one-level scales. The expectation carries the global, so a fold that never happens
+/// (or happens twice) fails by that factor.
+#[test]
+fn register_matmul_quant_rhs_two_level_staged_packed_smem() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let plan = Tiling::new()
+        .extents(&[(M, 4), (N, 8), (K, 16)])
+        .level(WalkOrder::RowMajor, Schedule::Staged, |l| {
+            l.axis(M, Cut::sequential(4))
+                .axis(N, Cut::sequential(4))
+                .axis(K, Cut::sequential(4))
+        })
+        .build()
+        .partitioner()
+        .clone();
+    run_register_matmul_quant_rhs(
+        client,
+        (4, 8, 16),
+        plan,
+        QuantValue::Q8S,
+        4,
+        DequantAt::Read,
+        Some(0.5),
+    );
+}
+
+/// Two-level through the staged `DequantAt::Load` path: the fill dequantizes into the stage, so
+/// the global folds in the gmem read itself and the stage carries plain served values.
+#[test]
+fn register_matmul_quant_rhs_two_level_staged_dequantized_smem() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let plan = Tiling::new()
+        .extents(&[(M, 4), (N, 8), (K, 16)])
+        .level(WalkOrder::RowMajor, Schedule::Staged, |l| {
+            l.axis(M, Cut::sequential(4))
+                .axis(N, Cut::sequential(4))
+                .axis(K, Cut::sequential(4))
+        })
+        .build()
+        .partitioner()
+        .clone();
+    run_register_matmul_quant_rhs(
+        client,
+        (4, 8, 16),
+        plan,
+        QuantValue::Q8S,
+        4,
+        DequantAt::Load,
+        Some(0.5),
     );
 }
 
@@ -3243,12 +3320,19 @@ fn run_register_matmul_quant_rhs(
     value: QuantValue,
     bn: usize,
     dequant_at: DequantAt,
+    global: Option<f32>,
 ) {
-    let scheme = QuantScheme::default()
+    // The data is minted against the one-level scheme either way: a two-level tensor holds the
+    // same value and block-scale bytes, plus the global in its own binding.
+    let mint_scheme = QuantScheme::default()
         .with_level(QuantLevel::block([1, bn as u8]))
         .with_store(QuantStore::PackedU32(0))
         .with_value(value)
         .with_param(QuantParam::F32);
+    let scheme = match global {
+        Some(_) => mint_scheme.with_level(QuantLevel::block_tensor([1, bn as u8], QuantParam::F32)),
+        None => mint_scheme,
+    };
     let pack = scheme.num_quants();
 
     let max_width = client.properties().hardware.max_vector_size;
@@ -3268,8 +3352,13 @@ fn run_register_matmul_quant_rhs(
     // The weight and its per-(k, N-group) scales, minted together.
     let b = TileInput::builder(&client, space.project(&[K, N]))
         .untiled()
-        .packed(&scheme, dequant_at)
+        .packed(&mint_scheme, dequant_at)
         .arange();
+    let global_scale = global.map(|g| {
+        TestInput::builder(client.clone(), shape![1])
+            .custom(vec![g])
+            .generate_without_host_data()
+    });
     let c = TileInput::builder(&client, space.project(&[M, N]))
         .untiled()
         .zeros();
@@ -3280,12 +3369,16 @@ fn run_register_matmul_quant_rhs(
     // quantized RHS goes through the source builder, which binds it at the storage width.
     let launcher = space.launcher(&client);
     let a_op = launcher.arg(a.handle().binding()).subspace(&[M, K]).build();
-    let b_op = launcher
+    let b_src = launcher
         .arg(b.tile.handle().binding())
         .subspace(&[K, N])
-        .vectorize(pack)
-        .quantized(b.scales_arg(), scheme, dequant_at)
-        .build();
+        .vectorize(pack);
+    let b_op = match global_scale {
+        Some(g) => b_src
+            .quantized_two_level(b.scales_arg(), g.binding(), scheme, dequant_at)
+            .build(),
+        None => b_src.quantized(b.scales_arg(), scheme, dequant_at).build(),
+    };
     // The register microkernel lines the accumulator at the RHS's served width.
     let c_op = launcher
         .arg(c.handle().binding())
@@ -3309,12 +3402,16 @@ fn run_register_matmul_quant_rhs(
     let output = HostData::from_tensor_handle(&client, c.handle(), HostDataType::F32);
     // A is arange over (m, k): a[i, p] = i·k + p.
     let sn = n / bn;
+    let g = global.unwrap_or(1.0);
     let expected: Vec<f32> = (0..m * n)
         .map(|idx| {
             let (i, j) = (idx / n, idx % n);
             (0..k)
                 .map(|p| {
-                    ((i * k + p) as f32) * (b.q[p * n + j] as f32) * b.scale_values[p * sn + j / bn]
+                    ((i * k + p) as f32)
+                        * (b.q[p * n + j] as f32)
+                        * b.scale_values[p * sn + j / bn]
+                        * g
                 })
                 .sum()
         })

--- a/crates/cubek-tile/tests/tile/matmul.rs
+++ b/crates/cubek-tile/tests/tile/matmul.rs
@@ -9,7 +9,7 @@ use cubecl::{
     prelude::*,
     zspace::shape,
 };
-use cubek_quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels};
+use cubek_quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype};
 use cubek_test_utils::{
     HostData, HostDataType, TestInput, TestOutcome, TileInput, ValidationResult,
     assert_equals_approx,
@@ -1426,7 +1426,7 @@ fn cmma_matmul_quant_per_tensor_8x8x8() {
 
     let scale = 0.05f32;
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::tensor(QuantParam::F32))
+        .per_tensor(ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 
@@ -2040,7 +2040,7 @@ fn cmma_matmul_quant_block_m_8x8x8() {
 
     let bm = 4usize; // 2 blocks along M, each 4×8; one scale each
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([bm as u8, 8], QuantParam::F32))
+        .per_block([bm as u8, 8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 
@@ -2123,7 +2123,7 @@ fn cmma_matmul_quant_block_k_8x8x8() {
 
     let bk = 4usize; // 2 blocks along K, each 8×4; the scale changes at p = 4
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([8, bk as u8], QuantParam::F32))
+        .per_block([8, bk as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 
@@ -2239,7 +2239,7 @@ fn mma_matmul_quant_until_read() {
 
     let scale = 0.05f32;
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::tensor(QuantParam::F32))
+        .per_tensor(ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 
@@ -2326,7 +2326,7 @@ fn check_cmma_matmul_quant_k_walk(k: usize, schedule: Schedule) {
 
     let scale = 0.05f32;
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::tensor(QuantParam::F32))
+        .per_tensor(ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 
@@ -2420,7 +2420,7 @@ fn cmma_matmul_quant_block_m_k_walk() {
 
     // One scale per M-block, over the full K: block `[bm, k]`, scales shaped (m/bm, 1).
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([bm as u8, k as u8], QuantParam::F32))
+        .per_block([bm as u8, k as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
     let scale_vals: Vec<f32> = (0..m / bm).map(|b| 0.05 * (b + 1) as f32).collect();
@@ -2514,7 +2514,7 @@ fn cmma_matmul_quant_block_k_k_walk() {
 
     // One scale per K-block, over the full M: block `[m, bk]`, scales shaped (1, k/bk).
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([m as u8, bk as u8], QuantParam::F32))
+        .per_block([m as u8, bk as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
     let scale_vals: Vec<f32> = (0..k / bk).map(|b| 0.05 * (b + 1) as f32).collect();
@@ -2608,7 +2608,7 @@ fn cmma_matmul_quant_block_k_k_walk_vectorized() {
 
     // One scale per K-block, over the full M: block `[m, bk]`, scales shaped (1, k/bk).
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([m as u8, bk as u8], QuantParam::F32))
+        .per_block([m as u8, bk as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
     let scale_vals: Vec<f32> = (0..k / bk).map(|b| 0.05 * (b + 1) as f32).collect();
@@ -2817,7 +2817,7 @@ fn register_matmul_quant_native_block_m() {
 
     let (m, n, k, bm) = (8usize, 8usize, 8usize, 4usize);
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([bm as u8, k as u8], QuantParam::F32))
+        .per_block([bm as u8, k as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 
@@ -2867,7 +2867,7 @@ fn register_matmul_quant_native_direct_serve() {
 
     let (m, n, k, bm) = (8usize, 8usize, 8usize, 4usize);
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([bm as u8, k as u8], QuantParam::F32))
+        .per_block([bm as u8, k as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 
@@ -2924,7 +2924,7 @@ fn run_register_matmul_quant_packed(
     bm: usize,
 ) {
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([bm as u8, k as u8], QuantParam::F32))
+        .per_block([bm as u8, k as u8], ScaleDtype::F32)
         .with_store(QuantStore::PackedU32(0))
         .with_value(value);
     let pack = scheme.num_quants();
@@ -3268,7 +3268,7 @@ fn register_matmul_quant_rhs_two_level_staged_dequantized_smem() {
 fn quant_until_read_refused_by_a_cmma_leaf() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([1, 4], QuantParam::F32))
+        .per_block([1, 4], ScaleDtype::F32)
         .with_store(QuantStore::PackedU32(0))
         .with_value(QuantValue::Q8S);
     let leaf = Leaf::Cmma;
@@ -3313,13 +3313,11 @@ fn run_register_matmul_quant_rhs(
     // The data is minted against the one-level scheme either way: a two-level tensor holds the
     // same value and block-scale bytes, plus the outer scale in its own binding.
     let mint_scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([1, bn as u8], QuantParam::F32))
+        .per_block([1, bn as u8], ScaleDtype::F32)
         .with_store(QuantStore::PackedU32(0))
         .with_value(value);
     let scheme = match outer {
-        Some(_) => mint_scheme.with_scales(
-            ScaleLevels::block([1, bn as u8], QuantParam::F32).and_tensor(QuantParam::F32),
-        ),
+        Some(_) => mint_scheme.per_tensor(ScaleDtype::F32),
         None => mint_scheme,
     };
     let pack = scheme.num_quants();

--- a/crates/cubek-tile/tests/tile/matmul.rs
+++ b/crates/cubek-tile/tests/tile/matmul.rs
@@ -2952,7 +2952,7 @@ fn run_register_matmul_quant_packed(
         a.tile.tensor_arg(1),
         a_dtype,
         scheme,
-        a.scales_arg(),
+        a.scales_binding().into_tensor_arg(),
         a.scale_values.clone(),
         bm,
         q,
@@ -3206,9 +3206,9 @@ fn register_matmul_quant_rhs_staged_dequantized_smem() {
 }
 
 /// Two-level through the staged `DequantAt::Read` path: the stage keeps the packed weight, and
-/// `stage_scales` writes `global * local` into the smem scale grid, so the reads below see
-/// effective one-level scales. The expectation carries the global, so a fold that never happens
-/// (or happens twice) fails by that factor.
+/// `stage_scales` writes `outer * local` into the smem scale grid, so the reads below see
+/// effective one-level scales. The expectation carries the outer scale, so a fold that never
+/// happens (or happens twice) fails by that factor.
 #[test]
 fn register_matmul_quant_rhs_two_level_staged_packed_smem() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
@@ -3234,7 +3234,7 @@ fn register_matmul_quant_rhs_two_level_staged_packed_smem() {
 }
 
 /// Two-level through the staged `DequantAt::Load` path: the fill dequantizes into the stage, so
-/// the global folds in the gmem read itself and the stage carries plain served values.
+/// the outer scale folds in the gmem read itself and the stage carries plain served values.
 #[test]
 fn register_matmul_quant_rhs_two_level_staged_dequantized_smem() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
@@ -3295,7 +3295,7 @@ fn quant_until_read_refused_by_a_cmma_leaf() {
         .subspace(&[K, N])
         .vectorize(scheme.num_quants())
         .leaf(leaf)
-        .quantized(b.scales_arg(), scheme, DequantAt::Read)
+        .quantized(&[b.scales_binding()], scheme, DequantAt::Read)
         .build();
 }
 
@@ -3308,15 +3308,15 @@ fn run_register_matmul_quant_rhs(
     value: QuantValue,
     bn: usize,
     dequant_at: DequantAt,
-    global: Option<f32>,
+    outer: Option<f32>,
 ) {
     // The data is minted against the one-level scheme either way: a two-level tensor holds the
-    // same value and block-scale bytes, plus the global in its own binding.
+    // same value and block-scale bytes, plus the outer scale in its own binding.
     let mint_scheme = QuantScheme::default()
         .with_scales(ScaleLevels::block([1, bn as u8], QuantParam::F32))
         .with_store(QuantStore::PackedU32(0))
         .with_value(value);
-    let scheme = match global {
+    let scheme = match outer {
         Some(_) => mint_scheme.with_scales(
             ScaleLevels::block([1, bn as u8], QuantParam::F32).and_tensor(QuantParam::F32),
         ),
@@ -3343,7 +3343,7 @@ fn run_register_matmul_quant_rhs(
         .untiled()
         .packed(&mint_scheme, dequant_at)
         .arange();
-    let global_scale = global.map(|g| {
+    let outer_scale = outer.map(|g| {
         TestInput::builder(client.clone(), shape![1])
             .custom(vec![g])
             .generate_without_host_data()
@@ -3362,12 +3362,9 @@ fn run_register_matmul_quant_rhs(
         .arg(b.tile.handle().binding())
         .subspace(&[K, N])
         .vectorize(pack);
-    let b_op = match global_scale {
-        Some(g) => b_src
-            .quantized_two_level(b.scales_arg(), g.binding(), scheme, dequant_at)
-            .build(),
-        None => b_src.quantized(b.scales_arg(), scheme, dequant_at).build(),
-    };
+    let mut scales = vec![b.scales_binding()];
+    scales.extend(outer_scale.map(|g| g.binding()));
+    let b_op = b_src.quantized(&scales, scheme, dequant_at).build();
     // The register microkernel lines the accumulator at the RHS's served width.
     let c_op = launcher
         .arg(c.handle().binding())
@@ -3391,7 +3388,7 @@ fn run_register_matmul_quant_rhs(
     let output = HostData::from_tensor_handle(&client, c.handle(), HostDataType::F32);
     // A is arange over (m, k): a[i, p] = i·k + p.
     let sn = n / bn;
-    let g = global.unwrap_or(1.0);
+    let g = outer.unwrap_or(1.0);
     let expected: Vec<f32> = (0..m * n)
         .map(|idx| {
             let (i, j) = (idx / n, idx % n);

--- a/crates/cubek-tile/tests/tile/matmul.rs
+++ b/crates/cubek-tile/tests/tile/matmul.rs
@@ -3206,8 +3206,8 @@ fn register_matmul_quant_rhs_staged_dequantized_smem() {
 }
 
 /// Two-level through the staged `DequantAt::Read` path: the stage keeps the packed weight, and
-/// `stage_scales` writes `outer * local` into the smem scale grid, so the reads below see
-/// effective one-level scales. The expectation carries the outer scale, so a fold that never
+/// `stage_scales` writes `global * local` into the smem scale grid, so the reads below see
+/// effective one-level scales. The expectation carries the global scale, so a fold that never
 /// happens (or happens twice) fails by that factor.
 #[test]
 fn register_matmul_quant_rhs_two_level_staged_packed_smem() {
@@ -3234,7 +3234,7 @@ fn register_matmul_quant_rhs_two_level_staged_packed_smem() {
 }
 
 /// Two-level through the staged `DequantAt::Load` path: the fill dequantizes into the stage, so
-/// the outer scale folds in the gmem read itself and the stage carries plain served values.
+/// the global scale folds in the gmem read itself and the stage carries plain served values.
 #[test]
 fn register_matmul_quant_rhs_two_level_staged_dequantized_smem() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
@@ -3308,15 +3308,15 @@ fn run_register_matmul_quant_rhs(
     value: QuantValue,
     bn: usize,
     dequant_at: DequantAt,
-    outer: Option<f32>,
+    global: Option<f32>,
 ) {
     // The data is minted against the one-level scheme either way: a two-level tensor holds the
-    // same value and block-scale bytes, plus the outer scale in its own binding.
+    // same value and block-scale bytes, plus the global scale in its own binding.
     let mint_scheme = QuantScheme::default()
         .per_block([1, bn as u8], ScaleDtype::F32)
         .with_store(QuantStore::PackedU32(0))
         .with_value(value);
-    let scheme = match outer {
+    let scheme = match global {
         Some(_) => mint_scheme.per_tensor(ScaleDtype::F32),
         None => mint_scheme,
     };
@@ -3341,7 +3341,7 @@ fn run_register_matmul_quant_rhs(
         .untiled()
         .packed(&mint_scheme, dequant_at)
         .arange();
-    let outer_scale = outer.map(|g| {
+    let global_scale = global.map(|g| {
         TestInput::builder(client.clone(), shape![1])
             .custom(vec![g])
             .generate_without_host_data()
@@ -3361,7 +3361,7 @@ fn run_register_matmul_quant_rhs(
         .subspace(&[K, N])
         .vectorize(pack);
     let mut scales = vec![b.scales_binding()];
-    scales.extend(outer_scale.map(|g| g.binding()));
+    scales.extend(global_scale.map(|g| g.binding()));
     let b_op = b_src.quantized(&scales, scheme, dequant_at).build();
     // The register microkernel lines the accumulator at the RHS's served width.
     let c_op = launcher
@@ -3386,7 +3386,7 @@ fn run_register_matmul_quant_rhs(
     let output = HostData::from_tensor_handle(&client, c.handle(), HostDataType::F32);
     // A is arange over (m, k): a[i, p] = i·k + p.
     let sn = n / bn;
-    let g = outer.unwrap_or(1.0);
+    let g = global.unwrap_or(1.0);
     let expected: Vec<f32> = (0..m * n)
         .map(|idx| {
             let (i, j) = (idx / n, idx % n);

--- a/crates/cubek-tile/tests/tile/matmul.rs
+++ b/crates/cubek-tile/tests/tile/matmul.rs
@@ -9,7 +9,7 @@ use cubecl::{
     prelude::*,
     zspace::shape,
 };
-use cubek_quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue};
+use cubek_quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels};
 use cubek_test_utils::{
     HostData, HostDataType, TestInput, TestOutcome, TileInput, ValidationResult,
     assert_equals_approx,
@@ -1426,10 +1426,9 @@ fn cmma_matmul_quant_per_tensor_8x8x8() {
 
     let scale = 0.05f32;
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::Tensor)
+        .with_scales(ScaleLevels::tensor(QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     // A: i8 quantized, with host values to build the reference.
     let a_dtype = ElemType::from_quant_value(scheme.value);
@@ -2041,10 +2040,9 @@ fn cmma_matmul_quant_block_m_8x8x8() {
 
     let bm = 4usize; // 2 blocks along M, each 4×8; one scale each
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([bm as u8, 8]))
+        .with_scales(ScaleLevels::block([bm as u8, 8], QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     let a_dtype = ElemType::from_quant_value(scheme.value);
     let (lo, hi) = scheme.value.range();
@@ -2125,10 +2123,9 @@ fn cmma_matmul_quant_block_k_8x8x8() {
 
     let bk = 4usize; // 2 blocks along K, each 8×4; the scale changes at p = 4
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([8, bk as u8]))
+        .with_scales(ScaleLevels::block([8, bk as u8], QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     let a_dtype = ElemType::from_quant_value(scheme.value);
     let (lo, hi) = scheme.value.range();
@@ -2242,10 +2239,9 @@ fn mma_matmul_quant_until_read() {
 
     let scale = 0.05f32;
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::Tensor)
+        .with_scales(ScaleLevels::tensor(QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     let a_dtype = ElemType::from_quant_value(scheme.value);
     let (lo, hi) = scheme.value.range();
@@ -2330,10 +2326,9 @@ fn check_cmma_matmul_quant_k_walk(k: usize, schedule: Schedule) {
 
     let scale = 0.05f32;
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::Tensor)
+        .with_scales(ScaleLevels::tensor(QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     // A: i8 quantized (m×k), with host values for the reference.
     let a_dtype = ElemType::from_quant_value(scheme.value);
@@ -2425,10 +2420,9 @@ fn cmma_matmul_quant_block_m_k_walk() {
 
     // One scale per M-block, over the full K: block `[bm, k]`, scales shaped (m/bm, 1).
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([bm as u8, k as u8]))
+        .with_scales(ScaleLevels::block([bm as u8, k as u8], QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
     let scale_vals: Vec<f32> = (0..m / bm).map(|b| 0.05 * (b + 1) as f32).collect();
 
     let a_dtype = ElemType::from_quant_value(scheme.value);
@@ -2520,10 +2514,9 @@ fn cmma_matmul_quant_block_k_k_walk() {
 
     // One scale per K-block, over the full M: block `[m, bk]`, scales shaped (1, k/bk).
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([m as u8, bk as u8]))
+        .with_scales(ScaleLevels::block([m as u8, bk as u8], QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
     let scale_vals: Vec<f32> = (0..k / bk).map(|b| 0.05 * (b + 1) as f32).collect();
 
     let a_dtype = ElemType::from_quant_value(scheme.value);
@@ -2615,10 +2608,9 @@ fn cmma_matmul_quant_block_k_k_walk_vectorized() {
 
     // One scale per K-block, over the full M: block `[m, bk]`, scales shaped (1, k/bk).
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([m as u8, bk as u8]))
+        .with_scales(ScaleLevels::block([m as u8, bk as u8], QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
     let scale_vals: Vec<f32> = (0..k / bk).map(|b| 0.05 * (b + 1) as f32).collect();
 
     let a_dtype = ElemType::from_quant_value(scheme.value);
@@ -2825,10 +2817,9 @@ fn register_matmul_quant_native_block_m() {
 
     let (m, n, k, bm) = (8usize, 8usize, 8usize, 4usize);
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([bm as u8, k as u8]))
+        .with_scales(ScaleLevels::block([bm as u8, k as u8], QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     let a_dtype = ElemType::from_quant_value(scheme.value);
     let (lo, hi) = scheme.value.range();
@@ -2876,10 +2867,9 @@ fn register_matmul_quant_native_direct_serve() {
 
     let (m, n, k, bm) = (8usize, 8usize, 8usize, 4usize);
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([bm as u8, k as u8]))
+        .with_scales(ScaleLevels::block([bm as u8, k as u8], QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     let a_dtype = ElemType::from_quant_value(scheme.value);
     let (lo, hi) = scheme.value.range();
@@ -2934,10 +2924,9 @@ fn run_register_matmul_quant_packed(
     bm: usize,
 ) {
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([bm as u8, k as u8]))
+        .with_scales(ScaleLevels::block([bm as u8, k as u8], QuantParam::F32))
         .with_store(QuantStore::PackedU32(0))
-        .with_value(value)
-        .with_param(QuantParam::F32);
+        .with_value(value);
     let pack = scheme.num_quants();
 
     let max_width = client.properties().hardware.max_vector_size;
@@ -3279,10 +3268,9 @@ fn register_matmul_quant_rhs_two_level_staged_dequantized_smem() {
 fn quant_until_read_refused_by_a_cmma_leaf() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([1, 4]))
+        .with_scales(ScaleLevels::block([1, 4], QuantParam::F32))
         .with_store(QuantStore::PackedU32(0))
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
     let leaf = Leaf::Cmma;
     let plan = Tiling::new()
         .extents(&[(M, 8), (N, 8), (K, 8)])
@@ -3325,12 +3313,13 @@ fn run_register_matmul_quant_rhs(
     // The data is minted against the one-level scheme either way: a two-level tensor holds the
     // same value and block-scale bytes, plus the global in its own binding.
     let mint_scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([1, bn as u8]))
+        .with_scales(ScaleLevels::block([1, bn as u8], QuantParam::F32))
         .with_store(QuantStore::PackedU32(0))
-        .with_value(value)
-        .with_param(QuantParam::F32);
+        .with_value(value);
     let scheme = match global {
-        Some(_) => mint_scheme.with_level(QuantLevel::block_tensor([1, bn as u8], QuantParam::F32)),
+        Some(_) => mint_scheme.with_scales(
+            ScaleLevels::block([1, bn as u8], QuantParam::F32).and_tensor(QuantParam::F32),
+        ),
         None => mint_scheme,
     };
     let pack = scheme.num_quants();
@@ -3423,4 +3412,3 @@ fn run_register_matmul_quant_rhs(
         .as_test_outcome()
         .enforce()
 }
-

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -8,7 +8,7 @@ use cubek_test_utils::{
     ValidationResult, assert_equals_approx,
 };
 use cubek_tile::{
-    Axis, Cut, DequantAt, QuantTileArg, QuantTileArgLaunch, Schedule, Space, TileArg,
+    Axis, CubeAxis, Cut, DequantAt, QuantTileArg, QuantTileArgLaunch, Schedule, Space, TileArg,
     TileArgLaunch, TileSpec, Tiling, WalkOrder,
 };
 
@@ -36,6 +36,48 @@ fn copy_non_quantized_matches_reference() {
         output.arg(),
         space,
         dtype,
+    );
+
+    let input_host = HostData::from_tensor_handle(&client, input.handle(), HostDataType::F32);
+    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    assert_equals_approx(&got, &input_host, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// The op walks the levels that hand regions to different cubes and stops at the plane level,
+/// which the transport spreads over the cube itself. Stepping the plane level would leave every
+/// plane but the first unwritten, since the fill indexes by the flat unit.
+#[test]
+fn copy_spread_across_cubes_and_planes_matches_reference() {
+    let (m, n) = (4, 512);
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = Tiling::new()
+        .extents(&[(M, m), (N, n)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(M, Cut::cube(CubeAxis::Y, 1))
+                .axis(N, Cut::cube(CubeAxis::X, 128))
+        })
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(M, Cut::sequential(1)).axis(N, Cut::plane(32))
+        })
+        .build()
+        .launcher_over(&client, &[]);
+    let space = launch.space().clone();
+
+    let input = TileInput::builder(&client, space.clone())
+        .untiled()
+        .arange();
+    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+
+    plain_copy::launch::<TestRuntime>(
+        &client,
+        launch.cube_count(),
+        launch.cube_dim(),
+        input.arg(),
+        output.arg(),
+        space,
+        f32::elem_type_native(),
     );
 
     let input_host = HostData::from_tensor_handle(&client, input.handle(), HostDataType::F32);
@@ -374,7 +416,7 @@ pub fn plain_copy<E: Numeric>(
 ) {
     let input = input.tile(comptime!(space.clone()));
     let mut output = output.tile(space);
-    output.copy_from(&input);
+    output.copy(&input);
 }
 
 #[cube(launch)]

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -243,7 +243,7 @@ pub fn dequant_copy<I: Numeric, O: Numeric, V: Size>(
 }
 
 /// Two-level: block scales normalized by one per-tensor scale, both folded into every read,
-/// `out == q * scale[i/bm, j/bn] * global`. The expectation carries the global, so an
+/// `out == q * scale[i/bm, j/bn] * outer`. The expectation carries the outer scale, so an
 /// implementation that drops it fails by exactly that factor.
 #[test]
 fn copy_quantized_two_level_matches_reference() {
@@ -253,19 +253,19 @@ fn copy_quantized_two_level_matches_reference() {
 }
 
 /// The mutation check on the same path: a zero per-tensor scale zeroes every reconstruction, so
-/// the global provably participates in each read rather than defaulting to one.
+/// the outer scale provably participates in each read rather than defaulting to one.
 #[test]
-fn copy_quantized_two_level_zero_global_zeroes_output() {
+fn copy_quantized_two_level_zero_outer_scale_zeroes_output() {
     run_quantized_two_level(8, 8, 4, 4, 0.0);
 }
 
-/// A two-level scheme with no global binding is refused by the builder, host-side and on the
+/// A two-level scheme with no outer binding is refused by the builder, host-side and on the
 /// caller's thread: a missing per-tensor scale would otherwise reconstruct every value short by
 /// that factor. (The kernel-side backstop in `QuantTileArg::tile` cannot be pinned here: it fires
 /// on the compile server, where a panic is swallowed rather than propagated.)
 #[test]
 #[should_panic(expected = "takes as many scale bindings")]
-fn two_level_without_global_refused_by_the_builder() {
+fn two_level_without_outer_scale_refused_by_the_builder() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let (m, n) = (8, 8);
     let scheme = two_level_scheme(4, 4);
@@ -284,7 +284,7 @@ fn two_level_without_global_refused_by_the_builder() {
     launcher
         .arg(input.binding())
         .subspace(&[M, N])
-        .quantized(scales.binding().into_tensor_arg(), scheme, DequantAt::Read)
+        .quantized(&[scales.binding()], scheme, DequantAt::Read)
         .build();
 }
 
@@ -298,8 +298,8 @@ fn two_level_scheme(bm: usize, bn: usize) -> QuantScheme {
 }
 
 /// [`run_quantized_block`] with a two-level scheme: the same block grid, its scales normalized
-/// by `global`, bound as a third 1-element tensor.
-fn run_quantized_two_level(m: usize, n: usize, bm: usize, bn: usize, global: f32) {
+/// by `outer`, bound as a third 1-element tensor.
+fn run_quantized_two_level(m: usize, n: usize, bm: usize, bn: usize, outer: f32) {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
         TestOutcome::Validated(ValidationResult::Skipped(
@@ -333,8 +333,8 @@ fn run_quantized_two_level(m: usize, n: usize, bm: usize, bn: usize, global: f32
     let scales = TestInput::builder(client.clone(), Shape::from(vec![sm, sn]))
         .custom(scale_vals.clone())
         .generate_without_host_data();
-    let global_scale = TestInput::builder(client.clone(), Shape::from(vec![1usize]))
-        .custom(vec![global])
+    let outer_scale = TestInput::builder(client.clone(), Shape::from(vec![1usize]))
+        .custom(vec![outer])
         .generate_without_host_data();
 
     let out_dtype = f32::elem_type_native();
@@ -346,7 +346,7 @@ fn run_quantized_two_level(m: usize, n: usize, bm: usize, bn: usize, global: f32
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
-            Some(linear_view(global_scale.binding())).into(),
+            Some(linear_view(outer_scale.binding())).into(),
             TileSpec::direct(&[M, N]),
             scheme,
             DequantAt::Read,
@@ -364,7 +364,7 @@ fn run_quantized_two_level(m: usize, n: usize, bm: usize, bn: usize, global: f32
                 .iter_indices()
                 .map(|idx| {
                     let scale = scale_vals[(idx[0] / bm) * sn + (idx[1] / bn)];
-                    input_host.get_f32(&idx) * scale * global
+                    input_host.get_f32(&idx) * scale * outer
                 })
                 .collect(),
         ),

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -243,7 +243,7 @@ pub fn dequant_copy<I: Numeric, O: Numeric, V: Size>(
 }
 
 /// Two-level: block scales normalized by one per-tensor scale, both folded into every read,
-/// `out == q * scale[i/bm, j/bn] * outer`. The expectation carries the outer scale, so an
+/// `out == q * scale[i/bm, j/bn] * global`. The expectation carries the global scale, so an
 /// implementation that drops it fails by exactly that factor.
 #[test]
 fn copy_quantized_two_level_matches_reference() {
@@ -251,24 +251,24 @@ fn copy_quantized_two_level_matches_reference() {
     run_quantized_block(16, 8, 4, 4, Some(0.25));
     run_quantized_block(6, 8, 4, 4, Some(0.5)); // M's last block is half-filled: masked overhang
     // The whole window fits inside one block: `QuantInfo::uniform()` holds, so this exercises
-    // `uniform_scale()`'s outer-scale fold instead of `new_with_outer_scale`'s per-position one.
+    // `uniform_scale()`'s global-scale fold instead of `new_with_global_scale`'s per-position one.
     run_quantized_block(4, 4, 4, 4, Some(0.5));
 }
 
 /// The mutation check on the same path: a zero per-tensor scale zeroes every reconstruction, so
-/// the outer scale provably participates in each read rather than defaulting to one.
+/// the global scale provably participates in each read rather than defaulting to one.
 #[test]
-fn copy_quantized_two_level_zero_outer_scale_zeroes_output() {
+fn copy_quantized_two_level_zero_global_scale_zeroes_output() {
     run_quantized_block(8, 8, 4, 4, Some(0.0));
 }
 
-/// A two-level scheme with no outer binding is refused by the builder, host-side and on the
+/// A two-level scheme with no global binding is refused by the builder, host-side and on the
 /// caller's thread: a missing per-tensor scale would otherwise reconstruct every value short by
 /// that factor. (The kernel-side backstop in `QuantTileArg::tile` cannot be pinned here: it fires
 /// on the compile server, where a panic is swallowed rather than propagated.)
 #[test]
 #[should_panic(expected = "takes as many scale bindings")]
-fn two_level_without_outer_scale_refused_by_the_builder() {
+fn two_level_without_global_scale_refused_by_the_builder() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let (m, n) = (8, 8);
     let scheme = two_level_scheme(4, 4);
@@ -300,10 +300,10 @@ fn two_level_scheme(bm: usize, bn: usize) -> QuantScheme {
 }
 
 /// Copy a `bm×bn` block-scaled Q8S input and check each element used its own block's scale:
-/// `out == q * scale[i/bm, j/bn]`, or with `outer` set (two-level), `out == q * scale[..] *
-/// outer`, the outer scale bound as a third 1-element tensor. The space tiles into block-sized
+/// `out == q * scale[i/bm, j/bn]`, or with `global` set (two-level), `out == q * scale[..] *
+/// global`, the global scale bound as a third 1-element tensor. The space tiles into block-sized
 /// leaves, so a tensor that doesn't fill its last block overhangs it.
-fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, outer: Option<f32>) {
+fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, global: Option<f32>) {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
         TestOutcome::Validated(ValidationResult::Skipped(
@@ -317,7 +317,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, outer: Option<f
         .per_block([bm as u8, bn as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
-    let scheme = match outer {
+    let scheme = match global {
         Some(_) => block_scheme.per_tensor(ScaleDtype::F32),
         None => block_scheme,
     };
@@ -347,7 +347,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, outer: Option<f
     let scales = TestInput::builder(client.clone(), Shape::from(vec![sm, sn]))
         .custom(scale_vals.clone())
         .generate_without_host_data();
-    let outer_scale = outer.map(|g| {
+    let global_scale = global.map(|g| {
         TestInput::builder(client.clone(), Shape::from(vec![1usize]))
             .custom(vec![g])
             .generate_without_host_data()
@@ -362,7 +362,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, outer: Option<f
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
-            outer_scale.map(|g| linear_view(g.binding())).into(),
+            global_scale.map(|g| linear_view(g.binding())).into(),
             TileSpec::direct(&[M, N]),
             scheme,
             DequantAt::Read,
@@ -374,7 +374,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, outer: Option<f
     );
 
     let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
-    let g = outer.unwrap_or(1.0);
+    let g = global.unwrap_or(1.0);
     let expected = HostData {
         data: HostDataVec::F32(
             input_host

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -120,11 +120,11 @@ fn copy_quantized_per_tensor_matches_reference() {
 /// live values (and their scales) intact, not that the overhang itself is suppressed.
 #[test]
 fn copy_quantized_block_matches_reference() {
-    run_quantized_block(8, 8, 4, 4); // square 2×2 grid of blocks
-    run_quantized_block(8, 8, 8, 4); // blocks along N only (per-column-group)
-    run_quantized_block(8, 8, 4, 8); // blocks along M only (per-row-group)
-    run_quantized_block(16, 8, 4, 4); // non-square tensor, 4×2 grid
-    run_quantized_block(6, 8, 4, 4); // M's last block is half-filled: the overhang is masked
+    run_quantized_block(8, 8, 4, 4, None); // square 2×2 grid of blocks
+    run_quantized_block(8, 8, 8, 4, None); // blocks along N only (per-column-group)
+    run_quantized_block(8, 8, 4, 8, None); // blocks along M only (per-row-group)
+    run_quantized_block(16, 8, 4, 4, None); // non-square tensor, 4×2 grid
+    run_quantized_block(6, 8, 4, 4, None); // M's last block is half-filled: the overhang is masked
 }
 
 /// Packed-u32 block-quantized: the buffer holds `num_quants` values per `u32`, which the view
@@ -247,16 +247,19 @@ pub fn dequant_copy<I: Numeric, O: Numeric, V: Size>(
 /// implementation that drops it fails by exactly that factor.
 #[test]
 fn copy_quantized_two_level_matches_reference() {
-    run_quantized_two_level(8, 8, 4, 4, 0.5);
-    run_quantized_two_level(16, 8, 4, 4, 0.25);
-    run_quantized_two_level(6, 8, 4, 4, 0.5); // M's last block is half-filled: masked overhang
+    run_quantized_block(8, 8, 4, 4, Some(0.5));
+    run_quantized_block(16, 8, 4, 4, Some(0.25));
+    run_quantized_block(6, 8, 4, 4, Some(0.5)); // M's last block is half-filled: masked overhang
+    // The whole window fits inside one block: `QuantInfo::uniform()` holds, so this exercises
+    // `uniform_scale()`'s outer-scale fold instead of `new_with_outer_scale`'s per-position one.
+    run_quantized_block(4, 4, 4, 4, Some(0.5));
 }
 
 /// The mutation check on the same path: a zero per-tensor scale zeroes every reconstruction, so
 /// the outer scale provably participates in each read rather than defaulting to one.
 #[test]
 fn copy_quantized_two_level_zero_outer_scale_zeroes_output() {
-    run_quantized_two_level(8, 8, 4, 4, 0.0);
+    run_quantized_block(8, 8, 4, 4, Some(0.0));
 }
 
 /// A two-level scheme with no outer binding is refused by the builder, host-side and on the
@@ -296,89 +299,11 @@ fn two_level_scheme(bm: usize, bn: usize) -> QuantScheme {
         .with_value(QuantValue::Q8S)
 }
 
-/// [`run_quantized_block`] with a two-level scheme: the same block grid, its scales normalized
-/// by `outer`, bound as a third 1-element tensor.
-fn run_quantized_two_level(m: usize, n: usize, bm: usize, bn: usize, outer: f32) {
-    let client = <TestRuntime as Runtime>::client(&Default::default());
-    if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
-        TestOutcome::Validated(ValidationResult::Skipped(
-            "backend has no native i8".to_string(),
-        ))
-        .enforce();
-        return;
-    }
-
-    let scheme = two_level_scheme(bm, bn);
-
-    let shape = Shape::from(vec![m, n]);
-    let input_dtype = ElemType::from_quant_value(scheme.value);
-    let (lo, hi) = scheme.value.range();
-    let (input, input_host) = TestInput::builder(client.clone(), shape.clone())
-        .dtype(input_dtype)
-        .uniform(0x1, lo, hi)
-        .generate_with_f32_host_data();
-
-    let space = Tiling::new()
-        .extents(&[(M, m), (N, n)])
-        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
-            l.axis(M, Cut::sequential(bm)).axis(N, Cut::sequential(bn))
-        })
-        .build();
-    let check = !m.is_multiple_of(bm) || !n.is_multiple_of(bn);
-    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
-
-    let (sm, sn) = (m.div_ceil(bm), n.div_ceil(bn));
-    let scale_vals: Vec<f32> = (0..sm * sn).map(|k| 0.05 * (k + 1) as f32).collect();
-    let scales = TestInput::builder(client.clone(), Shape::from(vec![sm, sn]))
-        .custom(scale_vals.clone())
-        .generate_without_host_data();
-    let outer_scale = TestInput::builder(client.clone(), Shape::from(vec![1usize]))
-        .custom(vec![outer])
-        .generate_without_host_data();
-
-    let out_dtype = f32::elem_type_native();
-    dequant_copy::launch::<TestRuntime>(
-        &client,
-        CubeCount::new_single(),
-        CubeDim::new_single(),
-        1,
-        QuantTileArgLaunch::new(
-            input.binding().into_tensor_arg(),
-            scales.binding().into_tensor_arg(),
-            Some(linear_view(outer_scale.binding())).into(),
-            TileSpec::direct(&[M, N]),
-            scheme,
-            DequantAt::Read,
-        ),
-        TileArgLaunch::new(output.tensor_arg(1), output.spec().checked(check)),
-        space,
-        input_dtype,
-        out_dtype,
-    );
-
-    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
-    let expected = HostData {
-        data: HostDataVec::F32(
-            input_host
-                .iter_indices()
-                .map(|idx| {
-                    let scale = scale_vals[(idx[0] / bm) * sn + (idx[1] / bn)];
-                    input_host.get_f32(&idx) * scale * outer
-                })
-                .collect(),
-        ),
-        strides: StridedLayout::RowMajor.compute_strides(&shape),
-        shape,
-    };
-    assert_equals_approx(&got, &expected, 1e-6)
-        .as_test_outcome()
-        .enforce();
-}
-
 /// Copy a `bm×bn` block-scaled Q8S input and check each element used its own block's scale:
-/// `out == q * scale[i/bm, j/bn]`. The space tiles into block-sized leaves, so a tensor that
-/// doesn't fill its last block overhangs it.
-fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize) {
+/// `out == q * scale[i/bm, j/bn]`, or with `outer` set (two-level), `out == q * scale[..] *
+/// outer`, the outer scale bound as a third 1-element tensor. The space tiles into block-sized
+/// leaves, so a tensor that doesn't fill its last block overhangs it.
+fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, outer: Option<f32>) {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
         TestOutcome::Validated(ValidationResult::Skipped(
@@ -388,10 +313,14 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize) {
         return;
     }
 
-    let scheme = QuantScheme::default()
+    let block_scheme = QuantScheme::default()
         .per_block([bm as u8, bn as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
+    let scheme = match outer {
+        Some(_) => block_scheme.per_tensor(ScaleDtype::F32),
+        None => block_scheme,
+    };
 
     let shape = Shape::from(vec![m, n]);
     let input_dtype = ElemType::from_quant_value(scheme.value);
@@ -418,6 +347,11 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize) {
     let scales = TestInput::builder(client.clone(), Shape::from(vec![sm, sn]))
         .custom(scale_vals.clone())
         .generate_without_host_data();
+    let outer_scale = outer.map(|g| {
+        TestInput::builder(client.clone(), Shape::from(vec![1usize]))
+            .custom(vec![g])
+            .generate_without_host_data()
+    });
 
     let out_dtype = f32::elem_type_native();
     dequant_copy::launch::<TestRuntime>(
@@ -428,7 +362,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize) {
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
-            None.into(),
+            outer_scale.map(|g| linear_view(g.binding())).into(),
             TileSpec::direct(&[M, N]),
             scheme,
             DequantAt::Read,
@@ -440,13 +374,14 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize) {
     );
 
     let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    let g = outer.unwrap_or(1.0);
     let expected = HostData {
         data: HostDataVec::F32(
             input_host
                 .iter_indices()
                 .map(|idx| {
                     let scale = scale_vals[(idx[0] / bm) * sn + (idx[1] / bn)];
-                    input_host.get_f32(&idx) * scale
+                    input_host.get_f32(&idx) * scale * g
                 })
                 .collect(),
         ),

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -84,6 +84,7 @@ fn copy_quantized_per_tensor_matches_reference() {
         CubeCount::new_single(),
         CubeDim::new_single(),
         1,
+        1,
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
@@ -104,6 +105,154 @@ fn copy_quantized_per_tensor_matches_reference() {
             input_host
                 .iter_indices()
                 .map(|idx| input_host.get_f32(&idx) * scale)
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// Per-tensor native Q8S served in 4-wide lines, through the builder: one full block covers
+/// every line, so nothing can straddle a scale and the vectorized operand is accepted.
+#[test]
+fn copy_quantized_per_tensor_vectorized_matches_reference() {
+    let (m, n, v) = (8, 8, 4);
+    let scale = 0.05f32;
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
+        TestOutcome::Validated(ValidationResult::Skipped(
+            "backend has no native i8".to_string(),
+        ))
+        .enforce();
+        return;
+    }
+    let max_width = client.properties().hardware.max_vector_size;
+    if v > max_width {
+        TestOutcome::Validated(ValidationResult::Skipped(format!(
+            "device vectors cap at {max_width}, below the {v}-wide served line"
+        )))
+        .enforce();
+        return;
+    }
+
+    let scheme = QuantScheme::default()
+        .per_tensor(ScaleDtype::F32)
+        .with_store(QuantStore::Native)
+        .with_value(QuantValue::Q8S);
+
+    let shape = Shape::from(vec![m, n]);
+    let input_dtype = ElemType::from_quant_value(scheme.value);
+    let (lo, hi) = scheme.value.range();
+    let (input, input_host) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .uniform(0x1, lo, hi)
+        .generate_with_f32_host_data();
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![1usize]))
+        .custom(vec![scale])
+        .generate_without_host_data();
+
+    let space = Space::new(&[(M, m), (N, n)]);
+    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+
+    let launcher = space.launcher_over(&client, &[]);
+    let input_op = launcher
+        .arg(input.binding())
+        .subspace(&[M, N])
+        .vectorize(v)
+        .quantized(&[scales.binding()], scheme, DequantAt::Read)
+        .build();
+
+    let out_dtype = f32::elem_type_native();
+    dequant_copy::launch::<TestRuntime>(
+        &client,
+        launcher.cube_count(),
+        launcher.cube_dim(),
+        input_op.bound_width(),
+        v,
+        input_op.arg(),
+        output.arg(),
+        launcher.space().clone(),
+        input_dtype,
+        out_dtype,
+    );
+
+    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            input_host
+                .iter_indices()
+                .map(|idx| input_host.get_f32(&idx) * scale)
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
+/// Per-tensor packed-u32 Q8S, through the builder: one full block covers whole `pack`-wide
+/// lines. The binding is a `u32`, so this runs on every backend, no native i8 needed.
+#[test]
+fn copy_quantized_per_tensor_packed_matches_reference() {
+    let (m, n) = (8, 8);
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+
+    let scheme = QuantScheme::default()
+        .per_tensor(ScaleDtype::F32)
+        .with_store(QuantStore::PackedU32(0))
+        .with_value(QuantValue::Q8S);
+    let pack = scheme.num_quants();
+
+    let max_width = client.properties().hardware.max_vector_size;
+    if pack > max_width {
+        TestOutcome::Validated(ValidationResult::Skipped(format!(
+            "device vectors cap at {max_width}, below the packing factor ({pack})"
+        )))
+        .enforce();
+        return;
+    }
+
+    let space = Space::new(&[(M, m), (N, n)]);
+    let input = TileInput::builder(&client, space.clone())
+        .untiled()
+        .packed(&scheme, DequantAt::Read)
+        .arange();
+    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+
+    let launcher = space.launcher_over(&client, &[]);
+    let input_op = launcher
+        .arg(input.tile.handle().binding())
+        .subspace(&[M, N])
+        .vectorize(pack)
+        .quantized(&[input.scales_binding()], scheme, DequantAt::Read)
+        .build();
+
+    let input_dtype = u32::elem_type_native();
+    let out_dtype = f32::elem_type_native();
+    dequant_copy::launch::<TestRuntime>(
+        &client,
+        launcher.cube_count(),
+        launcher.cube_dim(),
+        input_op.bound_width(),
+        pack,
+        input_op.arg(),
+        output.arg(),
+        launcher.space().clone(),
+        input_dtype,
+        out_dtype,
+    );
+
+    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    let shape = Shape::from(vec![m, n]);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            (0..m * n)
+                .map(|k| input.q[k] as f32 * input.scale_values[0])
                 .collect(),
         ),
         strides: StridedLayout::RowMajor.compute_strides(&shape),
@@ -186,6 +335,7 @@ fn run_quantized_packed(m: usize, n: usize, value: QuantValue, bm: usize, bn: us
         &client,
         CubeCount::new_single(),
         CubeDim::new_single(),
+        1,
         pack,
         input.arg(),
         output.arg(),
@@ -229,10 +379,11 @@ pub fn plain_copy<E: Numeric>(
 
 #[cube(launch)]
 /// `I` names the binding's element only: the arg's scheme recovers the served value, so a
-/// quantized input dequantizes with nothing threaded through the body.
-pub fn dequant_copy<I: Numeric, O: Numeric, V: Size>(
-    input: &QuantTileArg<'_, I, Const<1>>,
-    output: &TileArg<'_, O, V>,
+/// quantized input dequantizes with nothing threaded through the body. `VI` is the binding
+/// width (served ÷ packing factor), `VO` the served width the copy writes at.
+pub fn dequant_copy<I: Numeric, O: Numeric, VI: Size, VO: Size>(
+    input: &QuantTileArg<'_, I, VI>,
+    output: &TileArg<'_, O, VO>,
     #[comptime] space: Space,
     #[define(I)] _input_dtype: ElemType,
     #[define(O)] _output_dtype: ElemType,
@@ -358,6 +509,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, global: Option<
         &client,
         CubeCount::new_single(),
         CubeDim::new_single(),
+        1,
         1,
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -2,7 +2,7 @@ use cubecl::{
     TestRuntime, features::TypeUsage, ir::ElemType, prelude::*,
     std::tensor::layout::linear::linear_view, zspace::Shape,
 };
-use cubek_quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels};
+use cubek_quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype};
 use cubek_test_utils::{
     HostData, HostDataType, HostDataVec, StridedLayout, TestInput, TestOutcome, TileInput,
     ValidationResult, assert_equals_approx,
@@ -60,7 +60,7 @@ fn copy_quantized_per_tensor_matches_reference() {
     }
 
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::tensor(QuantParam::F32))
+        .per_tensor(ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 
@@ -157,7 +157,7 @@ fn run_quantized_packed(m: usize, n: usize, value: QuantValue, bm: usize, bn: us
     let client = <TestRuntime as Runtime>::client(&Default::default());
 
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([bm as u8, bn as u8], QuantParam::F32))
+        .per_block([bm as u8, bn as u8], ScaleDtype::F32)
         .with_store(QuantStore::PackedU32(0))
         .with_value(value);
     let pack = scheme.num_quants();
@@ -290,9 +290,8 @@ fn two_level_without_outer_scale_refused_by_the_builder() {
 
 fn two_level_scheme(bm: usize, bn: usize) -> QuantScheme {
     QuantScheme::default()
-        .with_scales(
-            ScaleLevels::block([bm as u8, bn as u8], QuantParam::F32).and_tensor(QuantParam::F32),
-        )
+        .per_block([bm as u8, bn as u8], ScaleDtype::F32)
+        .per_tensor(ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S)
 }
@@ -390,7 +389,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize) {
     }
 
     let scheme = QuantScheme::default()
-        .with_scales(ScaleLevels::block([bm as u8, bn as u8], QuantParam::F32))
+        .per_block([bm as u8, bn as u8], ScaleDtype::F32)
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S);
 

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -1,4 +1,7 @@
-use cubecl::{TestRuntime, features::TypeUsage, ir::ElemType, prelude::*, zspace::Shape};
+use cubecl::{
+    TestRuntime, features::TypeUsage, ir::ElemType, prelude::*,
+    std::tensor::layout::linear::linear_view, zspace::Shape,
+};
 use cubek_quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue};
 use cubek_test_utils::{
     HostData, HostDataType, HostDataVec, StridedLayout, TestInput, TestOutcome, TileInput,
@@ -85,6 +88,7 @@ fn copy_quantized_per_tensor_matches_reference() {
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, N]),
             scheme,
             DequantAt::Read,
@@ -240,6 +244,142 @@ pub fn dequant_copy<I: Numeric, O: Numeric, V: Size>(
     output.copy_from(&input);
 }
 
+/// Two-level: block scales normalized by one per-tensor scale, both folded into every read,
+/// `out == q * scale[i/bm, j/bn] * global`. The expectation carries the global, so an
+/// implementation that drops it fails by exactly that factor.
+#[test]
+fn copy_quantized_two_level_matches_reference() {
+    run_quantized_two_level(8, 8, 4, 4, 0.5);
+    run_quantized_two_level(16, 8, 4, 4, 0.25);
+    run_quantized_two_level(6, 8, 4, 4, 0.5); // M's last block is half-filled: masked overhang
+}
+
+/// The mutation check on the same path: a zero per-tensor scale zeroes every reconstruction, so
+/// the global provably participates in each read rather than defaulting to one.
+#[test]
+fn copy_quantized_two_level_zero_global_zeroes_output() {
+    run_quantized_two_level(8, 8, 4, 4, 0.0);
+}
+
+/// A two-level scheme with no global binding is refused by the builder, host-side and on the
+/// caller's thread: a missing per-tensor scale would otherwise reconstruct every value short by
+/// that factor. (The kernel-side backstop in `QuantTileArg::tile` cannot be pinned here: it fires
+/// on the compile server, where a panic is swallowed rather than propagated.)
+#[test]
+#[should_panic(expected = "takes a per-tensor scale")]
+fn two_level_without_global_refused_by_the_builder() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let (m, n) = (8, 8);
+    let scheme = two_level_scheme(4, 4);
+    let shape = Shape::from(vec![m, n]);
+    let input_dtype = ElemType::from_quant_value(scheme.value);
+    let input = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .uniform(0x1, -8.0, 7.0)
+        .generate_without_host_data();
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![2usize, 2]))
+        .custom(vec![1.0; 4])
+        .generate_without_host_data();
+
+    let space = Space::new(&[(M, m), (N, n)]);
+    let launcher = space.launcher(&client);
+    launcher
+        .arg(input.binding())
+        .subspace(&[M, N])
+        .quantized(scales.binding().into_tensor_arg(), scheme, DequantAt::Read)
+        .build();
+}
+
+fn two_level_scheme(bm: usize, bn: usize) -> QuantScheme {
+    QuantScheme::default()
+        .with_level(QuantLevel::block_tensor(
+            [bm as u8, bn as u8],
+            QuantParam::F32,
+        ))
+        .with_store(QuantStore::Native)
+        .with_value(QuantValue::Q8S)
+        .with_param(QuantParam::F32)
+}
+
+/// [`run_quantized_block`] with a two-level scheme: the same block grid, its scales normalized
+/// by `global`, bound as a third 1-element tensor.
+fn run_quantized_two_level(m: usize, n: usize, bm: usize, bn: usize, global: f32) {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    if !i8::supported_uses(&client).contains(TypeUsage::Conversion) {
+        TestOutcome::Validated(ValidationResult::Skipped(
+            "backend has no native i8".to_string(),
+        ))
+        .enforce();
+        return;
+    }
+
+    let scheme = two_level_scheme(bm, bn);
+
+    let shape = Shape::from(vec![m, n]);
+    let input_dtype = ElemType::from_quant_value(scheme.value);
+    let (lo, hi) = scheme.value.range();
+    let (input, input_host) = TestInput::builder(client.clone(), shape.clone())
+        .dtype(input_dtype)
+        .uniform(0x1, lo, hi)
+        .generate_with_f32_host_data();
+
+    let space = Tiling::new()
+        .extents(&[(M, m), (N, n)])
+        .level(WalkOrder::RowMajor, Schedule::Direct, |l| {
+            l.axis(M, Cut::sequential(bm)).axis(N, Cut::sequential(bn))
+        })
+        .build();
+    let check = !m.is_multiple_of(bm) || !n.is_multiple_of(bn);
+    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+
+    let (sm, sn) = (m.div_ceil(bm), n.div_ceil(bn));
+    let scale_vals: Vec<f32> = (0..sm * sn).map(|k| 0.05 * (k + 1) as f32).collect();
+    let scales = TestInput::builder(client.clone(), Shape::from(vec![sm, sn]))
+        .custom(scale_vals.clone())
+        .generate_without_host_data();
+    let global_scale = TestInput::builder(client.clone(), Shape::from(vec![1usize]))
+        .custom(vec![global])
+        .generate_without_host_data();
+
+    let out_dtype = f32::elem_type_native();
+    dequant_copy::launch::<TestRuntime>(
+        &client,
+        CubeCount::new_single(),
+        CubeDim::new_single(),
+        1,
+        QuantTileArgLaunch::new(
+            input.binding().into_tensor_arg(),
+            scales.binding().into_tensor_arg(),
+            Some(linear_view(global_scale.binding())).into(),
+            TileSpec::direct(&[M, N]),
+            scheme,
+            DequantAt::Read,
+        ),
+        TileArgLaunch::new(output.tensor_arg(1), output.spec().checked(check)),
+        space,
+        input_dtype,
+        out_dtype,
+    );
+
+    let got = HostData::from_tensor_handle(&client, output.handle(), HostDataType::F32);
+    let expected = HostData {
+        data: HostDataVec::F32(
+            input_host
+                .iter_indices()
+                .map(|idx| {
+                    let scale = scale_vals[(idx[0] / bm) * sn + (idx[1] / bn)];
+                    input_host.get_f32(&idx) * scale * global
+                })
+                .collect(),
+        ),
+        strides: StridedLayout::RowMajor.compute_strides(&shape),
+        shape,
+    };
+    assert_equals_approx(&got, &expected, 1e-6)
+        .as_test_outcome()
+        .enforce();
+}
+
 /// Copy a `bm×bn` block-scaled Q8S input and check each element used its own block's scale:
 /// `out == q * scale[i/bm, j/bn]`. The space tiles into block-sized leaves, so a tensor that
 /// doesn't fill its last block overhangs it.
@@ -294,6 +434,7 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize) {
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             TileSpec::direct(&[M, N]),
             scheme,
             DequantAt::Read,

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -2,7 +2,7 @@ use cubecl::{
     TestRuntime, features::TypeUsage, ir::ElemType, prelude::*,
     std::tensor::layout::linear::linear_view, zspace::Shape,
 };
-use cubek_quant::scheme::{QuantLevel, QuantParam, QuantScheme, QuantStore, QuantValue};
+use cubek_quant::scheme::{QuantParam, QuantScheme, QuantStore, QuantValue, ScaleLevels};
 use cubek_test_utils::{
     HostData, HostDataType, HostDataVec, StridedLayout, TestInput, TestOutcome, TileInput,
     ValidationResult, assert_equals_approx,
@@ -60,10 +60,9 @@ fn copy_quantized_per_tensor_matches_reference() {
     }
 
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::Tensor)
+        .with_scales(ScaleLevels::tensor(QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     let shape = Shape::from(vec![m, n]);
     let input_dtype = ElemType::from_quant_value(scheme.value);
@@ -158,10 +157,9 @@ fn run_quantized_packed(m: usize, n: usize, value: QuantValue, bm: usize, bn: us
     let client = <TestRuntime as Runtime>::client(&Default::default());
 
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([bm as u8, bn as u8]))
+        .with_scales(ScaleLevels::block([bm as u8, bn as u8], QuantParam::F32))
         .with_store(QuantStore::PackedU32(0))
-        .with_value(value)
-        .with_param(QuantParam::F32);
+        .with_value(value);
     let pack = scheme.num_quants();
 
     let max_width = client.properties().hardware.max_vector_size;
@@ -266,7 +264,7 @@ fn copy_quantized_two_level_zero_global_zeroes_output() {
 /// that factor. (The kernel-side backstop in `QuantTileArg::tile` cannot be pinned here: it fires
 /// on the compile server, where a panic is swallowed rather than propagated.)
 #[test]
-#[should_panic(expected = "takes a per-tensor scale")]
+#[should_panic(expected = "takes as many scale bindings")]
 fn two_level_without_global_refused_by_the_builder() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     let (m, n) = (8, 8);
@@ -292,13 +290,11 @@ fn two_level_without_global_refused_by_the_builder() {
 
 fn two_level_scheme(bm: usize, bn: usize) -> QuantScheme {
     QuantScheme::default()
-        .with_level(QuantLevel::block_tensor(
-            [bm as u8, bn as u8],
-            QuantParam::F32,
-        ))
+        .with_scales(
+            ScaleLevels::block([bm as u8, bn as u8], QuantParam::F32).and_tensor(QuantParam::F32),
+        )
         .with_store(QuantStore::Native)
         .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32)
 }
 
 /// [`run_quantized_block`] with a two-level scheme: the same block grid, its scales normalized
@@ -394,10 +390,9 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize) {
     }
 
     let scheme = QuantScheme::default()
-        .with_level(QuantLevel::block([bm as u8, bn as u8]))
+        .with_scales(ScaleLevels::block([bm as u8, bn as u8], QuantParam::F32))
         .with_store(QuantStore::Native)
-        .with_value(QuantValue::Q8S)
-        .with_param(QuantParam::F32);
+        .with_value(QuantValue::Q8S);
 
     let shape = Shape::from(vec![m, n]);
     let input_dtype = ElemType::from_quant_value(scheme.value);


### PR DESCRIPTION
A dequantize kernel built on the tile engine: it plans its geometry host-side and its body is one `Tile::copy`, since the input tile serves the output element and decodes on read. Stacked on #501.

Not wired into `dequantize::launch_ref`. Nothing routes to it yet, on purpose: it becomes a real path once it is fully implemented and tested.

## What changed

- The launch picks the widest served line that tiles the innermost extent, rides contiguous strides, covers whole packed `u32` words and sits inside one scale block. It then picks a cube tile edge, and a plane cut when one raises the cube's unit count without straddling a scale block.
- The kernel only walks what was proven sound: a vectorized plan never overhangs, and every edge either tiles whole scale blocks or sits inside one.
- Serves native and innermost-packed stores, one or two scale levels, with the packed binding re-declared from storage words to the values they hold.

## Testing

Unit tests for the width and geometry choices, and device tests over the schemes it serves plus the shapes and strides that fall back. 8 tiled tests and 10 unit tests pass; tile quant tests 38 passed.
