### PR TITLE
chore(deps): bump tracel-ai/github-actions from v8 to v11 in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   publish-cubek-random:
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-random
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -24,7 +24,7 @@ jobs:
   publish-cubek-test-utils:
     needs:
       - publish-cubek-tile
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-test-utils
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -35,7 +35,7 @@ jobs:
     needs:
       - publish-cubek-tile
       - publish-cubek-test-utils
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-quant
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -46,7 +46,7 @@ jobs:
     needs:
       - publish-cubek-test-utils
       - publish-cubek-std
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-reduce
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -60,7 +60,7 @@ jobs:
       - publish-cubek-tile
       - publish-cubek-test-utils
       - publish-cubek-std
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-matmul
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -73,7 +73,7 @@ jobs:
       - publish-cubek-matmul
       - publish-cubek-test-utils
       - publish-cubek-std
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-convolution
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -86,7 +86,7 @@ jobs:
       - publish-cubek-matmul
       - publish-cubek-test-utils
       - publish-cubek-std
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-attention
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -97,7 +97,7 @@ jobs:
     needs:
       - publish-cubek-test-utils
       - publish-cubek-std
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-fft
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -107,7 +107,7 @@ jobs:
   publish-cubek-interpolate:
     needs:
       - publish-cubek-test-utils
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-interpolate
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -117,7 +117,7 @@ jobs:
   publish-cubek-pool:
     needs:
       - publish-cubek-test-utils
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-pool
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -125,7 +125,7 @@ jobs:
       CRATES_IO_API_TOKEN: ${{ secrets.CRATES_IO_API_TOKEN }}
 
   publish-cubek-tile:
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-tile
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -135,7 +135,7 @@ jobs:
   publish-cubek-resample:
     needs:
       - publish-cubek-test-utils
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-resample
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -145,7 +145,7 @@ jobs:
   publish-cubek-std:
     needs:
       - publish-cubek-test-utils
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek-std
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}
@@ -167,7 +167,7 @@ jobs:
       - publish-cubek-tile
       - publish-cubek-test-utils
       - publish-cubek-std
-    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v8
+    uses: tracel-ai/github-actions/.github/workflows/publish-crate.yml@v11
     with:
       crate: cubek
       dry-run-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-only || false }}


### PR DESCRIPTION
Bumps the 14 `publish-crate.yml` pins in `publish.yml` from `@v8` to `@v11`.

Split out from #517 so it can be judged separately. The two PRs touch disjoint files and are independent, either can merge first.

`publish-crate.yml` did not change between v8 and v9, so this is the identical change as tracel-ai/burn#5391 and tracel-ai/cubecl#1536.

## What it does

v11's `publish-crate.yml` bounds its `apt-get update` and `apt-get install`, so a stalled Ubuntu mirror cannot hang a release job to the 6 hour ceiling. It also changes how xtask is invoked:

| | v8 | v11 |
|---|---|---|
| command | `cargo xtask publish` | `xtask publish` |
| resolves via | cubek's `.cargo/config.toml` alias | the `tracel-xtask-cli` binary |

## Why that is not a behavior change

`tracel-xtask-cli` is a **launcher**, not a reimplementation. It finds the git root, locates the local xtask crate, and runs it ([main.rs](https://github.com/tracel-ai/xtask/blob/main/crates/tracel-xtask-cli/src/main.rs)):

> The xtask crate is a real workspace member, so we can invoke it via:
> `cargo run --package <package> --bin <bin> -- ...`

That is what cubek's alias already does. Both paths execute cubek's own `xtask` crate, so the publish logic still comes from `tracel-xtask = "=4.16.0"` as pinned in the workspace and locked. The CLI's own version does not affect what publish does.

## What actually differs

- **Target directory.** The alias uses `target/xtask`; the CLI uses a persistent cache under `~/.cache/xtask/targets/`. Both are cold on a fresh runner.
- **`sync_workspace_dependencies` runs first**, and it can rewrite `Cargo.toml` files. It returns immediately when there is no `Dependencies.toml` at the git root. **cubek has none**, so this is a no-op here.
- **A new step on the release path.** The publish job now runs `cargo install tracel-xtask-cli`, unpinned. A new compile and a new network dependency, so a new place the release can fail. It fails loudly rather than publishing something wrong.

## Note on verification

`publish.yml` only triggers on release, so nothing in this PR is exercised by its own CI. The first execution would be a real publish. That is the main reason it is separate from #517.
