### PR TITLE
Read a spanning operand at the accumulator cell, and restore the build

### DIFF
--- a/crates/cubek-tile/src/microkernel/contract/gather.rs
+++ b/crates/cubek-tile/src/microkernel/contract/gather.rs
@@ -8,6 +8,14 @@ use crate::*;
 
 /// N-D variant of [`direct::contract`](super::direct::contract) for operations with
 /// multiple contracted axes or projected operands.
+///
+/// The outer product it runs is an optimization, not the definition of the contraction: it holds
+/// only while the lhs is free of the accumulator's column and the rhs free of its row, which is
+/// what lets one read of each serve a whole row or column of cells. A resampling operand breaks
+/// that: the gather makes the value depend on the output position, and a procedural weight
+/// depends on it too, so an operand spanning the other's free axis is read at the cell instead,
+/// and the rank-1 update degenerates to a per-cell `fma`. Only the reads change; what is
+/// contracted, and the accumulator block living in registers across `kc`, do not.
 #[cube]
 pub(super) fn contract<
     E: Numeric,
@@ -43,8 +51,20 @@ pub(super) fn contract<
     let reduce_extents = comptime!(reduce.iter().map(|&a| merged.extent(a)).collect::<Vec<_>>());
     let kc = comptime!(reduce_extents.iter().product::<usize>());
 
+    // Whether either operand varies along the axis the outer product assumes it is free of.
+    // `rhs_spans_col` separates an rhs that merely varies down the rows, and so still holds for a
+    // whole row of cells, from one that varies cell by cell.
+    let lhs_spans_col = comptime!(lhs.space.contains(space.axis_at(rank - 1)));
+    let rhs_spans_row = comptime!(rhs.space.contains(space.axis_at(rank - 2)));
+    let rhs_spans_col = comptime!(rhs.space.contains(space.axis_at(rank - 1)));
+
     comptime!(assert_operand_shapes(
-        &lhs.space, &rhs.space, &space, &reduce
+        &lhs.space,
+        &rhs.space,
+        &space,
+        &reduce,
+        vw,
+        lhs_spans_col
     ));
 
     let lhs_view = lhs.nd::<IL, WPL, L>();
@@ -82,7 +102,8 @@ pub(super) fn contract<
 
         // One rhs line per accumulator column, reused by every row of the rank-1 update. Held
         // across the whole K walk rather than re-declared per step, so the trace allocates it once
-        // however many lane bodies the fan-out below emits.
+        // however many lane bodies the fan-out below emits. An rhs varying down the rows has no
+        // such per-column value, and leaves this unwritten for the trace to fold away.
         let mut b = Array::<Vector<E, V>>::new(nr);
 
         if comptime!(lane_fanout && lw > 1) {
@@ -107,6 +128,9 @@ pub(super) fn contract<
                         comptime!(rhs.space.clone()),
                         lw,
                         vw,
+                        lhs_spans_col,
+                        rhs_spans_row,
+                        rhs_spans_col,
                     );
                 }
             }
@@ -130,6 +154,9 @@ pub(super) fn contract<
                     comptime!(rhs.space.clone()),
                     lw,
                     vw,
+                    lhs_spans_col,
+                    rhs_spans_row,
+                    rhs_spans_col,
                 );
             }
         } else {
@@ -155,6 +182,9 @@ pub(super) fn contract<
                     comptime!(rhs.space.clone()),
                     lw,
                     vw,
+                    lhs_spans_col,
+                    rhs_spans_row,
+                    rhs_spans_col,
                 );
             }
         }
@@ -166,6 +196,10 @@ pub(super) fn contract<
 /// One gathered rank-1 update. `lane` names the component to take when the caller walks `K` as
 /// (line, lane), so shader backends see a fixed `extract`; `None` is the flat walk, which resolves
 /// the component from `p` instead.
+///
+/// The span flags say which operand reads hoist out of the cell loop: each read is taken at the
+/// coarsest cell the operand is invariant over, so the plain outer product still reads one lhs
+/// per row and one rhs per column.
 #[cube]
 #[allow(clippy::too_many_arguments)]
 fn rank1_update<E: Numeric, EL: Numeric, L: Size, ER: Numeric, V: Size>(
@@ -186,47 +220,148 @@ fn rank1_update<E: Numeric, EL: Numeric, L: Size, ER: Numeric, V: Size>(
     #[comptime] rhs_space: Space,
     #[comptime] lw: usize,
     #[comptime] vw: usize,
+    #[comptime] lhs_spans_col: bool,
+    #[comptime] rhs_spans_row: bool,
+    #[comptime] rhs_spans_col: bool,
 ) {
     let reduce_coords = unravel(&const_coords(reduce_extents), p.fcast::<u32>());
 
-    #[unroll(unroll)]
-    for n in 0..nr {
-        let acc_coords = acc_cell_coords(batch, 0u32, n as u32);
-        let pos = resolve_nd_coords(
-            comptime!(rhs_space.clone()),
-            comptime!(space.clone()),
-            comptime!(reduce.clone()),
-            &acc_coords,
-            &reduce_coords,
-            vw,
-            false,
-        );
-        b[n] = Vector::<E, V>::cast_from(rhs_view.read(pos));
+    // An rhs free of the row holds for every row, so its `nr` lines are read once here and reused
+    // down the `i` loop.
+    if comptime!(!rhs_spans_row) {
+        #[unroll(unroll)]
+        for n in 0..nr {
+            b[n] = Vector::<E, V>::cast_from(cell_read::<ER, V>(
+                rhs_view,
+                batch,
+                0u32,
+                n as u32,
+                &reduce_coords,
+                comptime!(rhs_space.clone()),
+                comptime!(space.clone()),
+                comptime!(reduce.clone()),
+                vw,
+            ));
+        }
     }
     #[unroll(unroll)]
     for i in 0..mr {
-        let acc_coords = acc_cell_coords(batch, i as u32, 0u32);
-        // `resolve_nd_coords` divides the fastest contracted coordinate by `lw` into a line index,
-        // so this is the same position for every lane of one line.
-        let pos = resolve_nd_coords(
-            comptime!(lhs_space.clone()),
-            comptime!(space.clone()),
-            comptime!(reduce.clone()),
-            &acc_coords,
-            &reduce_coords,
-            lw,
-            false,
-        );
-        let lhs_line = lhs_view.read(pos);
-        let a = if comptime!(lane.is_some()) {
-            Vector::<E, V>::cast_from(lhs_line.extract(comptime!(lane.unwrap())))
-        } else {
-            Vector::<E, V>::cast_from(lhs_line.extract_dynamic(p % lw))
-        };
+        // Whatever is invariant across the row's cells is read once here. Each stays at zero, and
+        // folds away, when the cell loop reads that operand for itself.
+        let mut a_row = Vector::<E, V>::cast_from(E::from_int(0));
+        if comptime!(!lhs_spans_col) {
+            // `resolve_nd_coords` divides the fastest contracted coordinate by `lw` into a line
+            // index, so this is the same position for every lane of one line.
+            let line = cell_read::<EL, L>(
+                lhs_view,
+                batch,
+                i as u32,
+                0u32,
+                &reduce_coords,
+                comptime!(lhs_space.clone()),
+                comptime!(space.clone()),
+                comptime!(reduce.clone()),
+                lw,
+            );
+            a_row = lane_component::<E, EL, L, V>(line, p, lane, lw);
+        }
+        let mut b_row = Vector::<E, V>::cast_from(E::from_int(0));
+        if comptime!(rhs_spans_row && !rhs_spans_col) {
+            b_row = Vector::<E, V>::cast_from(cell_read::<ER, V>(
+                rhs_view,
+                batch,
+                i as u32,
+                0u32,
+                &reduce_coords,
+                comptime!(rhs_space.clone()),
+                comptime!(space.clone()),
+                comptime!(reduce.clone()),
+                vw,
+            ));
+        }
         #[unroll(unroll)]
         for n in 0..nr {
-            c[i * nr + n] = fma(a, b[n], c[i * nr + n]);
+            let a = if comptime!(lhs_spans_col) {
+                let line = cell_read::<EL, L>(
+                    lhs_view,
+                    batch,
+                    i as u32,
+                    n as u32,
+                    &reduce_coords,
+                    comptime!(lhs_space.clone()),
+                    comptime!(space.clone()),
+                    comptime!(reduce.clone()),
+                    lw,
+                );
+                lane_component::<E, EL, L, V>(line, p, lane, lw)
+            } else {
+                a_row
+            };
+            let v = if comptime!(!rhs_spans_row) {
+                b[n]
+            } else if comptime!(!rhs_spans_col) {
+                b_row
+            } else {
+                Vector::<E, V>::cast_from(cell_read::<ER, V>(
+                    rhs_view,
+                    batch,
+                    i as u32,
+                    n as u32,
+                    &reduce_coords,
+                    comptime!(rhs_space.clone()),
+                    comptime!(space.clone()),
+                    comptime!(reduce.clone()),
+                    vw,
+                ))
+            };
+            // Explicit `fma`, for the reason [`block::rank1_update`] gives.
+            c[i * nr + n] = fma(a, v, c[i * nr + n]);
         }
+    }
+}
+
+/// One operand read at the accumulator cell `(row, col)` of the batch matrix `batch` names.
+/// `width` is the operand's own line width, since only its innermost axis is addressed in lines.
+#[cube]
+fn cell_read<T: Numeric, W: Size>(
+    view: &MaskedView<'_, Vector<T, W>, CoordsDyn>,
+    batch: &Coords<u32>,
+    row: u32,
+    col: u32,
+    reduce_coords: &Coords<u32>,
+    #[comptime] operand: Space,
+    #[comptime] acc: Space,
+    #[comptime] reduce: Vec<Axis>,
+    #[comptime] width: usize,
+) -> Vector<T, W> {
+    let acc_coords = acc_cell_coords(batch, row, col);
+    let pos = resolve_nd_coords(
+        operand,
+        acc,
+        reduce,
+        &acc_coords,
+        reduce_coords,
+        width,
+        false,
+    );
+    view.read(pos)
+}
+
+/// The `K` component of one lhs line, widened into the accumulate element. Fixed when the caller
+/// walks `K` as (line, lane), resolved from `p` on the flat walk.
+#[cube]
+fn lane_component<E: Numeric, EL: Numeric, L: Size, V: Size>(
+    line: Vector<EL, L>,
+    p: usize,
+    #[comptime] lane: Option<usize>,
+    #[comptime] lw: usize,
+) -> Vector<E, V> {
+    if comptime!(lane.is_some()) {
+        Vector::<E, V>::cast_from(line.extract(comptime!(lane.unwrap())))
+    } else if comptime!(lw == 1) {
+        Vector::<E, V>::cast_from(line.extract(0usize))
+    } else {
+        Vector::<E, V>::cast_from(line.extract_dynamic(p % lw))
     }
 }
 
@@ -252,7 +387,14 @@ fn acc_cell_coords(batch: &Coords<u32>, row: u32, col: u32) -> Coords<u32> {
 /// treat one axis per operand as the vectorized one and address it in lines; if that is not the
 /// axis the operand actually lines along, the reads are silently off by the width rather than
 /// wrong in a way a test would localize. Host-side, so a violation is a comptime message.
-fn assert_operand_shapes(lhs: &Space, rhs: &Space, acc: &Space, reduce: &[Axis]) {
+fn assert_operand_shapes(
+    lhs: &Space,
+    rhs: &Space,
+    acc: &Space,
+    reduce: &[Axis],
+    rhs_vec_len: usize,
+    lhs_spans_col: bool,
+) {
     assert!(
         !reduce.is_empty(),
         "contract gather: the operands contract no axis against the accumulator"
@@ -272,8 +414,21 @@ fn assert_operand_shapes(lhs: &Space, rhs: &Space, acc: &Space, reduce: &[Axis])
         lhs.axis_at(lhs.rank() - 1) == fastest,
         "contract gather: the lhs must line along the fastest contracted axis {fastest:?}"
     );
+    // Only a vectorized rhs has to line along that axis; a scalar one is addressed in elements
+    // and so need not span it at all, which is what lets a weight shared by every column live in
+    // a space that simply omits it.
     assert!(
-        rhs.axis_at(rhs.rank() - 1) == acc.axis_at(acc.rank() - 1),
-        "contract gather: the rhs must line along the accumulator's innermost axis"
+        rhs_vec_len == 1 || rhs.axis_at(rhs.rank() - 1) == acc.axis_at(acc.rank() - 1),
+        "contract gather: a vectorized rhs must line along the accumulator's innermost axis"
+    );
+    // An lhs varying along the column is read once per cell, and a cell is `rhs_vec_len` columns
+    // wide. The lhs lines along a contracted axis, not this one, so one read cannot cover them:
+    // it would need a value per lane off an axis it does not line along, and the broadcast would
+    // silently serve the first column's value to all of them.
+    assert!(
+        !lhs_spans_col || rhs_vec_len == 1,
+        "contract gather: an lhs spanning the accumulator's innermost axis needs a value per \
+         column, so that axis cannot also be served in lines (the accumulator is {rhs_vec_len} \
+         wide)"
     );
 }

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -177,6 +177,7 @@ impl<T: Numeric> Tile<T> {
     /// element's scalar is the *stored* type — `u32` words for a packed scheme, `i8` native),
     /// the scales ride as a plain second tensor, and the comptime scheme says how reads fold
     /// them back in. The served width is the binding's width × the scheme's packing factor.
+    #[allow(clippy::too_many_arguments)]
     pub fn of_dequant<E: CubePrimitive>(
         values: &Tensor<E>,
         scales: &Tensor<f32>,

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -33,8 +33,9 @@ use crate::*;
 
 impl<T: Numeric> Tile<T> {
     /// Create a coordinate-backed tile from an arbitrary procedural recipe. The concrete recipe
-    /// is erased only while CubeCL expands this call.
-    pub fn procedural<R: Recipe<T> + 'static>(_space: Space, _recipe: R) -> Self {
+    /// is erased only while CubeCL expands this call. `leaf` is what will consume the tile, which
+    /// a recipe has no spec to carry: it is the leaf the peer operands state.
+    pub fn procedural<R: Recipe<T> + 'static>(_space: Space, _recipe: R, _leaf: Leaf) -> Self {
         unexpanded!()
     }
 
@@ -42,8 +43,9 @@ impl<T: Numeric> Tile<T> {
         scope: &Scope,
         space: Space,
         recipe: R::ExpandType,
+        leaf: Leaf,
     ) -> TileExpand<T> {
-        Self::__expand_procedural_resident::<R>(scope, space, recipe, StagePlan::in_place())
+        Self::__expand_procedural_resident::<R>(scope, space, recipe, StagePlan::in_place(), leaf)
     }
 
     /// [`procedural`](Tile::procedural) with the residences stated: a level asking for a stage
@@ -53,6 +55,7 @@ impl<T: Numeric> Tile<T> {
         _space: Space,
         _recipe: R,
         _stage: StagePlan,
+        _leaf: Leaf,
     ) -> Self {
         unexpanded!()
     }
@@ -62,40 +65,47 @@ impl<T: Numeric> Tile<T> {
         space: Space,
         recipe: R::ExpandType,
         stage: StagePlan,
+        leaf: Leaf,
     ) -> TileExpand<T> {
         Self::__expand_procedural_virtual(
             scope,
             space,
             VirtualRecipe::<T>::__expand_new::<R>(scope, recipe),
             stage,
+            leaf,
         )
     }
 
     /// Create a coordinate-backed tile yielding constant zero.
-    pub fn zeros(_space: Space) -> Self {
+    pub fn zeros(_space: Space, _leaf: Leaf) -> Self {
         unexpanded!()
     }
 
-    pub fn __expand_zeros(scope: &Scope, space: Space) -> TileExpand<T> {
-        Self::__expand_procedural::<Zeros>(scope, space, ZerosExpand {})
+    pub fn __expand_zeros(scope: &Scope, space: Space, leaf: Leaf) -> TileExpand<T> {
+        Self::__expand_procedural::<Zeros>(scope, space, ZerosExpand {}, leaf)
     }
 
     /// Create a coordinate-backed tile yielding constant one.
-    pub fn ones(_space: Space) -> Self {
+    pub fn ones(_space: Space, _leaf: Leaf) -> Self {
         unexpanded!()
     }
 
-    pub fn __expand_ones(scope: &Scope, space: Space) -> TileExpand<T> {
-        Self::__expand_procedural::<Ones>(scope, space, OnesExpand {})
+    pub fn __expand_ones(scope: &Scope, space: Space, leaf: Leaf) -> TileExpand<T> {
+        Self::__expand_procedural::<Ones>(scope, space, OnesExpand {}, leaf)
     }
 
     /// Create a coordinate-backed tile yielding a constant value.
-    pub fn constant(_space: Space, _value: T) -> Self {
+    pub fn constant(_space: Space, _value: T, _leaf: Leaf) -> Self {
         unexpanded!()
     }
 
-    pub fn __expand_constant(scope: &Scope, space: Space, value: NativeExpand<T>) -> TileExpand<T> {
-        Self::__expand_procedural::<Constant<T>>(scope, space, ConstantExpand::<T> { value })
+    pub fn __expand_constant(
+        scope: &Scope,
+        space: Space,
+        value: NativeExpand<T>,
+        leaf: Leaf,
+    ) -> TileExpand<T> {
+        Self::__expand_procedural::<Constant<T>>(scope, space, ConstantExpand::<T> { value }, leaf)
     }
 }
 

--- a/crates/cubek-tile/tests/tile/matmul.rs
+++ b/crates/cubek-tile/tests/tile/matmul.rs
@@ -2,17 +2,17 @@
 #![allow(non_snake_case)]
 
 use cubecl::{
+    TestRuntime,
     cmma::{MatrixIdent, MatrixLayout},
     features::TypeUsage,
     ir::ElemType,
     prelude::*,
     zspace::shape,
-    TestRuntime,
 };
 use cubek_quant::scheme::{QuantScheme, QuantStore, QuantValue, ScaleDtype};
 use cubek_test_utils::{
-    assert_equals_approx, HostData, HostDataType, TestInput, TestOutcome, TileInput,
-    ValidationResult, MEMORY_LEAF,
+    HostData, HostDataType, MEMORY_LEAF, TestInput, TestOutcome, TileInput, ValidationResult,
+    assert_equals_approx,
 };
 
 use cubek_tile::*;
@@ -1832,6 +1832,7 @@ fn cmma_matmul_quant_per_tensor_8x8x8() {
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
             None.into(),
+            None.into(),
             TileSpec::direct(&[M, K], MEMORY_LEAF),
             scheme,
             DequantAt::Load,
@@ -2438,6 +2439,7 @@ fn cmma_matmul_quant_block_m_8x8x8() {
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
             None.into(),
+            None.into(),
             TileSpec::direct(&[M, K], MEMORY_LEAF),
             scheme,
             DequantAt::Load,
@@ -2520,6 +2522,7 @@ fn cmma_matmul_quant_block_k_8x8x8() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             None.into(),
             TileSpec::direct(&[M, K], MEMORY_LEAF),
             scheme,
@@ -2635,6 +2638,7 @@ fn mma_matmul_quant_until_read() {
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
             None.into(),
+            None.into(),
             TileSpec::direct(&[M, K], leaf).residence(&[Residence::Smem]),
             scheme,
             DequantAt::Read,
@@ -2723,6 +2727,7 @@ fn check_cmma_matmul_quant_k_walk(k: usize, buffering: Buffering) {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             None.into(),
             TileSpec::direct(&[M, K], leaf).residence(&[Residence::Smem]),
             scheme,
@@ -2817,6 +2822,7 @@ fn cmma_matmul_quant_block_m_k_walk() {
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
             None.into(),
+            None.into(),
             TileSpec::direct(&[M, K], leaf).residence(&[Residence::Smem]),
             scheme,
             DequantAt::Load,
@@ -2910,6 +2916,7 @@ fn cmma_matmul_quant_block_k_k_walk() {
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
             None.into(),
+            None.into(),
             TileSpec::direct(&[M, K], leaf).residence(&[Residence::Smem]),
             scheme,
             DequantAt::Load,
@@ -3002,6 +3009,7 @@ fn cmma_matmul_quant_block_k_k_walk_vectorized() {
         QuantTileArgLaunch::new(
             a_input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
             None.into(),
             TileSpec::direct(&[M, K], leaf).residence(&[Residence::Smem]),
             scheme,
@@ -3509,6 +3517,7 @@ fn run_register_matmul_quant(
         QuantTileArgLaunch::new(
             a_arg,
             scales_arg,
+            None.into(),
             None.into(),
             TileSpec::direct(&[M, K], MEMORY_LEAF).residence(residence),
             scheme,

--- a/crates/cubek-tile/tests/tile/procedural.rs
+++ b/crates/cubek-tile/tests/tile/procedural.rs
@@ -105,6 +105,7 @@ fn product_kernel<E: Float>(
             affine_along(COL, E::from_int(0), E::from_int(1)),
         ),
         stage,
+        comptime!(output.spec.leaf),
     );
     materialize(&source, output, space);
 }
@@ -117,6 +118,7 @@ fn affine_plus_phase<E: Float>(
     scale: u32,
     offset: i32,
     divisor: u32,
+    #[comptime] leaf: Leaf,
 ) -> Tile<E> {
     Tile::<E>::procedural::<Sum<AffineCoordinate<E>, Phase<E>>>(
         space,
@@ -130,6 +132,7 @@ fn affine_plus_phase<E: Float>(
                 divisor,
             },
         ),
+        leaf,
     )
 }
 
@@ -149,9 +152,16 @@ fn phase_kernel<E: Float>(
             SCALE.runtime(),
             OFFSET.runtime(),
             DIVISOR.runtime(),
+            comptime!(output.spec.leaf),
         )
     } else {
-        affine_plus_phase::<E>(comptime!(space.clone()), SCALE, OFFSET, DIVISOR)
+        affine_plus_phase::<E>(
+            comptime!(space.clone()),
+            SCALE,
+            OFFSET,
+            DIVISOR,
+            comptime!(output.spec.leaf),
+        )
     };
     materialize(&source, output, space);
 }
@@ -168,6 +178,7 @@ fn rebase_kernel<E: Float>(
             axis: ROW,
             scale: 2.0,
         },
+        comptime!(output.spec.leaf),
     );
     // The second region starts at (2, 3), so its first logical coordinate reads row 2.
     let region = Region::trailing(comptime!(space.clone()), 1usize, 1usize);
@@ -190,6 +201,7 @@ fn constant_kernel<E: Float>(
         Constant::<E> {
             value: runtime_scalar::<E>(E::new(-1.25_f32)),
         },
+        comptime!(output.spec.leaf),
     );
     materialize(&source, output, space);
 }
@@ -204,6 +216,7 @@ fn affine_kernel<E: Float>(
     let source = Tile::<E>::procedural::<AffineCoordinate<E>>(
         comptime!(space.clone()),
         along_col::<E>(offset),
+        comptime!(output.spec.leaf),
     );
     materialize(&source, output, space);
 }
@@ -222,6 +235,7 @@ fn linear_kernel<E: Float>(
             runtime_scalar::<E>(E::new(comptime!(offset.get()))),
             runtime_scalar::<E>(E::new(1.0_f32)),
         ),
+        comptime!(output.spec.leaf),
     );
     materialize(&source, output, space);
 }
@@ -242,6 +256,7 @@ fn cubic_kernel<E: Float>(
             runtime_scalar::<E>(E::new(1.0_f32)),
             a,
         ),
+        comptime!(output.spec.leaf),
     );
     materialize(&source, output, space);
 }
@@ -262,6 +277,7 @@ fn lanczos_kernel<E: Float>(
             runtime_scalar::<E>(E::new(1.0_f32)),
             lobes,
         ),
+        comptime!(output.spec.leaf),
     );
     materialize(&source, output, space);
 }
@@ -282,6 +298,7 @@ fn linear_over_axis_value_kernel<E: Float>(
                 scale: 0.5,
             },
         },
+        comptime!(output.spec.leaf),
     );
     materialize(&source, output, space);
 }
@@ -299,6 +316,7 @@ fn integer_kernel<E: Int>(
         Constant::<E> {
             value: runtime_scalar::<E>(E::new(7)),
         },
+        comptime!(output.spec.leaf),
     );
     materialize(&source, output, space);
 }
@@ -315,6 +333,7 @@ fn direct_copy_kernel<E: Float>(
         Constant::<E> {
             value: runtime_scalar::<E>(E::new(1.0_f32)),
         },
+        comptime!(output.spec.leaf),
     );
     let mut output = output.tile(space);
     output.copy_from(&source);
@@ -332,6 +351,7 @@ fn divided_direct_copy_kernel<E: Float>(
         Constant::<E> {
             value: runtime_scalar::<E>(E::new(1.0_f32)),
         },
+        comptime!(output.spec.leaf),
     );
     let region = Region::trailing(comptime!(space.clone()), 0usize, 0usize);
     let source = source.at(&region);

--- a/crates/cubek-tile/tests/tile/quant/copy.rs
+++ b/crates/cubek-tile/tests/tile/quant/copy.rs
@@ -136,10 +136,9 @@ fn copy_quantized_per_tensor_matches_reference() {
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
+            None.into(),
+            None.into(),
             TileSpec::direct(&[M, N], MEMORY_LEAF),
-            None.into(),
-            None.into(),
-            TileSpec::direct(&[M, N]),
             scheme,
             DequantAt::Read,
         ),
@@ -205,11 +204,13 @@ fn copy_quantized_per_tensor_vectorized_matches_reference() {
         .generate_without_host_data();
 
     let space = Space::new(&[(M, m), (N, n)]);
-    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+    let output = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
+        .untiled()
+        .zeros();
 
     let launcher = space.launcher_over(&client, &[]);
     let input_op = launcher
-        .arg(input.binding())
+        .arg(input.binding(), MEMORY_LEAF)
         .subspace(&[M, N])
         .vectorize(v)
         .quantized(&[scales.binding()], scheme, DequantAt::Read)
@@ -268,15 +269,17 @@ fn copy_quantized_per_tensor_packed_matches_reference() {
     }
 
     let space = Space::new(&[(M, m), (N, n)]);
-    let input = TileInput::builder(&client, space.clone())
+    let input = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
         .untiled()
         .packed(&scheme, DequantAt::Read)
         .arange();
-    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+    let output = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
+        .untiled()
+        .zeros();
 
     let launcher = space.launcher_over(&client, &[]);
     let input_op = launcher
-        .arg(input.tile.handle().binding())
+        .arg(input.tile.handle().binding(), MEMORY_LEAF)
         .subspace(&[M, N])
         .vectorize(pack)
         .quantized(&[input.scales_binding()], scheme, DequantAt::Read)
@@ -379,11 +382,13 @@ fn copy_quantized_lookup_matches_reference() {
     ];
 
     let space = Space::new(&[(M, m), (N, n)]);
-    let input = TileInput::builder(&client, space.clone())
+    let input = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
         .untiled()
         .packed(&scheme, DequantAt::Read)
         .lookup_arange(&table);
-    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+    let output = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
+        .untiled()
+        .zeros();
 
     dequant_copy::launch::<TestRuntime>(
         &client,
@@ -444,11 +449,13 @@ fn run_quantized_subword(m: usize, n: usize, value: QuantValue, bm: usize, bn: u
     assert!(w < pack && pack.is_multiple_of(w));
 
     let space = Space::new(&[(M, m), (N, n)]);
-    let input = TileInput::builder(&client, space.clone())
+    let input = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
         .untiled()
         .packed(&scheme, DequantAt::Load)
         .arange();
-    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+    let output = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
+        .untiled()
+        .zeros();
 
     dequant_copy::launch::<TestRuntime>(
         &client,
@@ -502,11 +509,13 @@ fn copy_quantized_subword_lookup_matches_reference() {
     ];
 
     let space = Space::new(&[(M, m), (N, n)]);
-    let input = TileInput::builder(&client, space.clone())
+    let input = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
         .untiled()
         .packed(&scheme, DequantAt::Load)
         .lookup_arange(&table);
-    let output = TileInput::builder(&client, space.clone()).untiled().zeros();
+    let output = TileInput::builder(&client, space.clone(), MEMORY_LEAF)
+        .untiled()
+        .zeros();
 
     dequant_copy::launch::<TestRuntime>(
         &client,
@@ -684,7 +693,7 @@ fn two_level_without_global_scale_refused_by_the_builder() {
     let space = Space::new(&[(M, m), (N, n)]);
     let launcher = space.launcher(&client);
     launcher
-        .arg(input.binding())
+        .arg(input.binding(), MEMORY_LEAF)
         .subspace(&[M, N])
         .quantized(&[scales.binding()], scheme, DequantAt::Read)
         .build();
@@ -764,10 +773,9 @@ fn run_quantized_block(m: usize, n: usize, bm: usize, bn: usize, global: Option<
         QuantTileArgLaunch::new(
             input.binding().into_tensor_arg(),
             scales.binding().into_tensor_arg(),
-            TileSpec::direct(&[M, N], MEMORY_LEAF),
             global_scale.map(|g| linear_view(g.binding())).into(),
             None.into(),
-            TileSpec::direct(&[M, N]),
+            TileSpec::direct(&[M, N], MEMORY_LEAF),
             scheme,
             DequantAt::Read,
         ),

--- a/crates/cubek-tile/tests/tile/reduce.rs
+++ b/crates/cubek-tile/tests/tile/reduce.rs
@@ -98,6 +98,7 @@ fn procedural_reduce_kernel<E: Float>(
             axis: K,
         },
         stage,
+        comptime!(output.spec.leaf),
     );
     let mut output = output.tile(space);
     reduce_body(&input, &mut output, comptime!(LeafOp::Max));


### PR DESCRIPTION
Two things, kept as separate commits.

## Restoring the build

`main` does not compile. Three unfinished refactors:

- **`Tile::procedural_virtual` (blocks the whole crate).** It gained a `leaf` parameter in #508, when `Leaf::Memory` stopped being a unit variant and started carrying a `MemoryMmaConfig`, but the public constructors it is reached through were never given one. `procedural`, `procedural_resident`, `zeros`, `ones` and `constant` now state the leaf, the way every other operand states it. A recipe has no spec to carry one, so it takes the leaf its peer operands already name (`comptime!(output.spec.leaf)` at every call site). A hardcoded default cannot stand in: the config is never read off an operand, only off an accumulator, but the variant is.
- **The quant lookup table (#509)** added a field to `QuantTileArg` that nine `QuantTileArgLaunch::new` calls in the matmul tests never passed.
- **A merge in the quant copy tests** left one spec argument stranded ahead of the global and table scales, with a second, leafless one behind them, plus stale `TileInput::builder` / `launcher.arg` calls from before those grew their `Leaf`.

Also silences the too-many-arguments lint on `MemData::of_dequant`, which fails the `-D warnings` gate, and formats the matmul tests' import block, which is the one file `cargo fmt --check` rejects on `main`.

## Reading a spanning operand at the accumulator cell

The gather nest's outer product is an optimization, not the definition of the contraction: one lhs read serves a whole row and one rhs read a whole column only while the lhs is free of the accumulator's column and the rhs free of its row. A resampling operand breaks that. The gather makes its value depend on the output position, and a procedural weight depends on it too, so a gemv-shaped contraction could not be expressed at all: the rhs assert demanded every rhs line along the accumulator's innermost axis, which a weight shared by every channel does not span.

Each operand's read is now taken at the coarsest cell it is invariant over, chosen by three comptime flags off the operand spaces. An operand free of the other's axis reads exactly as before; one that spans it is read per cell instead, and the rank-1 update degenerates to a per-cell `fma`. What is contracted, and the accumulator block living in registers across `kc`, do not change.

The rhs now has to line along the accumulator's innermost axis only when it is vectorized, since a scalar rhs is addressed in elements and need not span that axis at all. An lhs spanning it, though, needs a value per column off an axis it does not line along, so that case requires a scalar rhs rather than silently broadcasting the first column's value.

`cell_read` folds the coordinate assembly the five read sites share; `lane_component` folds the fixed-lane versus dynamic extract, and picks up the `lw == 1` case the flat walk was missing.
