### PR TITLE
Update cubecl rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -733,7 +733,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -948,7 +948,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "ahash",
  "buildid",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=3b3e3e5c41c700af8cd847d81e3bc1df42544c8a#3b3e3e5c41c700af8cd847d81e3bc1df42544c8a"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -733,7 +733,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -757,7 +757,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -948,7 +948,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "cubecl-common",
  "darling 0.24.0",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "darling 0.24.0",
  "inflections",
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "ahash",
  "buildid",
@@ -1030,7 +1030,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1075,7 +1075,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.2"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4732ab27b0913e65bb072b969092ee38c1ad8c06#4732ab27b0913e65bb072b969092ee38c1ad8c06"
+source = "git+https://github.com/tracel-ai/cubecl?rev=213561cb97bfa6781aa08691d9cf2d3e1f376db7#213561cb97bfa6781aa08691d9cf2d3e1f376db7"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.2"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "3b3e3e5c41c700af8cd847d81e3bc1df42544c8a", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "3b3e3e5c41c700af8cd847d81e3bc1df42544c8a", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "3b3e3e5c41c700af8cd847d81e3bc1df42544c8a", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "4732ab27b0913e65bb072b969092ee38c1ad8c06", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "4732ab27b0913e65bb072b969092ee38c1ad8c06", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "4732ab27b0913e65bb072b969092ee38c1ad8c06", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.2", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ version = "0.3.0-pre.2"
 # cubecl-common = { path = "../cubecl/crates/cubecl-common", default-features = false }
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "4732ab27b0913e65bb072b969092ee38c1ad8c06", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "4732ab27b0913e65bb072b969092ee38c1ad8c06", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "4732ab27b0913e65bb072b969092ee38c1ad8c06", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "213561cb97bfa6781aa08691d9cf2d3e1f376db7", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "213561cb97bfa6781aa08691d9cf2d3e1f376db7", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "213561cb97bfa6781aa08691d9cf2d3e1f376db7", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.2", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.2", default-features = false }

--- a/crates/cubek-interpolate/src/eval/cpu_reference/forward/nearest.rs
+++ b/crates/cubek-interpolate/src/eval/cpu_reference/forward/nearest.rs
@@ -17,19 +17,16 @@ pub fn reference_nearest(
     for_each_output_coord(output_shape, |linear, out_coord| {
         let b = out_coord[0];
 
-        let y;
-        let x;
-
-        match nearest_mode {
-            NearestMode::Exact => {
-                y = std::cmp::min(((out_coord[1] * 2 + 1) * h_in) / (h_out * 2), h_in - 1);
-                x = std::cmp::min(((out_coord[2] * 2 + 1) * w_in) / (w_out * 2), w_in - 1);
-            }
-            NearestMode::Floor => {
-                y = std::cmp::min((out_coord[1] * h_in) / h_out, h_in - 1);
-                x = std::cmp::min((out_coord[2] * w_in) / w_out, w_in - 1);
-            }
-        }
+        let (y, x) = match nearest_mode {
+            NearestMode::Exact => (
+                std::cmp::min(((out_coord[1] * 2 + 1) * h_in) / (h_out * 2), h_in - 1),
+                std::cmp::min(((out_coord[2] * 2 + 1) * w_in) / (w_out * 2), w_in - 1),
+            ),
+            NearestMode::Floor => (
+                std::cmp::min((out_coord[1] * h_in) / h_out, h_in - 1),
+                std::cmp::min((out_coord[2] * w_in) / w_out, w_in - 1),
+            ),
+        };
 
         let c = out_coord[3];
 

--- a/crates/cubek-test-utils/src/test_tensor/io.rs
+++ b/crates/cubek-test-utils/src/test_tensor/io.rs
@@ -139,8 +139,8 @@ pub fn read_host_data(path: &Path) -> io::Result<HostData> {
             // Guaranteed-aligned re-cast: build the Vec<f32> from the byte
             // chunks rather than transmuting the buffer in place.
             let mut v = Vec::with_capacity(elem_count);
-            for chunk in buf.chunks_exact(4) {
-                v.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+            for chunk in buf.as_chunks::<4>().0 {
+                v.push(f32::from_le_bytes(*chunk));
             }
             HostDataVec::F32(v)
         }
@@ -148,8 +148,8 @@ pub fn read_host_data(path: &Path) -> io::Result<HostData> {
             let mut buf = vec![0u8; elem_count * std::mem::size_of::<f64>()];
             r.read_exact(&mut buf)?;
             let mut v = Vec::with_capacity(elem_count);
-            for chunk in buf.chunks_exact(8) {
-                v.push(f64::from_le_bytes(chunk.try_into().unwrap()));
+            for chunk in buf.as_chunks::<8>().0 {
+                v.push(f64::from_le_bytes(*chunk));
             }
             HostDataVec::F64(v)
         }
@@ -157,8 +157,8 @@ pub fn read_host_data(path: &Path) -> io::Result<HostData> {
             let mut buf = vec![0u8; elem_count * std::mem::size_of::<i32>()];
             r.read_exact(&mut buf)?;
             let mut v = Vec::with_capacity(elem_count);
-            for chunk in buf.chunks_exact(4) {
-                v.push(i32::from_le_bytes(chunk.try_into().unwrap()));
+            for chunk in buf.as_chunks::<4>().0 {
+                v.push(i32::from_le_bytes(*chunk));
             }
             HostDataVec::I32(v)
         }


### PR DESCRIPTION
Moves the pinned cubecl revision from `3b3e3e5c` to current main (`4732ab27`). The whole workspace compiles and the full test suites pass locally on both `cubecl/cpu` and `cubecl/wgpu`.

Motivation: the newer CPU runtime reports the L1d cache size in `max_shared_memory_size` (the pinned revision reported total system memory there), which lets CPU kernels derive their dispatch-amortization thresholds from hardware properties instead of hardcoding them. First consumer is cubek-random's CPU geometry.