### PR TITLE
Define internal crates once in workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,23 @@ cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969
 # cubecl-environment = { version = "=0.11.0-pre.3", default-features = false }
 # cubecl-ir = { version = "=0.11.0-pre.3", default-features = false }
 
+### Internal cubek crates ###
+# Declared here so each consumer Cargo.toml can use `workspace = true` instead of
+# repeating the path and version.
+cubek = { path = "crates/cubek", version = "=0.3.0-pre.3", default-features = false }
+cubek-attention = { path = "crates/cubek-attention", version = "=0.3.0-pre.3", default-features = false }
+cubek-convolution = { path = "crates/cubek-convolution", version = "=0.3.0-pre.3", default-features = false }
+cubek-fft = { path = "crates/cubek-fft", version = "=0.3.0-pre.3", default-features = false }
+cubek-interpolate = { path = "crates/cubek-interpolate", version = "=0.3.0-pre.3", default-features = false }
+cubek-matmul = { path = "crates/cubek-matmul", version = "=0.3.0-pre.3", default-features = false }
+cubek-pool = { path = "crates/cubek-pool", version = "=0.3.0-pre.3", default-features = false }
+cubek-quant = { path = "crates/cubek-quant", version = "=0.3.0-pre.3", default-features = false }
+cubek-random = { path = "crates/cubek-random", version = "=0.3.0-pre.3", default-features = false }
+cubek-reduce = { path = "crates/cubek-reduce", version = "=0.3.0-pre.3", default-features = false }
+cubek-std = { path = "crates/cubek-std", version = "=0.3.0-pre.3", default-features = false }
+cubek-test-utils = { path = "crates/cubek-test-utils", version = "=0.3.0-pre.3", default-features = false }
+cubek-tile = { path = "crates/cubek-tile", version = "=0.3.0-pre.3", default-features = false }
+
 log = { default-features = false, version = "0.4.22" }
 
 serde = { version = "1.0.204", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,22 +15,6 @@ rust-version = "1.92"
 version = "0.3.0-pre.3"
 
 [workspace.dependencies]
-### For local development. ###
-# cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
-# cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
-# cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
-# cubecl-ir = { path = "../cubecl/crates/cubecl-ir", default-features = false }
-### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
-cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
-### For releases ###
-# cubecl = { version = "=0.11.0-pre.3", default-features = false }
-# cubecl-common = { version = "=0.11.0-pre.3", default-features = false }
-# cubecl-environment = { version = "=0.11.0-pre.3", default-features = false }
-# cubecl-ir = { version = "=0.11.0-pre.3", default-features = false }
-
 ### Internal cubek crates ###
 # Declared here so each consumer Cargo.toml can use `workspace = true` instead of
 # repeating the path and version.
@@ -48,6 +32,23 @@ cubek-std = { path = "crates/cubek-std", version = "=0.3.0-pre.3", default-featu
 cubek-test-utils = { path = "crates/cubek-test-utils", version = "=0.3.0-pre.3", default-features = false }
 cubek-tile = { path = "crates/cubek-tile", version = "=0.3.0-pre.3", default-features = false }
 
+### For local development. ###
+# cubecl = { path = "../cubecl/crates/cubecl", default-features = false }
+# cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
+# cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
+# cubecl-ir = { path = "../cubecl/crates/cubecl-ir", default-features = false }
+### For the main cubek branch. ###
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
+cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
+### For releases ###
+# cubecl = { version = "=0.11.0-pre.3", default-features = false }
+# cubecl-common = { version = "=0.11.0-pre.3", default-features = false }
+# cubecl-environment = { version = "=0.11.0-pre.3", default-features = false }
+# cubecl-ir = { version = "=0.11.0-pre.3", default-features = false }
+
+
 log = { default-features = false, version = "0.4.22" }
 
 serde = { version = "1.0.204", default-features = false, features = [
@@ -60,7 +61,6 @@ rand = { version = "0.10.0", default-features = false, features = [
 ] } # std_rng is for no_std
 
 # Testing
-
 bytemuck = "1.16.1"
 half = { version = "2.5", features = [
     "alloc",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,8 +32,7 @@ cpu-reference = [
 path = "src/lib.rs"
 
 [dependencies]
-cubecl = { workspace = true, features = ["test-runtime", "stdlib"] }
-cubek = { path = "../crates/cubek", version = "=0.3.0-pre.3", default-features = false, features = [
+cubek = { workspace = true, features = [
     "stdlib",
     "random",
     "reduce",
@@ -45,34 +44,18 @@ cubek = { path = "../crates/cubek", version = "=0.3.0-pre.3", default-features =
     "fft",
     "quantization",
 ] }
-cubek-attention = { path = "../crates/cubek-attention", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-convolution = { path = "../crates/cubek-convolution", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-fft = { path = "../crates/cubek-fft", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-interpolate = { path = "../crates/cubek-interpolate", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-matmul = { path = "../crates/cubek-matmul", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-pool = { path = "../crates/cubek-pool", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-random = { path = "../crates/cubek-random", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-reduce = { path = "../crates/cubek-reduce", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-std = { path = "../crates/cubek-std", version = "=0.3.0-pre.3", features = [
-    "benchmarks",
-] }
-cubek-test-utils = { path = "../crates/cubek-test-utils", version = "=0.3.0-pre.3" }
+cubek-attention = { workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-convolution = { workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-fft = {workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-interpolate = { workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-matmul = { workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-pool = { workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-random = { workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-reduce = { workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-std = { workspace = true, default-features = true, features = ["benchmarks"] }
+cubek-test-utils = { workspace = true, default-features = true }
+
+cubecl = { workspace = true, features = ["test-runtime", "stdlib"] }
 half = { workspace = true }
 
 [[bench]]

--- a/crates/cubek-attention/Cargo.toml
+++ b/crates/cubek-attention/Cargo.toml
@@ -27,17 +27,19 @@ cpu-reference = ["dep:cubek-test-utils"]
 benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 
 [dependencies]
-cubecl = { workspace = true, features = ["stdlib"] }
-cubecl-common = { workspace = true }
 cubek-matmul = { workspace = true, features = ["multi-level"] }
 cubek-std = { workspace = true }
 cubek-test-utils = { workspace = true, optional = true }
+
+cubecl = { workspace = true, features = ["stdlib"] }
+cubecl-common = { workspace = true }
 
 bytemuck = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 serde = { workspace = true }
 
 [dev-dependencies]
-cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-attention = { path = ".", features = ["benchmarks"] }
 cubek-test-utils = { workspace = true }
+
+cubecl = { workspace = true, features = ["test-runtime"] }

--- a/crates/cubek-attention/Cargo.toml
+++ b/crates/cubek-attention/Cargo.toml
@@ -29,11 +29,9 @@ benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 [dependencies]
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true }
-cubek-matmul = { path = "../cubek-matmul", version = "=0.3.0-pre.3", default-features = false, features = [
-    "multi-level",
-] }
-cubek-std = { path = "../cubek-std", version = "=0.3.0-pre.3", default-features = false }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-matmul = { workspace = true, features = ["multi-level"] }
+cubek-std = { workspace = true }
+cubek-test-utils = { workspace = true, optional = true }
 
 bytemuck = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
@@ -42,4 +40,4 @@ serde = { workspace = true }
 [dev-dependencies]
 cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-attention = { path = ".", features = ["benchmarks"] }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek-convolution/Cargo.toml
+++ b/crates/cubek-convolution/Cargo.toml
@@ -27,12 +27,10 @@ benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 [dependencies]
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true }
-cubek-matmul = { path = "../cubek-matmul", default-features = false, version = "=0.3.0-pre.3", features = [
-    "multi-level",
-] }
-cubek-std = { path = "../cubek-std", default-features = false, version = "=0.3.0-pre.3" }
-cubek-tile = { path = "../cubek-tile", version = "=0.3.0-pre.3", default-features = false }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-matmul = { workspace = true, features = ["multi-level"] }
+cubek-std = { workspace = true }
+cubek-tile = { workspace = true }
+cubek-test-utils = { workspace = true, optional = true }
 
 bytemuck = { workspace = true }
 cubecl-ir = { workspace = true }
@@ -42,4 +40,4 @@ serde = { workspace = true }
 [dev-dependencies]
 cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-convolution = { path = ".", features = ["cpu-reference"] }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek-convolution/Cargo.toml
+++ b/crates/cubek-convolution/Cargo.toml
@@ -25,12 +25,13 @@ cpu-reference = ["dep:cubek-test-utils", "cubek-matmul/cpu-reference"]
 benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 
 [dependencies]
-cubecl = { workspace = true, features = ["stdlib"] }
-cubecl-common = { workspace = true }
 cubek-matmul = { workspace = true, features = ["multi-level"] }
 cubek-std = { workspace = true }
 cubek-tile = { workspace = true }
 cubek-test-utils = { workspace = true, optional = true }
+
+cubecl = { workspace = true, features = ["stdlib"] }
+cubecl-common = { workspace = true }
 
 bytemuck = { workspace = true }
 cubecl-ir = { workspace = true }
@@ -38,6 +39,7 @@ half = { workspace = true, features = ["bytemuck"] }
 serde = { workspace = true }
 
 [dev-dependencies]
-cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-convolution = { path = ".", features = ["cpu-reference"] }
 cubek-test-utils = { workspace = true }
+
+cubecl = { workspace = true, features = ["test-runtime"] }

--- a/crates/cubek-fft/Cargo.toml
+++ b/crates/cubek-fft/Cargo.toml
@@ -26,7 +26,7 @@ benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 
 [dependencies]
 cubecl = { workspace = true }
-cubek-test-utils = { path = "./../cubek-test-utils/", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-test-utils = { workspace = true, optional = true }
 num-complex = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -34,4 +34,4 @@ num-complex = { workspace = true }
 cubecl = { workspace = true, features = ["test-runtime"] }
 cubecl-common = { workspace = true }
 cubek-fft = { path = ".", features = ["cpu-reference"] }
-cubek-test-utils = { path = "./../cubek-test-utils/", version = "=0.3.0-pre.3", default-features = false }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek-fft/Cargo.toml
+++ b/crates/cubek-fft/Cargo.toml
@@ -25,13 +25,17 @@ cpu-reference = ["dep:num-complex", "dep:cubek-test-utils"]
 benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 
 [dependencies]
-cubecl = { workspace = true }
 cubek-test-utils = { workspace = true, optional = true }
+
+cubecl = { workspace = true }
+
 num-complex = { workspace = true, optional = true }
 
 [dev-dependencies]
-num-complex = { workspace = true }
-cubecl = { workspace = true, features = ["test-runtime"] }
-cubecl-common = { workspace = true }
 cubek-fft = { path = ".", features = ["cpu-reference"] }
 cubek-test-utils = { workspace = true }
+
+cubecl = { workspace = true, features = ["test-runtime"] }
+cubecl-common = { workspace = true }
+
+num-complex = { workspace = true }

--- a/crates/cubek-interpolate/Cargo.toml
+++ b/crates/cubek-interpolate/Cargo.toml
@@ -25,15 +25,18 @@ cpu-reference = ["dep:cubek-test-utils"]
 benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 
 [dependencies]
+cubek-tile = { workspace = true }
+cubek-test-utils = { workspace = true, optional = true }
+
 cubecl = { workspace = true }
 cubecl-common = { workspace = true }
-cubek-tile = { workspace = true }
+
 half = { workspace = true }
 thiserror = { workspace = true }
-cubek-test-utils = { workspace = true, optional = true }
 serde = { workspace = true }
 
 [dev-dependencies]
-cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-interpolate = { path = ".", features = ["cpu-reference"] }
 cubek-test-utils = { workspace = true }
+
+cubecl = { workspace = true, features = ["test-runtime"] }

--- a/crates/cubek-interpolate/Cargo.toml
+++ b/crates/cubek-interpolate/Cargo.toml
@@ -27,13 +27,13 @@ benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 [dependencies]
 cubecl = { workspace = true }
 cubecl-common = { workspace = true }
-cubek-tile = { path = "../cubek-tile", version = "=0.3.0-pre.3", default-features = false }
+cubek-tile = { workspace = true }
 half = { workspace = true }
 thiserror = { workspace = true }
-cubek-test-utils = { path = "./../cubek-test-utils/", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-test-utils = { workspace = true, optional = true }
 serde = { workspace = true }
 
 [dev-dependencies]
 cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-interpolate = { path = ".", features = ["cpu-reference"] }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek-matmul/Cargo.toml
+++ b/crates/cubek-matmul/Cargo.toml
@@ -29,12 +29,10 @@ cpu-reference = ["dep:cubek-test-utils", "cubek-std/testing"]
 benchmarks = ["cpu-reference", "dep:cubek-quant", "cubecl/test-runtime"]
 
 [dependencies]
-cubek-quant = { path = "../cubek-quant", version = "=0.3.0-pre.3", default-features = false, features = [
-    "kernels",
-], optional = true }
-cubek-std = { path = "../cubek-std", version = "=0.3.0-pre.3", default-features = false }
-cubek-tile = { path = "../cubek-tile", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-quant = { workspace = true, optional = true, features = ["kernels"] }
+cubek-std = { workspace = true }
+cubek-tile = { workspace = true, optional = true }
+cubek-test-utils = { workspace = true, optional = true }
 
 bytemuck = { workspace = true }
 cubecl = { workspace = true, features = ["stdlib"] }
@@ -44,8 +42,6 @@ serde = { workspace = true }
 
 [dev-dependencies]
 cubecl = { workspace = true, features = ["test-runtime"] }
-cubek-matmul = { path = ".", default-features = false, features = ["cpu-reference"] }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false }
-cubek-quant = { path = "../cubek-quant", version = "=0.3.0-pre.3", features = [
-    "kernels",
-] }
+cubek-matmul = { workspace = true, features = ["cpu-reference"] }
+cubek-test-utils = { workspace = true }
+cubek-quant = { workspace = true, features = ["kernels"] }

--- a/crates/cubek-matmul/Cargo.toml
+++ b/crates/cubek-matmul/Cargo.toml
@@ -34,14 +34,16 @@ cubek-std = { workspace = true }
 cubek-tile = { workspace = true, optional = true }
 cubek-test-utils = { workspace = true, optional = true }
 
-bytemuck = { workspace = true }
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true }
+
+bytemuck = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 serde = { workspace = true }
 
 [dev-dependencies]
-cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-matmul = { workspace = true, features = ["cpu-reference"] }
 cubek-test-utils = { workspace = true }
 cubek-quant = { workspace = true, features = ["kernels"] }
+
+cubecl = { workspace = true, features = ["test-runtime"] }

--- a/crates/cubek-pool/Cargo.toml
+++ b/crates/cubek-pool/Cargo.toml
@@ -24,10 +24,10 @@ cpu-reference = ["dep:cubek-test-utils"]
 [dependencies]
 cubecl = { workspace = true }
 cubecl-common = { workspace = true }
-cubek-test-utils = { path = "./../cubek-test-utils/", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-test-utils = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-pool = { path = ".", features = ["cpu-reference", "benchmarks"] }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek-pool/Cargo.toml
+++ b/crates/cubek-pool/Cargo.toml
@@ -22,12 +22,15 @@ benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 cpu-reference = ["dep:cubek-test-utils"]
 
 [dependencies]
+cubek-test-utils = { workspace = true, optional = true }
+
 cubecl = { workspace = true }
 cubecl-common = { workspace = true }
-cubek-test-utils = { workspace = true, optional = true }
+
 thiserror = { workspace = true }
 
 [dev-dependencies]
-cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-pool = { path = ".", features = ["cpu-reference", "benchmarks"] }
 cubek-test-utils = { workspace = true }
+
+cubecl = { workspace = true, features = ["test-runtime"] }

--- a/crates/cubek-quant/Cargo.toml
+++ b/crates/cubek-quant/Cargo.toml
@@ -22,11 +22,11 @@ full = ["extended"]
 [dependencies]
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true, features = ["fp8"] }
-cubek-tile = { path = "../cubek-tile", version = "=0.3.0-pre.3", default-features = false }
+cubek-tile = { workspace = true }
 
 half.workspace = true
 serde = { workspace = true }
 
 [dev-dependencies]
 cubecl = { workspace = true, features = ["test-runtime"] }
-cubek-test-utils = { path = "../cubek-test-utils", default-features = false }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek-quant/Cargo.toml
+++ b/crates/cubek-quant/Cargo.toml
@@ -20,13 +20,15 @@ extended = ["heavy"]
 full = ["extended"]
 
 [dependencies]
+cubek-tile = { workspace = true }
+
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true, features = ["fp8"] }
-cubek-tile = { workspace = true }
 
 half.workspace = true
 serde = { workspace = true }
 
 [dev-dependencies]
-cubecl = { workspace = true, features = ["test-runtime"] }
 cubek-test-utils = { workspace = true }
+
+cubecl = { workspace = true, features = ["test-runtime"] }

--- a/crates/cubek-random/Cargo.toml
+++ b/crates/cubek-random/Cargo.toml
@@ -26,8 +26,8 @@ benchmarks = ["dep:cubek-test-utils", "cubecl/test-runtime"]
 cubecl = { workspace = true }
 cubecl-common = { workspace = true }
 cubecl-environment = { workspace = true }
-cubek-std = { path = "../cubek-std", version = "=0.3.0-pre.3", default-features = false }
-cubek-test-utils = { path = "./../cubek-test-utils/", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-std = { workspace = true }
+cubek-test-utils = { workspace = true, optional = true }
 
 num-traits = { workspace = true }
 rand = { workspace = true }

--- a/crates/cubek-random/Cargo.toml
+++ b/crates/cubek-random/Cargo.toml
@@ -23,11 +23,12 @@ full = ["extended", "benchmarks"]
 benchmarks = ["dep:cubek-test-utils", "cubecl/test-runtime"]
 
 [dependencies]
+cubek-std = { workspace = true }
+cubek-test-utils = { workspace = true, optional = true }
+
 cubecl = { workspace = true }
 cubecl-common = { workspace = true }
 cubecl-environment = { workspace = true }
-cubek-std = { workspace = true }
-cubek-test-utils = { workspace = true, optional = true }
 
 num-traits = { workspace = true }
 rand = { workspace = true }

--- a/crates/cubek-reduce/Cargo.toml
+++ b/crates/cubek-reduce/Cargo.toml
@@ -30,8 +30,8 @@ benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 
 [dependencies]
 cubecl = { workspace = true }
-cubek-std = { path = "../cubek-std", version = "=0.3.0-pre.3", default-features = false }
-cubek-test-utils = { path = "./../cubek-test-utils/", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-std = { workspace = true }
+cubek-test-utils = { workspace = true, optional = true }
 
 num-traits = { workspace = true }
 serde = { workspace = true }
@@ -41,5 +41,5 @@ thiserror = { workspace = true }
 [dev-dependencies]
 cubecl = { workspace = true, features = ["test-runtime"] }
 cubecl-common = { workspace = true }
-cubek-reduce = { path = ".", features = ["cpu-reference"] }
-cubek-test-utils = { path = "./../cubek-test-utils/", version = "=0.3.0-pre.3" }
+cubek-reduce = { workspace = true, features = ["cpu-reference"] }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek-reduce/Cargo.toml
+++ b/crates/cubek-reduce/Cargo.toml
@@ -29,9 +29,10 @@ cpu-reference = ["dep:cubek-test-utils"]
 benchmarks = ["cpu-reference", "cubecl/test-runtime"]
 
 [dependencies]
-cubecl = { workspace = true }
 cubek-std = { workspace = true }
 cubek-test-utils = { workspace = true, optional = true }
+
+cubecl = { workspace = true }
 
 num-traits = { workspace = true }
 serde = { workspace = true }
@@ -39,7 +40,8 @@ half = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-cubecl = { workspace = true, features = ["test-runtime"] }
-cubecl-common = { workspace = true }
 cubek-reduce = { workspace = true, features = ["cpu-reference"] }
 cubek-test-utils = { workspace = true }
+
+cubecl = { workspace = true, features = ["test-runtime"] }
+cubecl-common = { workspace = true }

--- a/crates/cubek-std/Cargo.toml
+++ b/crates/cubek-std/Cargo.toml
@@ -27,9 +27,10 @@ testing = ["dep:cubek-test-utils", "cubecl/test-runtime"]
 benchmarks = ["testing"]
 
 [dependencies]
+cubek-test-utils = { workspace = true, optional = true }
+
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true }
-cubek-test-utils = { workspace = true, optional = true }
 
 [dev-dependencies]
 cubek-test-utils = { workspace = true }

--- a/crates/cubek-std/Cargo.toml
+++ b/crates/cubek-std/Cargo.toml
@@ -29,7 +29,7 @@ benchmarks = ["testing"]
 [dependencies]
 cubecl = { workspace = true, features = ["stdlib"] }
 cubecl-common = { workspace = true }
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-test-utils = { workspace = true, optional = true }
 
 [dev-dependencies]
-cubek-test-utils = { path = "../cubek-test-utils", version = "=0.3.0-pre.3", default-features = false }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek-test-utils/Cargo.toml
+++ b/crates/cubek-test-utils/Cargo.toml
@@ -21,7 +21,7 @@ extended = ["heavy"]
 full = ["extended"]
 
 [dependencies]
-cubek-tile = { path = "../cubek-tile", version = "=0.3.0-pre.3", default-features = false }
+cubek-tile = { workspace = true }
 
 bytemuck = { workspace = true }
 cubecl = { workspace = true, features = ["stdlib", "test-runtime"] }

--- a/crates/cubek-test-utils/Cargo.toml
+++ b/crates/cubek-test-utils/Cargo.toml
@@ -23,9 +23,10 @@ full = ["extended"]
 [dependencies]
 cubek-tile = { workspace = true }
 
-bytemuck = { workspace = true }
 cubecl = { workspace = true, features = ["stdlib", "test-runtime"] }
 cubecl-common = { workspace = true, features = ["fp8"] }
+
+bytemuck = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 serde = { workspace = true }
 rand = { workspace = true }

--- a/crates/cubek-tile/Cargo.toml
+++ b/crates/cubek-tile/Cargo.toml
@@ -18,9 +18,10 @@ extended = ["heavy"]
 full = ["extended"]
 
 [dependencies]
-bytemuck = { workspace = true }
 cubecl = { workspace = true, features = ["stdlib", "test-runtime"] }
 cubecl-common = { workspace = true }
+
+bytemuck = { workspace = true }
 half = { workspace = true, features = ["bytemuck"] }
 serde = { workspace = true }
 

--- a/crates/cubek-tile/Cargo.toml
+++ b/crates/cubek-tile/Cargo.toml
@@ -25,5 +25,5 @@ half = { workspace = true, features = ["bytemuck"] }
 serde = { workspace = true }
 
 [dev-dependencies]
-cubek-quant = { path = "./../cubek-quant/", default-features = false }
-cubek-test-utils = { path = "./../cubek-test-utils/", default-features = false }
+cubek-quant = { workspace = true }
+cubek-test-utils = { workspace = true }

--- a/crates/cubek/Cargo.toml
+++ b/crates/cubek/Cargo.toml
@@ -63,14 +63,14 @@ fft = ["cubek-fft"]
 
 [dependencies]
 cubecl = { workspace = true }
-cubek-attention = { path = "../cubek-attention", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-interpolate = { path = "../cubek-interpolate", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-pool = { path = "../cubek-pool", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-convolution = { path = "../cubek-convolution", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-matmul = { path = "../cubek-matmul", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-quant = { path = "../cubek-quant", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-random = { path = "../cubek-random", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-reduce = { path = "../cubek-reduce", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-fft = { path = "../cubek-fft", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-std = { path = "../cubek-std", version = "=0.3.0-pre.3", default-features = false, optional = true }
-cubek-tile = { path = "../cubek-tile", version = "=0.3.0-pre.3", default-features = false, optional = true }
+cubek-attention = { workspace = true, optional = true }
+cubek-convolution = { workspace = true, optional = true }
+cubek-fft = { workspace = true, optional = true }
+cubek-interpolate = { workspace = true, optional = true }
+cubek-matmul = { workspace = true, optional = true }
+cubek-pool = { workspace = true, optional = true }
+cubek-quant = { workspace = true, optional = true }
+cubek-random = { workspace = true, optional = true }
+cubek-reduce = { workspace = true, optional = true }
+cubek-std = { workspace = true, optional = true }
+cubek-tile = { workspace = true, optional = true }


### PR DESCRIPTION
Member crates now declare cubek-* dependencies with `workspace = true` instead of repeating `path`/`version` in every manifest, matching how burn and cubecl handle their internal crates. A release bump now edits one block in the root manifest.

Each dependency section lists the internal crates as their own group first, then the external ones.

Manifest-only refactor: `cargo check --workspace --all-targets` clean.