### PR TITLE
chore(deps): migrate to tracel-ai/github-actions v11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,6 @@ env:
   CARGO_TERM_COLOR: always
   RUST_PREVIOUS_VERSION: 1.95.0
 
-  # Sourced from https://vulkan.lunarg.com/sdk/home#linux
-  VULKAN_SDK_VERSION: "1.3.268"
-
-  # Sourced from https://archive.mesa3d.org/. Bumping this requires
-  # updating the mesa build in https://github.com/gfx-rs/ci-build and creating a new release.
-  MESA_VERSION: "24.2.3"
-  # Corresponds to https://github.com/gfx-rs/ci-build/releases
-  MESA_CI_BINARY_BUILD: "build19"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -60,8 +51,11 @@ jobs:
           - rust: stable
             toolchain: stable
     steps:
-      - name: Setup Rust
-        uses: tracel-ai/github-actions/setup-rust@v5
+      - name: checkout
+        uses: actions/checkout@v6
+      # --------------------------------------------------------------------------------
+      - name: Install Rust
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux
@@ -83,7 +77,7 @@ jobs:
         run: cargo clippy --tests --features extended -- -D warnings
       # --------------------------------------------------------------------------------
       - name: Typos
-        uses: tracel-ai/github-actions/check-typos@v5
+        uses: tracel-ai/github-actions/check-typos@v11
 
   documentation:
     runs-on: ubuntu-24.04
@@ -95,8 +89,11 @@ jobs:
           - rust: stable
             toolchain: stable
     steps:
-      - name: Setup Rust
-        uses: tracel-ai/github-actions/setup-rust@v5
+      - name: checkout
+        uses: actions/checkout@v6
+      # --------------------------------------------------------------------------------
+      - name: Install Rust
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux
@@ -119,19 +116,21 @@ jobs:
           - rust: prev
             toolchain: ${{ needs.prepare-checks.outputs.rust-prev-version }}
     steps:
-      - name: Setup Rust
-        uses: tracel-ai/github-actions/setup-rust@v5
+      - name: checkout
+        uses: actions/checkout@v6
+      # --------------------------------------------------------------------------------
+      - name: Install Rust
+        uses: tracel-ai/github-actions/install-rust@v11
         with:
           rust-toolchain: ${{ matrix.toolchain }}
           cache-key: ${{ matrix.rust }}-linux
+          apt-packages: build-essential
       # --------------------------------------------------------------------------------
-      - name: Setup Linux runner
-        uses: tracel-ai/github-actions/setup-linux@v5
-        with:
-          apt-packages: "build-essential"
-          vulkan-sdk-version: ${{ env.VULKAN_SDK_VERSION }}
-          mesa-version: ${{ env.MESA_VERSION }}
-          mesa-ci-build-version: ${{ env.MESA_CI_BINARY_BUILD }}
+      - name: Install Mesa
+        uses: tracel-ai/github-actions/install-mesa@v11
+      # --------------------------------------------------------------------------------
+      - name: Install Vulkan SDK
+        uses: tracel-ai/github-actions/install-vulkan-sdk@v11
       # --------------------------------------------------------------------------------
       - name: Tests
         run: cargo xtask test --ci


### PR DESCRIPTION
Moves `ci.yml` off the `v5` actions onto the current layout: `install-rust`, `install-mesa`, `install-vulkan-sdk` and `check-typos` at `@v11`.

## Why

v11 bounds every apt and curl call in `tracel-ai/github-actions` (tracel-ai/github-actions#5). Canonical's `azure.archive.ubuntu.com` intermittently stops answering from GitHub runners, apt fails over to `archive.ubuntu.com`, which accepts the connection and then delivers nothing. With nothing bounding it, the step runs to GitHub's 6 hour job ceiling.

cubek lost 4 jobs that way over roughly 25 CI runs between 2026-08-17 and 2026-08-19, all in `Setup Linux runner`, plus 3 more that stalled for 20 to 25 minutes. The `v5` line was never fixed, so getting the fix means moving to the current layout. That is why this is a migration rather than the one-line bump burn and cubecl needed.

## Checkout is now explicit

`setup-rust@v5` checked out the repository as part of the action. `install-rust` does not, so every job gains an explicit `actions/checkout@v6` step. Taking v6 rather than the v4 the old action used also clears the "Node.js 20 is deprecated" warning that appeared on every run.

## The GPU stack changes, and there was no version-preserving option

`setup-linux@v5` declares `vulkan-sdk-version`, `mesa-version` and `mesa-ci-build-version` but never reads them. It adds the LunarG apt repo and runs `apt-get install -y vulkan-sdk`, while `setup-llvmpipe-lavapipe@v4` installs `mesa-vulkan-drivers` from Ubuntu. Neither is pinned. So the three env vars this PR removes were documenting versions that were never installed:

| | declared in `ci.yml` | actually installed | after this PR |
|---|---|---|---|
| Vulkan SDK | 1.3.268 | 1.4.313.0 (LunarG apt, rc builds) | 1.4.328.1 |
| mesa | 24.2.3 / build19 | 25.2.8 (Ubuntu apt) | 25.2.7 / build26 |

"Actually installed" is read off the [green run on 2026-08-19](https://github.com/tracel-ai/cubek/actions/runs/32267380697).

Matching the current versions is not possible. `install-mesa` draws from `gfx-rs/ci-build`, which publishes one mesa version per release tag: build26 is 25.2.7, build25 is 25.2.6, build27 and later are 26.x. No tag carries 25.2.8, and it is a different build lineage from Ubuntu's package regardless. So this takes the action defaults, which is the configuration cubecl already runs against the same wgpu and Vulkan tests.

## What to watch

- **This PR's CI run is the actual verification.** cubek's `linux-std-tests` genuinely exercises Vulkan on lavapipe, 894 tests with wgpu and vulkan in the logs, so the GPU stack moving under those tests is the real risk. Unlike the burn and cubecl bumps, this is not a no-op.
- Dropping `setup-linux` also drops its `swapoff` and `apt clean` disk reclamation. `install-rust` still removes dotnet, ghc and boost. cubecl runs without the extra reclamation, but cubek's build is larger, so disk pressure is the other plausible failure mode.
- The timeout changes have not run on a GitHub runner before this batch. If a mirror stalls during this run, the expected result is a red step in about 15 minutes rather than a hung job. That is the fix working.
