### PR TITLE
Factor exact static tap offsets out of the rational numerator

### DIFF
--- a/crates/cubek-tile/src/physical/projection/map.rs
+++ b/crates/cubek-tile/src/physical/projection/map.rs
@@ -292,6 +292,23 @@ impl PhysicalAxisMap {
         self.divisor
     }
 
+    /// The static physical step this term contributes outside this map's rational floor, when it
+    /// can be factored exactly: `⌊(base + digit * scale) / divisor⌋` is
+    /// `⌊base / divisor⌋ + digit * (scale / divisor)` for a static `scale` a static `divisor`
+    /// divides. The per-term counterpart of [`reduced`](Self::reduced), which needs *every*
+    /// coefficient divisible and takes the divisor away with them; this leaves the divisor in
+    /// place for the terms that still need it.
+    ///
+    /// `Some` implies [`is_rational`](Self::is_rational): a unit divisor divides every coefficient
+    /// and would empty the numerator, so readers that only add these back under a division are
+    /// entitled to skip them elsewhere.
+    pub(crate) fn static_offset_step(&self, term: usize) -> Option<usize> {
+        match (self.divisor, self.terms[term].scale) {
+            (Divisor::Static(d), Scale::Static(s)) if d > 1 && s.is_multiple_of(d) => Some(s / d),
+            _ => None,
+        }
+    }
+
     /// Whether this axis divides by anything but `1`, so the plain affine sum is not the physical
     /// coordinate and every path below has to carry the division.
     pub fn is_rational(&self) -> bool {
@@ -414,6 +431,36 @@ mod tests {
         assert!(dynamic_div.divisor().is_dynamic());
         assert_eq!(dynamic_div.origin(), None);
         assert_eq!(dynamic_div.residue(), None);
+    }
+
+    /// A rational map need not reduce as a whole for some of its terms to be exact steps. This is
+    /// the resampling shape: the spatial term stays under the floor, while a tap coefficient of
+    /// the divisor advances one physical cell at a time.
+    #[test]
+    fn a_rational_map_factors_exact_static_terms_into_offsets() {
+        let map = PhysicalAxisMap::affine_with_offset(&[(A, 5), (B, 6)], -2).over(6);
+
+        assert!(map.is_rational());
+        assert_eq!(map.static_offset_step(0), None);
+        assert_eq!(map.static_offset_step(1), Some(1));
+        for output in 0..8isize {
+            for tap in 0..3isize {
+                assert_eq!(
+                    (output * 5 + tap * 6 - 2).div_euclid(6),
+                    (output * 5 - 2).div_euclid(6) + tap
+                );
+            }
+        }
+
+        let strided_tap = PhysicalAxisMap::affine(&[(A, 5), (B, 12)]).over(6);
+        assert_eq!(strided_tap.static_offset_step(1), Some(2));
+
+        let fractional_tap = PhysicalAxisMap::affine(&[(A, 5), (B, 2)]).over(3);
+        assert_eq!(fractional_tap.static_offset_step(1), None);
+
+        let dynamic_divisor =
+            PhysicalAxisMap::affine(&[(A, 5), (B, 6)]).over(Divisor::Dynamic { min: 3 });
+        assert_eq!(dynamic_divisor.static_offset_step(1), None);
     }
 
     #[test]

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -91,6 +91,13 @@ impl<L: LogicalLayout> Layout for Projected<L> {
 /// out-of-range tap does, so the window's own [`Boundary`](crate::Boundary) (zero or the edge cell)
 /// still governs the read.
 ///
+/// Static terms a static divisor divides exactly leave the numerator before the floor, which
+/// [`PhysicalAxisMap::static_offset_step`](crate::PhysicalAxisMap) decides. A resampling map
+/// `⌊(o·scale + r·divisor + residue) / divisor⌋` is read as `⌊(o·scale + residue) / divisor⌋ + r`:
+/// the spatial projection stays under the one necessary divide while taps advance by their static
+/// physical step. Callers keep spelling the whole affine map, and no projection form spells the
+/// split.
+///
 /// Constant offsets are handled by [`Window`](crate::Window) and omitted here, all but the part a
 /// window origin cannot absorb: under a division the offset sets the phase the floor starts at, and
 /// that phase, which the [`RuntimeMap`](crate::RuntimeMap) carries, has to be inside the numerator.
@@ -159,31 +166,43 @@ impl Layout for AxisProjection {
             let axis_map = comptime!(self.projection.physical_axis(pa));
             let n = comptime!(axis_map.terms().len());
 
-            // Per-term products, summed below (chained, so a single coefficient-1 term folds to
-            // the coordinate itself). Under a division the sum is the numerator, and it starts at
-            // the phase the window origin could not absorb.
+            // Per-term products left in the numerator, summed below (chained, so a single
+            // coefficient-1 term folds to the coordinate itself). Under a division the sum starts
+            // at the phase the window origin could not absorb.
             let mut terms = Coords::<u32>::new();
             if comptime!(axis_map.is_rational()) {
                 terms.push(self.map.residues.at(pa));
             }
+            // The exact terms, held apart so the numerator above is the same expression for every
+            // tap: a gather then computes one spatial floor and adds a step to it, where a single
+            // sum would put every tap's coordinate under the divide and defeat the reuse.
+            let mut offsets = Coords::<u32>::new();
             #[unroll]
             for t in 0..n {
                 let term = comptime!(axis_map.terms()[t]);
                 let p = comptime!(self.space.position(term.axis));
-                match comptime!(term.scale) {
-                    Scale::Static(s) => terms.push(pos[p].fmul(comptime!(s as u32))),
-                    Scale::Dynamic { .. } => terms.push(pos[p].fmul(self.map.coefficients.at(
-                        comptime!(self.projection.dynamic_scale_index(pa, t).unwrap()),
-                    ))),
+                match comptime!(axis_map.static_offset_step(t)) {
+                    Some(step) => offsets.push(pos[p].fmul(comptime!(step as u32))),
+                    None => match comptime!(term.scale) {
+                        Scale::Static(s) => terms.push(pos[p].fmul(comptime!(s as u32))),
+                        Scale::Dynamic { .. } => terms.push(pos[p].fmul(self.map.coefficients.at(
+                            comptime!(self.projection.dynamic_scale_index(pa, t).unwrap()),
+                        ))),
+                    },
                 }
             }
-            let sum = terms.fsum(comptime!(
-                (0..n + axis_map.is_rational() as usize).collect::<Vec<_>>()
-            ));
+            let kept = terms.len();
+            let hoisted = offsets.len();
+            let sum = terms.fsum(comptime!((0..kept).collect::<Vec<_>>()));
 
             if comptime!(axis_map.is_rational()) {
                 match comptime!(axis_map.divisor()) {
-                    Divisor::Static(d) => out.push(sum.fdiv(comptime!(d as u32))),
+                    // No offsets when the divisor is dynamic, and `fadd` folds the empty sum away,
+                    // so only the static arm spells the addition.
+                    Divisor::Static(d) => {
+                        let offset = offsets.fsum(comptime!((0..hoisted).collect::<Vec<_>>()));
+                        out.push(sum.fdiv(comptime!(d as u32)).fadd(offset));
+                    }
                     Divisor::Dynamic { .. } => {
                         let divisor = self.map.coefficients.at(comptime!(
                             self.projection.dynamic_divisor_index(pa).unwrap()

--- a/crates/cubek-tile/src/tile/view/projected.rs
+++ b/crates/cubek-tile/src/tile/view/projected.rs
@@ -191,16 +191,16 @@ impl Layout for AxisProjection {
                     },
                 }
             }
-            let kept = terms.len();
-            let hoisted = offsets.len();
-            let sum = terms.fsum(comptime!((0..kept).collect::<Vec<_>>()));
+            let n_kept = terms.len();
+            let n_exact = offsets.len();
+            let sum = terms.fsum(comptime!((0..n_kept).collect::<Vec<_>>()));
 
             if comptime!(axis_map.is_rational()) {
                 match comptime!(axis_map.divisor()) {
                     // No offsets when the divisor is dynamic, and `fadd` folds the empty sum away,
                     // so only the static arm spells the addition.
                     Divisor::Static(d) => {
-                        let offset = offsets.fsum(comptime!((0..hoisted).collect::<Vec<_>>()));
+                        let offset = offsets.fsum(comptime!((0..n_exact).collect::<Vec<_>>()));
                         out.push(sum.fdiv(comptime!(d as u32)).fadd(offset));
                     }
                     Divisor::Dynamic { .. } => {


### PR DESCRIPTION
A rational axis map put every term under its floor, so each tap of a gather rebuilt
the whole affine numerator and paid for its own divide.

A static coefficient the divisor divides exactly is not part of that floor:
`⌊(o·scale + r·divisor + residue) / divisor⌋` is `⌊(o·scale + residue) / divisor⌋ + r`.
`PhysicalAxisMap::static_offset_step` reports those terms, and `AxisProjection` sums
them after the quotient instead of inside it. The spatial numerator is then the same
expression for every tap, leaving one divide per read.

The physical coordinate is unchanged, so window sizing, compaction and the boundary
policy are untouched. Callers keep spelling the whole affine map; nothing new to spell.