### PR TITLE
Give each coordinate axis its own boundary mode

### DIFF
--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -112,7 +112,9 @@ impl TileSpec {
         self.with_boundary(check.then_some(Boundary::Zero))
     }
 
-    /// Set the optional boundary handling mode for out-of-bounds access.
+    /// Set one boundary handling mode for out-of-bounds access on every coordinate axis. Flattens
+    /// whatever per-axis list [`boundaries`](Self::boundaries) may have set, so sequence the
+    /// per-axis call after this one, not before it.
     pub fn with_boundary(mut self, boundary: Option<Boundary>) -> Self {
         let coord_rank = self.projection.coordinate_rank();
         self.boundaries = match boundary {
@@ -124,7 +126,17 @@ impl TileSpec {
 
     /// State the boundary mode for every coordinate axis. An all-`None` list collapses to the
     /// empty one, so "nothing is checked" has a single representation whichever setter minted it.
+    /// The list is shaped over [`coordinate_rank`](Projection::coordinate_rank), not the buffer's
+    /// physical rank, which storage tiling splits into grid and tile fragments no
+    /// [`Window`](crate::Window) ever addresses.
     pub fn boundaries(mut self, boundaries: &[Option<Boundary>]) -> Self {
+        let coord_rank = self.projection.coordinate_rank();
+        assert!(
+            boundaries.len() == coord_rank,
+            "TileSpec::boundaries: {} modes stated but the operand has {coord_rank} coordinate \
+             axes",
+            boundaries.len()
+        );
         self.boundaries = match boundaries.iter().any(Option::is_some) {
             true => SmallVec::from_slice(boundaries),
             false => SmallVec::new(),

--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -24,9 +24,9 @@ use crate::*;
 pub struct TileSpec {
     /// How this operand's logical axes address its buffer's physical ones.
     pub projection: Projection,
-    /// How out-of-bounds reads/writes are handled (`None` keeps the unchecked divisible fast path;
-    /// `Some(Boundary::Zero)` returns zero on reads / skips writes; `Some(Boundary::Clamp)` clamps).
-    pub boundary: Option<Boundary>,
+    /// How each coordinate axis handles out-of-bounds access. `None` is the unchecked fast path;
+    /// an empty list means every axis is unchecked.
+    pub boundaries: SmallVec<[Option<Boundary>; MAX_AXES]>,
     /// The launch's cube size (units per cube), `0` when unknown; carried into the
     /// [`StagePlan`](crate::StagePlan) of every stage derived from this operand.
     pub units: usize,
@@ -48,7 +48,7 @@ pub struct TileSpec {
 impl TileSpec {
     /// An operand's spec from its mapping and its leaf; the optional halves are the safe defaults
     /// (unchecked, cube size unknown, nothing staged) and are set by
-    /// [`boundary`](Self::boundary), [`checked`](Self::checked), [`units`](Self::units),
+    /// [`with_boundary`](Self::with_boundary), [`checked`](Self::checked), [`units`](Self::units),
     /// [`storage`](Self::storage), and [`residence`](Self::residence).
     ///
     /// [`Projection::validate`] is not run here: its innermost-identity rule turns on the served
@@ -57,7 +57,7 @@ impl TileSpec {
     pub fn new(projection: Projection, leaf: Leaf) -> Self {
         TileSpec {
             projection,
-            boundary: None,
+            boundaries: SmallVec::new(),
             units: 0,
             storage: None,
             residence: SmallVec::new(),
@@ -108,20 +108,33 @@ impl TileSpec {
     /// whatever mode was set before it, so a `with_boundary(Some(Boundary::Clamp))` before this
     /// call is silently dropped back to `Zero`. Sequence a `Clamp` override after `checked`, not
     /// before it.
-    pub fn checked(mut self, check: bool) -> Self {
-        self.boundary = if check { Some(Boundary::Zero) } else { None };
-        self
+    pub fn checked(self, check: bool) -> Self {
+        self.with_boundary(check.then_some(Boundary::Zero))
     }
 
     /// Set the optional boundary handling mode for out-of-bounds access.
     pub fn with_boundary(mut self, boundary: Option<Boundary>) -> Self {
-        self.boundary = boundary;
+        let coord_rank = self.projection.coordinate_rank();
+        self.boundaries = match boundary {
+            Some(b) => SmallVec::from_elem(Some(b), coord_rank),
+            None => SmallVec::new(),
+        };
+        self
+    }
+
+    /// State the boundary mode for every coordinate axis. An all-`None` list collapses to the
+    /// empty one, so "nothing is checked" has a single representation whichever setter minted it.
+    pub fn boundaries(mut self, boundaries: &[Option<Boundary>]) -> Self {
+        self.boundaries = match boundaries.iter().any(Option::is_some) {
+            true => SmallVec::from_slice(boundaries),
+            false => SmallVec::new(),
+        };
         self
     }
 
     /// Whether this operand has bounds checking enabled.
     pub fn is_checked(&self) -> bool {
-        self.boundary.is_some()
+        self.boundaries.iter().any(Option::is_some)
     }
 
     /// Set the launch's cube size (units per cube).

--- a/crates/cubek-tile/src/physical/projection/base.rs
+++ b/crates/cubek-tile/src/physical/projection/base.rs
@@ -83,6 +83,15 @@ impl Projection {
         Projection::new(&self.axes, &physical)
     }
 
+    /// How many coordinates address this operand: its physical axes with each storage-tiled
+    /// axis's fragments folded back into the one coordinate they are digits of. This is the rank
+    /// every [`Window`](crate::Window) is shaped over, and so the rank of a
+    /// [`TileSpec`](crate::TileSpec)'s boundary list; [`physical_rank`](Self::physical_rank) is
+    /// the buffer's own, which is larger under storage tiling.
+    pub fn coordinate_rank(&self) -> usize {
+        self.carried_groups().len()
+    }
+
     /// The same buffer addressed by physical position instead of by this operand's own axes: each
     /// physical axis relabeled with the synthetic [`Axis`] of the coordinate that addresses it, at
     /// coefficient `1`. Storage tiling survives (a tiled axis's fragments share one label, which is

--- a/crates/cubek-tile/src/physical/projection/map.rs
+++ b/crates/cubek-tile/src/physical/projection/map.rs
@@ -344,19 +344,26 @@ impl PhysicalAxisMap {
             .map_or(0, |t| t.scale.get())
     }
 
+    /// The one [`Axis`] this map is the identity of, `None` when it combines several, scales,
+    /// shifts or divides. An identity map reaches exactly as far as its own coordinate, which is
+    /// what lets a caller prove it stays inside the buffer; anything else reaches further.
+    pub fn identity_axis(&self) -> Option<Axis> {
+        match self.terms.as_slice() {
+            [
+                AxisTerm {
+                    axis,
+                    scale: Scale::Static(1),
+                },
+            ] if self.offset == Offset::Static(0) && self.divisor.is_unit() => Some(*axis),
+            _ => None,
+        }
+    }
+
     /// Whether this physical axis is exactly `axis` at coefficient `1` with zero offset and no
     /// division. Says nothing about digit extraction, which is a property of the whole
     /// [`Projection`](crate::Projection) (how many physical axes carry `axis`), not of one map.
     pub fn is_identity(&self, axis: Axis) -> bool {
-        self.offset == Offset::Static(0)
-            && self.divisor.is_unit()
-            && matches!(
-                self.terms.as_slice(),
-                [AxisTerm {
-                    axis: a,
-                    scale: Scale::Static(1)
-                }] if *a == axis
-            )
+        self.identity_axis() == Some(axis)
     }
 }
 

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -450,14 +450,39 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
             None => Some(Boundary::Zero),
         });
 
-        // Bounds-checked operands cannot be vectorized.
-        assert!(
-            !(boundary.is_some() && v > 1),
-            "StridedTileSource: a bounds-checked operand cannot be vectorized; serve it scalar or \
-             state `checked(false)` if the launch proves every access in bounds"
-        );
-        // Validate projection vector width alignment on the host side.
         projection.validate(v);
+        let coords = projection.untiled();
+        let coord_rank = projection.coordinate_rank();
+
+        // Whether coordinate axis `pa` is inside the buffer by construction. Only an identity map
+        // can be: it reaches exactly as far as its own coordinate, so it stays inside whenever its
+        // tiling divides. An affine map reaches further than any axis extent describes, and how
+        // far is the caller's to size the buffer for, which is the trust the derivation above
+        // already runs on; no proof here can retire its policy.
+        let settled = |pa: usize| match coords.physical_axis(pa).identity_axis() {
+            Some(axis) => {
+                concrete.is_some_and(|space| !space.contains(axis) || !space.overhangs(axis))
+            }
+            None => false,
+        };
+
+        // A vector line only needs a scalar fallback when its own innermost axis can overhang.
+        // Other coordinate axes may still be masked or clamped independently (NHWC interpolation
+        // clamps H/W while serving a contiguous C line).
+        let innermost_overhangs = !settled(coord_rank - 1);
+        assert!(
+            !(boundary.is_some() && v > 1 && innermost_overhangs),
+            "StridedTileSource: the innermost axis is served in vector lines but can overhang; \
+             serve it scalar or \
+             state `checked(false)` if the launch proves its vector lines are in bounds"
+        );
+
+        // The mode covers the coordinate axes that can leave the buffer, and only those: a settled
+        // axis would pay for a mask that can never fire, and a settled *innermost* axis must be
+        // left alone outright, since a window clamps in lines and would alias the edge line.
+        let boundaries = (0..coord_rank)
+            .map(|pa| boundary.filter(|_| !settled(pa)))
+            .collect::<Vec<_>>();
 
         // Validate that explicit residences match the space's depth: extra or missing levels lead
         // to silent misconfiguration.
@@ -469,7 +494,7 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
         );
 
         let mut spec = TileSpec::new(projection, leaf)
-            .with_boundary(boundary)
+            .boundaries(&boundaries)
             .units(units)
             .residence(&residence);
         if let Some(storage) = storage {

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -167,13 +167,20 @@ impl<'a, Sp, Sub, Q, R: Runtime> StridedTileSource<'a, Sp, Sub, Q, R> {
     /// overwrites whatever mode was set before it, so a `with_boundary(Some(Boundary::Clamp))`
     /// before this call is silently dropped back to `Zero`. Sequence a `Clamp` override after
     /// `checked`, not before it.
+    ///
+    /// `checked(false)` disarms the operand outright. `checked(true)` states the *mode*, not the
+    /// axis list: [`build`](Self::build) still lands it only on the coordinate axes that can
+    /// leave the buffer, so an axis whose map is the identity of a logical axis whose tiling
+    /// divides stays unchecked whatever this says. That filtering is what lets a clamped operand
+    /// keep a vectorized innermost axis; there is no setter that masks a settled axis.
     pub fn checked(mut self, check: bool) -> Self {
         self.data.boundary = Some(if check { Some(Boundary::Zero) } else { None });
         self
     }
 
     /// Set the boundary handling mode for out-of-bounds access explicitly (`None` forces
-    /// unchecked, `Some` forces checked at that mode).
+    /// unchecked, `Some` forces checked at that mode). Like [`checked`](Self::checked), a `Some`
+    /// states the mode and [`build`](Self::build) picks the axes it lands on.
     pub fn with_boundary(mut self, boundary: Option<Boundary>) -> Self {
         self.data.boundary = Some(boundary);
         self
@@ -453,28 +460,39 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
         projection.validate(v);
         let coords = projection.untiled();
         let coord_rank = projection.coordinate_rank();
+        assert!(
+            coord_rank > 0,
+            "StridedTileSource: an operand must address at least one coordinate"
+        );
 
         // Whether coordinate axis `pa` is inside the buffer by construction. Only an identity map
         // can be: it reaches exactly as far as its own coordinate, so it stays inside whenever its
-        // tiling divides. An affine map reaches further than any axis extent describes, and how
-        // far is the caller's to size the buffer for, which is the trust the derivation above
-        // already runs on; no proof here can retire its policy.
+        // tiling divides. Its `Offset::Static(0)` is also what keeps it clear of the *underflow*
+        // half of the derivation above: a negative or `Dynamic` offset makes a map non-identity,
+        // so the axis whose origin can fall below zero is never one settled here. An affine map
+        // reaches further than any axis extent describes, and how far is the caller's to size the
+        // buffer for, which is the trust the derivation above already runs on; no proof here can
+        // retire its policy.
         let settled = |pa: usize| match coords.physical_axis(pa).identity_axis() {
+            // An axis the concrete space does not describe is unproven, not proven: the
+            // derivation above already skips it when *arming* the mode, so nothing here may use
+            // that same silence to drop one.
             Some(axis) => {
-                concrete.is_some_and(|space| !space.contains(axis) || !space.overhangs(axis))
+                concrete.is_some_and(|space| space.contains(axis) && !space.overhangs(axis))
             }
             None => false,
         };
 
-        // A vector line only needs a scalar fallback when its own innermost axis can overhang.
+        // A vector line only needs a scalar fallback when its own innermost axis is unsettled.
         // Other coordinate axes may still be masked or clamped independently (NHWC interpolation
         // clamps H/W while serving a contiguous C line).
-        let innermost_overhangs = !settled(coord_rank - 1);
+        let innermost_unsettled = !settled(coord_rank - 1);
         assert!(
-            !(boundary.is_some() && v > 1 && innermost_overhangs),
-            "StridedTileSource: the innermost axis is served in vector lines but can overhang; \
-             serve it scalar or \
-             state `checked(false)` if the launch proves its vector lines are in bounds"
+            !(boundary.is_some() && v > 1 && innermost_unsettled),
+            "StridedTileSource: the innermost axis is served in vector lines but is not provably \
+             in bounds (it overhangs its tiling, or its map is affine and reaches past any extent \
+             stated here); serve it scalar, or state `checked(false)` if the launch proves its \
+             vector lines are in bounds"
         );
 
         // The mode covers the coordinate axes that can leave the buffer, and only those: a settled

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -663,7 +663,11 @@ impl<T: Numeric> MemData<T> {
                     projection: gmem_projection,
                 },
                 // Stage origins are never negative, and smem never overhangs (`Overhang::Never`
-                // below), so the boundary policy is never consulted.
+                // below), so the boundary policy is never consulted. The empty list is the only
+                // thing it *can* be: this window is shaped over the buffer's own dims (a tiled
+                // stage's grid and tile fragments), while the sub-windows that inherit it are
+                // shaped over coordinates, so any per-axis list minted here would land on the
+                // wrong axes one level down.
                 window: Window::new(origin, extent, bound, false, comptime!(SmallVec::new())),
                 projection: comptime!(form.projection),
                 map,
@@ -1329,6 +1333,9 @@ impl<T: Numeric> MemData<T> {
     /// that is the aliasing [`matrix_mut`](MemData::matrix_mut) already refuses a gather for,
     /// arriving by a second route. Refused rather than silently raced.
     fn write_check(&self) -> comptime_type!(bool) {
+        // Whole-operand on purpose, unlike the per-axis mask below it: one clamped axis is enough
+        // to fold two distinct cells onto one, so there is no such thing as a partly writable
+        // clamped operand.
         comptime!(assert!(
             !self.window.boundaries.contains(&Some(Boundary::Clamp))
                 || !self.access.overhang.masks(),
@@ -2278,6 +2285,19 @@ impl Window {
         #[comptime] signed: bool,
         #[comptime] boundaries: SmallVec<[Option<Boundary>; MAX_AXES]>,
     ) -> Self {
+        // Both walks index `origin`, `pos` and `boundaries` by one counter, so a rank slip there
+        // would silently apply one axis's mode to another rather than fail. `bound` is left out:
+        // a sub-window inherits its parent's, which on a stage is the buffer's own rank (a tiled
+        // stage's fragments) rather than the coordinate rank the origin is at.
+        let origin_rank = origin.len();
+        let extent_rank = extent.len();
+        comptime!(assert!(
+            extent_rank == origin_rank
+                && (boundaries.is_empty() || boundaries.len() == origin_rank),
+            "Window: origin ({origin_rank}), extent ({extent_rank}) and boundaries ({}) index the \
+             same axes and must agree in rank",
+            boundaries.len()
+        ));
         Window {
             origin,
             extent,
@@ -2343,8 +2363,10 @@ impl Layout for Window {
 
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
         let mut valid = true;
+        // `origin`, not `bound`: the two share a rank on every window a mode can reach, and this
+        // is the one `pos` and `boundaries` are indexed by.
         #[unroll]
-        for i in 0..self.bound.len() {
+        for i in 0..self.origin.len() {
             if comptime!(self.boundaries.get(i).copied().flatten() == Some(Boundary::Zero)) {
                 let abs = self.origin.at(i).fadd(pos[i].fcast::<i32>());
                 let inside = if comptime!(self.signed) {

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -1,6 +1,7 @@
 //! The addressable backing store ([`MemData`], gmem and smem): its layouts, windows, and
 //! the memory-side [`Tile`] operations (construction, views, the cooperative copy).
 
+use cubecl::zspace::SmallVec;
 use cubecl::{
     prelude::*,
     quant::scheme::{QuantScheme, QuantStore, QuantValue},
@@ -281,13 +282,18 @@ impl<T: Numeric> Tile<T> {
         // The operand's own contract, checked here rather than at `TileSpec` construction because
         // it turns on the served width, which only this call, not the spec, ever knows.
         comptime!(projection.validate(vector_size));
-        // A window clamps in *lines*, so the cell it folds onto is the edge *element* only when a
-        // line is one element. `StridedTileSource::realize` refuses a checked vectorized operand
-        // already; this catches the hand-built spec, which never passes through it.
+        let coord_rank = comptime!(projection.coordinate_rank());
         comptime!(assert!(
-            spec.boundary != Some(Boundary::Clamp) || vector_size == 1,
-            "Tile::of: Boundary::Clamp needs a scalar operand, the window clamps to a line index \
-             (served at {vector_size})"
+            spec.boundaries.is_empty() || spec.boundaries.len() == coord_rank,
+            "Tile::of: boundaries rank ({}) does not match coordinate rank ({coord_rank})",
+            spec.boundaries.len()
+        ));
+        // A clamped vector line is only valid if the innermost coordinate axis is not clamped. The
+        // source builder derives that per-axis mask; this catches hand-built specs too.
+        comptime!(assert!(
+            vector_size == 1 || spec.boundaries.last().copied().flatten() != Some(Boundary::Clamp),
+            "Tile::of: Boundary::Clamp cannot clamp the vectorized innermost axis (served at \
+             {vector_size})"
         ));
         // Off the projection, not the space: a gathered operand's buffer has fewer physical axes
         // than its logical space has axes, and a storage-tiled one has more.
@@ -355,7 +361,7 @@ impl<T: Numeric> Tile<T> {
                     extent,
                     bound,
                     comptime!(coords.may_underflow()),
-                    comptime!(spec.boundary.unwrap_or(Boundary::Zero)),
+                    comptime!(spec.boundaries.clone()),
                 ),
                 projection: comptime!(coords),
                 map,
@@ -363,9 +369,10 @@ impl<T: Numeric> Tile<T> {
                 window_start: 0u32,
                 access: comptime!(Access {
                     whole: true,
-                    overhang: match spec.boundary {
-                        None => Overhang::Fits,
-                        Some(Boundary::Zero) | Some(Boundary::Clamp) => Overhang::Masked,
+                    overhang: if spec.is_checked() {
+                        Overhang::Masked
+                    } else {
+                        Overhang::Fits
                     },
                     stage,
                 }),
@@ -657,7 +664,7 @@ impl<T: Numeric> MemData<T> {
                 },
                 // Stage origins are never negative, and smem never overhangs (`Overhang::Never`
                 // below), so the boundary policy is never consulted.
-                window: Window::new(origin, extent, bound, false, Boundary::Zero),
+                window: Window::new(origin, extent, bound, false, comptime!(SmallVec::new())),
                 projection: comptime!(form.projection),
                 map,
                 offsets: Coords::<i32>::new(),
@@ -1323,7 +1330,8 @@ impl<T: Numeric> MemData<T> {
     /// arriving by a second route. Refused rather than silently raced.
     fn write_check(&self) -> comptime_type!(bool) {
         comptime!(assert!(
-            self.window.boundary != Boundary::Clamp || !self.access.overhang.masks(),
+            !self.window.boundaries.contains(&Some(Boundary::Clamp))
+                || !self.access.overhang.masks(),
             "MemData: a Boundary::Clamp operand is read-only, a clamped write aliases the edge cell"
         ));
         comptime!(self.access.overhang.masks())
@@ -1661,7 +1669,7 @@ impl<T: Numeric> MemData<T> {
                 extent,
                 self.window.bound.clone(),
                 comptime!(self.window.signed),
-                comptime!(self.window.boundary),
+                comptime!(self.window.boundaries.clone()),
             ),
             // How the logical axes address the physical ones is a fact about the buffer, invariant
             // down the descent. The offsets only placed the top window, which `origin` above
@@ -2255,10 +2263,10 @@ pub struct Window {
     /// Whether the origin can be negative.
     #[cube(comptime)]
     pub(crate) signed: bool,
-    /// How a coordinate past `bound` is handled. Only consulted when this window's
-    /// [`Access::overhang`](crate::Access::overhang) masks; harmless otherwise.
+    /// Per-coordinate-axis boundary handling, same rank as `bound`. `None` means that axis is in
+    /// bounds by construction; an empty list makes every axis `None`.
     #[cube(comptime)]
-    pub(crate) boundary: Boundary,
+    pub(crate) boundaries: SmallVec<[Option<Boundary>; MAX_AXES]>,
 }
 
 #[cube]
@@ -2268,14 +2276,14 @@ impl Window {
         extent: Coords<u32>,
         bound: Coords<u32>,
         #[comptime] signed: bool,
-        #[comptime] boundary: Boundary,
+        #[comptime] boundaries: SmallVec<[Option<Boundary>; MAX_AXES]>,
     ) -> Self {
         Window {
             origin,
             extent,
             bound,
             signed,
-            boundary,
+            boundaries,
         }
     }
 }
@@ -2301,11 +2309,10 @@ impl Layout for Window {
             } else {
                 abs.fcast::<u32>()
             };
-            // Under `Clamp`, fold a coordinate past `bound` onto the edge cell rather than
-            // leaving it for the mask: the physical address this returns is always valid,
-            // checked or not.
-            let shifted = match comptime!(self.boundary) {
-                Boundary::Clamp => {
+            // Under `Clamp`, fold this coordinate onto its axis's edge cell rather than
+            // leaving it for the mask.
+            let shifted = match comptime!(self.boundaries.get(i).copied().flatten()) {
+                Some(Boundary::Clamp) => {
                     let bound_i = self.bound.at(i);
                     // A zero-extent axis has no edge cell to fold onto, and `bound - 1` would
                     // wrap into a wild line index; it folds to `0` like an underflow instead.
@@ -2317,7 +2324,7 @@ impl Layout for Window {
                         shifted
                     }
                 }
-                Boundary::Zero => shifted,
+                None | Some(Boundary::Zero) => shifted,
             };
             out.push(shifted);
         }
@@ -2335,28 +2342,20 @@ impl Layout for Window {
     }
 
     fn is_in_bounds(&self, pos: Self::Coordinates) -> bool {
-        match comptime!(self.boundary) {
-            // `to_source_pos` already folds an out-of-range coordinate onto a valid one, so
-            // there is nothing left to mask.
-            Boundary::Clamp => true,
-            Boundary::Zero => {
-                let mut valid = true;
-
-                // Check if the absolute coordinate is within [0, bound).
-                #[unroll]
-                for i in 0..self.bound.len() {
-                    let abs = self.origin.at(i).fadd(pos[i].fcast::<i32>());
-                    let inside = if comptime!(self.signed) {
-                        abs >= 0i32 && abs.fcast::<u32>() < self.bound.at(i)
-                    } else {
-                        abs.fcast::<u32>() < self.bound.at(i)
-                    };
-                    valid = valid && inside;
-                }
-
-                valid
+        let mut valid = true;
+        #[unroll]
+        for i in 0..self.bound.len() {
+            if comptime!(self.boundaries.get(i).copied().flatten() == Some(Boundary::Zero)) {
+                let abs = self.origin.at(i).fadd(pos[i].fcast::<i32>());
+                let inside = if comptime!(self.signed) {
+                    abs >= 0i32 && abs.fcast::<u32>() < self.bound.at(i)
+                } else {
+                    abs.fcast::<u32>() < self.bound.at(i)
+                };
+                valid = valid && inside;
             }
         }
+        valid
     }
 }
 

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -8,7 +8,7 @@ use cubecl::{
 use cubek_test_utils::MEMORY_LEAF;
 use cubek_tile::{
     Axis, Boundary, Buffering, CubeAxis, Cut, DequantAt, Divisor, Offset, PhysicalAxisMap,
-    Projection, Residence, Scale, StridedOperand, Tiling, WalkOrder,
+    Projection, Residence, Scale, StorageTiling, StridedOperand, Tiling, WalkOrder,
 };
 
 const M: Axis = Axis(0);
@@ -120,14 +120,19 @@ fn arg_derives_check_from_subspace_overhang() {
         .subspace(&[M, K])
         .build();
     assert!(touches_k.spec.is_checked());
-    assert_eq!(touches_k.spec.boundary, Some(cubek_tile::Boundary::Zero));
+    // Only the axis that overhangs carries the mask: M divides, so its coordinate is settled and
+    // masking it would cost a comparison on every access that can never fail.
+    assert_eq!(
+        touches_k.spec.boundaries.as_slice(),
+        &[None, Some(Boundary::Zero)]
+    );
 
     let avoids_k = launch
         .arg(binding(&client, &[64, 64]), MEMORY_LEAF)
         .subspace(&[M, N])
         .build();
     assert!(!avoids_k.spec.is_checked());
-    assert_eq!(avoids_k.spec.boundary, None);
+    assert!(avoids_k.spec.boundaries.is_empty());
 
     // An explicit override still wins over the derivation.
     let forced = launch
@@ -136,7 +141,32 @@ fn arg_derives_check_from_subspace_overhang() {
         .checked(false)
         .build();
     assert!(!forced.spec.is_checked());
-    assert_eq!(forced.spec.boundary, None);
+    assert!(forced.spec.boundaries.is_empty());
+}
+
+/// A storage-tiled operand is addressed by fewer coordinates than its buffer has dims, and the
+/// boundary list follows the coordinates: sized off the physical rank it would land its per-axis
+/// modes on the grid fragments, which no [`Window`] ever reads.
+#[test]
+fn arg_sizes_boundaries_by_coordinate_rank_under_storage_tiling() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    // k = 18 overhangs its leaf (4), so K's coordinate is the one that needs the mode.
+    let launch = batched_space(1, 1, 64, 64, 18).launcher(&client);
+
+    // 2 coordinate axes (M, K), tiled into 4 physical buffer dims: 4*16 = 64 and 3*6 = 18.
+    let tiled = launch
+        .arg(binding(&client, &[4, 3, 16, 6]), MEMORY_LEAF)
+        .subspace(&[M, K])
+        .tiling(StorageTiling::uniform(2, 1))
+        .with_boundary(Some(Boundary::Clamp))
+        .build();
+
+    assert_eq!(tiled.spec.projection.physical_rank(), 4);
+    assert_eq!(tiled.spec.projection.coordinate_rank(), 2);
+    assert_eq!(
+        tiled.spec.boundaries.as_slice(),
+        &[None, Some(Boundary::Clamp)]
+    );
 }
 
 #[test]
@@ -194,7 +224,7 @@ fn arg_gathered_states_its_own_mapping() {
     assert_eq!(input.spec.projection, window(1, 1, 0));
     assert_eq!(input.spec.projection.physical_rank(), 2);
     // Nothing overhangs and the origin cannot go negative, so the gather stays unchecked.
-    assert_eq!(input.spec.boundary, None);
+    assert!(input.spec.boundaries.is_empty());
 }
 
 /// An overhanging axis arms the check through the affine map just as it does through a label: the
@@ -209,7 +239,9 @@ fn arg_gathered_derives_check_from_overhang() {
         .arg(binding(&client, &[81, 64]), MEMORY_LEAF)
         .gathered(window(1, 1, 0))
         .build();
-    assert_eq!(input.spec.boundary, Some(Boundary::Zero));
+    // The gathered coordinate takes the mask; N is its own coordinate and divides, so it is
+    // settled whatever the gather does.
+    assert_eq!(input.spec.boundaries.as_slice(), &[Some(Boundary::Zero), None]);
 
     // An explicit override still wins over the derivation.
     let forced = launch
@@ -217,7 +249,7 @@ fn arg_gathered_derives_check_from_overhang() {
         .gathered(window(1, 1, 0))
         .checked(false)
         .build();
-    assert_eq!(forced.spec.boundary, None);
+    assert!(forced.spec.boundaries.is_empty());
 }
 
 /// A padded window reads before the buffer's start whatever the tiling divides, so the derivation
@@ -231,20 +263,26 @@ fn arg_gathered_derives_check_from_underflow() {
         .arg(binding(&client, &[64, 64]), MEMORY_LEAF)
         .gathered(window(1, 1, -1))
         .build();
-    assert_eq!(padded.spec.boundary, Some(Boundary::Zero));
+    assert_eq!(
+        padded.spec.boundaries.as_slice(),
+        &[Some(Boundary::Zero), None]
+    );
 
     // A runtime offset's sign is unknown at launch, so it arms the guard conservatively.
     let dynamic = launch
         .arg(binding(&client, &[64, 64]), MEMORY_LEAF)
         .gathered(window(1, 1, Offset::Dynamic))
         .build();
-    assert_eq!(dynamic.spec.boundary, Some(Boundary::Zero));
+    assert_eq!(
+        dynamic.spec.boundaries.as_slice(),
+        &[Some(Boundary::Zero), None]
+    );
 
     let shifted = launch
         .arg(binding(&client, &[96, 64]), MEMORY_LEAF)
         .gathered(window(1, 1, 1))
         .build();
-    assert_eq!(shifted.spec.boundary, None);
+    assert!(shifted.spec.boundaries.is_empty());
 }
 
 /// The stated mapping replaces the labeling whole, so a leftover `subspace` describes nothing and
@@ -496,7 +534,7 @@ fn vector_size_falls_back_to_scalar() {
 }
 
 #[test]
-#[should_panic(expected = "cannot be vectorized")]
+#[should_panic(expected = "can overhang")]
 fn arg_checked_and_vectorized_panics() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     // k = 18 overhangs its leaf, so the derived check is true: vectorizing must refuse.
@@ -506,6 +544,43 @@ fn arg_checked_and_vectorized_panics() {
         .subspace(&[M, K])
         .vectorize(4)
         .build();
+}
+
+#[test]
+fn arg_vectorized_with_outer_axis_overhang_succeeds() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    // M = 63 overhangs its leaf (8); N = 64 divides cleanly.
+    let launch = batched_space(1, 1, 63, 64, 16).launcher(&client);
+    let arg = launch
+        .arg(binding(&client, &[63, 64]), MEMORY_LEAF)
+        .subspace(&[M, N])
+        .vectorize(4)
+        .build();
+    assert!(arg.spec.is_checked());
+    // M takes the mask, N carries the lines and needs none.
+    assert_eq!(
+        arg.spec.boundaries.as_slice(),
+        &[Some(Boundary::Zero), None]
+    );
+}
+
+#[test]
+fn arg_gathered_clamp_vectorized_exemption() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let launch = batched_space(1, 1, 64, 64, 16).launcher_over(&client, &[N]);
+    // 3 logical axes [M, K, N] mapped over 2 coordinate axes:
+    // Spatial (M, K) on coordinate 0 (clamped), channel N on coordinate 1 (vectorized & in-bounds).
+    let input = launch
+        .arg(binding(&client, &[79, 64]), MEMORY_LEAF)
+        .gathered(window(1, 1, 0))
+        .vectorize(4)
+        .with_boundary(Some(Boundary::Clamp))
+        .build();
+
+    assert_eq!(
+        input.spec.boundaries.as_slice(),
+        &[Some(Boundary::Clamp), None]
+    );
 }
 
 #[test]

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -241,7 +241,10 @@ fn arg_gathered_derives_check_from_overhang() {
         .build();
     // The gathered coordinate takes the mask; N is its own coordinate and divides, so it is
     // settled whatever the gather does.
-    assert_eq!(input.spec.boundaries.as_slice(), &[Some(Boundary::Zero), None]);
+    assert_eq!(
+        input.spec.boundaries.as_slice(),
+        &[Some(Boundary::Zero), None]
+    );
 
     // An explicit override still wins over the derivation.
     let forced = launch

--- a/crates/cubek-tile/tests/tile/launcher.rs
+++ b/crates/cubek-tile/tests/tile/launcher.rs
@@ -8,7 +8,7 @@ use cubecl::{
 use cubek_test_utils::MEMORY_LEAF;
 use cubek_tile::{
     Axis, Boundary, Buffering, CubeAxis, Cut, DequantAt, Divisor, Offset, PhysicalAxisMap,
-    Projection, Residence, Scale, StorageTiling, StridedOperand, Tiling, WalkOrder,
+    Projection, Residence, Scale, StorageTiling, StridedOperand, TileSpec, Tiling, WalkOrder,
 };
 
 const M: Axis = Axis(0);
@@ -537,7 +537,7 @@ fn vector_size_falls_back_to_scalar() {
 }
 
 #[test]
-#[should_panic(expected = "can overhang")]
+#[should_panic(expected = "not provably in bounds")]
 fn arg_checked_and_vectorized_panics() {
     let client = <TestRuntime as Runtime>::client(&Default::default());
     // k = 18 overhangs its leaf, so the derived check is true: vectorizing must refuse.
@@ -565,6 +565,33 @@ fn arg_vectorized_with_outer_axis_overhang_succeeds() {
         arg.spec.boundaries.as_slice(),
         &[Some(Boundary::Zero), None]
     );
+}
+
+/// `checked(true)` states the mode, not the axis list: the per-axis derivation still keeps it off
+/// the axes that cannot leave the buffer. Only `checked(false)` disarms outright.
+#[test]
+fn arg_explicit_check_still_narrows_to_the_unsettled_axes() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    // k = 18 overhangs its leaf (4); M divides, so no override can put a mask on it.
+    let launch = batched_space(1, 1, 64, 64, 18).launcher(&client);
+
+    let forced = launch
+        .arg(binding(&client, &[64, 18]), MEMORY_LEAF)
+        .subspace(&[M, K])
+        .checked(true)
+        .build();
+    assert_eq!(
+        forced.spec.boundaries.as_slice(),
+        &[None, Some(Boundary::Zero)]
+    );
+}
+
+/// The list is shaped over coordinate axes, and the setter is where a hand-built spec should learn
+/// that: `Tile::of` would only catch it in-kernel, one comptime expansion away from the call.
+#[test]
+#[should_panic(expected = "2 coordinate axes")]
+fn tile_spec_boundaries_must_match_the_coordinate_rank() {
+    let _ = TileSpec::new(Projection::direct(&[M, N]), MEMORY_LEAF).boundaries(&[None]);
 }
 
 #[test]


### PR DESCRIPTION
A tile operand carried one `Option<Boundary>` for the whole buffer, so a bounds-checked operand could not be vectorized at all. The window clamps and masks in lines, and one shared mode cannot say "clamp H and W, serve C whole". `TileSpec` now carries one mode per coordinate axis.

The mode still arms globally, off the same overhang and underflow derivation, but it only lands on the axes that can leave the buffer. An axis whose map is the identity of a logical axis whose tiling divides is settled: nothing can push it past its bound, so it takes no mode and pays for no comparison on any access. An affine map is never settled, since it reaches further than any axis extent describes and the caller is the one who sized the buffer for it.

`is_checked` is unchanged by this, so `Overhang` and every gate below it behave as before. What changes:

- a vectorized innermost axis is refused only when it can itself overhang, instead of whenever the operand is checked
- masks stop covering axes they could never fire on, so `[M, K]` with `K` overhanging goes from `[Zero, Zero]` to `[None, Zero]`

The list is shaped over coordinate axes, not physical ones, which storage tiling splits into grid and tile fragments. `Projection::coordinate_rank` names that rank and `Tile::of` asserts the list matches it, so a hand-built spec cannot land its modes on the fragments a window never reads.
