### PR TITLE
Fix depthwise launch validation and metrics

### DIFF
--- a/crates/cubek-convolution/src/components/error.rs
+++ b/crates/cubek-convolution/src/components/error.rs
@@ -1,6 +1,7 @@
 use core::fmt::Debug;
 use cubecl::server::LaunchError;
 use cubek_matmul::definition::{MatmulAvailabilityError, MatmulSetupError};
+use cubek_std::InvalidConfigError;
 
 #[allow(clippy::large_enum_variant)]
 pub enum ConvSetupError {
@@ -10,8 +11,13 @@ pub enum ConvSetupError {
     /// `groups == in_channels == out_channels`, one filter per channel.
     NotDepthwise {
         groups: usize,
-        channels: usize,
+        input_channels: usize,
+        output_channels: usize,
+        weight_channels: usize,
+        weight_group_channels: usize,
     },
+    /// A caller-provided convolution strategy cannot form valid launch geometry.
+    InvalidConfig(InvalidConfigError),
     Unknown,
     Launch(LaunchError),
 }
@@ -34,11 +40,22 @@ impl Debug for ConvSetupError {
                     "Unable to launch matmul because groups must be one, is actually {groups}",
                 )
             }
-            ConvSetupError::NotDepthwise { groups, channels } => writeln!(
+            ConvSetupError::NotDepthwise {
+                groups,
+                input_channels,
+                output_channels,
+                weight_channels,
+                weight_group_channels,
+            } => writeln!(
                 f,
                 "Unable to launch the depthwise convolution because it needs one filter per \
-                 channel, but groups is {groups} against {channels} channels",
+                 channel, but groups is {groups}, input channels is {input_channels}, output \
+                 channels is {output_channels}, weight channels is {weight_channels}, and weight \
+                 channels per group is {weight_group_channels}",
             ),
+            ConvSetupError::InvalidConfig(err) => {
+                write!(f, "Invalid convolution config: {err}")
+            }
             ConvSetupError::Unknown => write!(f, "Unknown"),
             ConvSetupError::Launch(err) => write!(f, "Launch error {err:?}"),
         }

--- a/crates/cubek-convolution/src/eval/benchmarks/depthwise/benchmark.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/depthwise/benchmark.rs
@@ -36,7 +36,9 @@ pub fn bench(
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
-    Ok(RunSamples::new(durations).with_flops(problem.flops()))
+    Ok(RunSamples::new(durations)
+        .with_flops(problem.flops())
+        .with_bytes(problem.bytes(dtype().size()), None))
 }
 
 struct DepthwiseBench {

--- a/crates/cubek-convolution/src/eval/benchmarks/depthwise/problem.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/depthwise/problem.rs
@@ -55,12 +55,12 @@ impl DepthwiseProblem {
     /// this to the measured time is the number to read — a depthwise pass has too little
     /// arithmetic per byte to be anything but bandwidth-bound, so its ceiling is the device's
     /// copy rate and not its flop rate.
-    pub fn bytes(&self, elem_size: usize) -> f64 {
+    pub fn bytes(&self, elem_size: usize) -> usize {
         let out = self.out_size();
         let elems = self.batch * self.size * self.size * self.channels
             + self.batch * out * out * self.channels
             + self.channels * self.kernel * self.kernel;
-        (elems * elem_size) as f64
+        elems * elem_size
     }
 }
 

--- a/crates/cubek-convolution/src/kernels/forward/depthwise.rs
+++ b/crates/cubek-convolution/src/kernels/forward/depthwise.rs
@@ -153,6 +153,41 @@ impl DepthwiseTiling {
         }
     }
 
+    /// Reject a degenerate tiling before its dimensions reach division and space construction.
+    fn validate(self) -> Result<Self, ConvSetupError> {
+        if self.rows == 0 || self.cols == 0 || self.chans == 0 || self.lines == 0 {
+            return Err(ConvSetupError::InvalidConfig(Box::new(format!(
+                "depthwise tiling dimensions must be non-zero, got rows {}, cols {}, chans {}, \
+                 lines {}",
+                self.rows, self.cols, self.chans, self.lines
+            ))));
+        }
+        Ok(self)
+    }
+
+    /// The channel edge one cube owns, checked because every factor is public configuration or
+    /// runtime hardware data.
+    fn channel_tile(self, lanes: usize, width: usize) -> Result<usize, ConvSetupError> {
+        let tile = lanes
+            .checked_mul(width)
+            .and_then(|tile| tile.checked_mul(self.chans))
+            .ok_or_else(|| {
+                ConvSetupError::InvalidConfig(Box::new(format!(
+                    "depthwise channel tile overflows: {lanes} lanes * {width} channels/line * {} \
+                     lines/lane",
+                    self.chans
+                )))
+            })?;
+        if tile == 0 {
+            return Err(ConvSetupError::InvalidConfig(Box::new(format!(
+                "depthwise channel tile must be non-zero, got {lanes} lanes * {width} \
+                 channels/line * {} lines/lane",
+                self.chans
+            ))));
+        }
+        Ok(tile)
+    }
+
     /// The space this tiling implies for a problem of these extents.
     ///
     /// Two levels. The first separates the output across the launch grid — an all-`sequential`
@@ -160,10 +195,8 @@ impl DepthwiseTiling {
     /// useless one. The second separates what one cube took across the cube's own threads: rows
     /// go to planes, channels to lanes. The taps stay `sequential` throughout — they are the
     /// contraction, and every tap of one output position accumulates into the same register.
-    fn space(&self, geometry: &Geometry, lanes: usize, width: usize) -> Space {
-        let Self {
-            rows, cols, chans, ..
-        } = *self;
+    fn space(&self, geometry: &Geometry, tile_c: usize, width: usize) -> Space {
+        let Self { rows, cols, .. } = *self;
         let Geometry {
             b,
             oh,
@@ -173,8 +206,6 @@ impl DepthwiseTiling {
             rw,
             ..
         } = *geometry;
-        let tile_c = lanes * width * chans;
-
         Tiling::new()
             .extents(&[(B, b), (OH, oh), (OW, ow), (C, c), (RH, rh), (RW, rw)])
             // The channel axis takes X so that the fastest-moving cube index is the one memory is
@@ -232,6 +263,7 @@ pub enum DepthwiseStrategy {
 ///
 /// [`ConvSetupError::NotDepthwise`] when the convolution is not one filter per channel — the
 /// tuner reads that as "this candidate does not apply here", which is exactly what it is — and
+/// [`ConvSetupError::InvalidConfig`] when a fixed tiling is degenerate. Returns
 /// [`ConvSetupError::Unknown`] when re-laying the filter cannot be launched.
 pub fn launch_depthwise<R: Runtime>(
     client: &ComputeClient<R>,
@@ -248,7 +280,8 @@ pub fn launch_depthwise<R: Runtime>(
             DepthwiseTiling::for_problem(geometry.c, geometry.taps(), lanes)
         }
         DepthwiseStrategy::Fixed(tiling) => tiling,
-    };
+    }
+    .validate()?;
     let DepthwiseTensors { input, weight, out } = tensors;
 
     // The filter, re-laid so the channel is its innermost dim like every other operand's. It has
@@ -267,14 +300,15 @@ pub fn launch_depthwise<R: Runtime>(
         tiling.lines,
         &[&input, &weight, &out],
     );
-    let space = tiling.space(&geometry, lanes, width);
+    let tile_c = tiling.channel_tile(lanes, width)?;
+    let space = tiling.space(&geometry, tile_c, width);
 
     // A tile that does not divide its axis leaves the last cube short, and a short cube's
     // terminal tile is still the full comptime size — so the cells past the end are addressed and
     // have to be guarded. Per axis, because the guard is real work per access and the axes that
     // need one are rarely the same: a 48x48 map divides evenly by any tile here while a
     // 24-channel block never fills one lane-width.
-    let ragged_c = !geometry.c.is_multiple_of(lanes * width * tiling.chans);
+    let ragged_c = !geometry.c.is_multiple_of(tile_c);
     let ragged_oh = !geometry.oh.is_multiple_of(tiling.rows);
     let ragged_ow = !geometry.ow.is_multiple_of(tiling.cols);
     let [ph, pw] = geometry.padding;
@@ -357,16 +391,29 @@ impl Geometry {
         groups: usize,
     ) -> Result<Self, ConvSetupError> {
         // NHWC throughout: [batch, h, w, channels].
-        let channels = tensors.input.shape[3];
-        if groups != channels || tensors.out.shape[3] != channels {
-            return Err(ConvSetupError::NotDepthwise { groups, channels });
+        let input_channels = tensors.input.shape[3];
+        let output_channels = tensors.out.shape[3];
+        let weight_channels = tensors.weight.shape[0];
+        let weight_group_channels = tensors.weight.shape[3];
+        if groups != input_channels
+            || output_channels != input_channels
+            || weight_channels != input_channels
+            || weight_group_channels != 1
+        {
+            return Err(ConvSetupError::NotDepthwise {
+                groups,
+                input_channels,
+                output_channels,
+                weight_channels,
+                weight_group_channels,
+            });
         }
 
         Ok(Self {
             b: tensors.out.shape[0],
             oh: tensors.out.shape[1],
             ow: tensors.out.shape[2],
-            c: channels,
+            c: input_channels,
             // Burn hands weights as [out_channels, kh, kw, in_channels / groups]; depthwise makes
             // that last axis 1, so the filter is [c, kh, kw] with the channel outermost.
             rh: tensors.weight.shape[1],

--- a/crates/cubek-convolution/src/kernels/forward/depthwise.rs
+++ b/crates/cubek-convolution/src/kernels/forward/depthwise.rs
@@ -195,7 +195,7 @@ impl DepthwiseTiling {
     /// useless one. The second separates what one cube took across the cube's own threads: rows
     /// go to planes, channels to lanes. The taps stay `sequential` throughout — they are the
     /// contraction, and every tap of one output position accumulates into the same register.
-    fn space(&self, geometry: &Geometry, tile_c: usize, width: usize) -> Space {
+    fn space(&self, geometry: &Geometry, lanes: usize, tile_c: usize, width: usize) -> Space {
         let Self { rows, cols, .. } = *self;
         let Geometry {
             b,
@@ -301,7 +301,7 @@ pub fn launch_depthwise<R: Runtime>(
         &[&input, &weight, &out],
     );
     let tile_c = tiling.channel_tile(lanes, width)?;
-    let space = tiling.space(&geometry, tile_c, width);
+    let space = tiling.space(&geometry, lanes, tile_c, width);
 
     // A tile that does not divide its axis leaves the last cube short, and a short cube's
     // terminal tile is still the full comptime size — so the cells past the end are addressed and

--- a/crates/cubek-convolution/tests/convolution/depthwise.rs
+++ b/crates/cubek-convolution/tests/convolution/depthwise.rs
@@ -307,9 +307,9 @@ fn depthwise_rejects_mismatched_weight_shape() {
         let result = launch_depthwise::<TestRuntime>(
             &client,
             DepthwiseTensors {
-                input: input.binding(),
+                input: input.clone().binding(),
                 weight: weight.binding(),
-                out: out.binding(),
+                out: out.clone().binding(),
             },
             ConvolutionArgs::<2> {
                 stride: [1; 2],

--- a/crates/cubek-convolution/tests/convolution/depthwise.rs
+++ b/crates/cubek-convolution/tests/convolution/depthwise.rs
@@ -7,7 +7,8 @@
 
 use cubecl::{Runtime, TestRuntime, prelude::*, std::tensor::TensorHandle, zspace::Shape};
 use cubek_convolution::{
-    ConvolutionArgs, DepthwiseStrategy, DepthwiseTensors, DepthwiseTiling, launch_depthwise,
+    ConvolutionArgs, DepthwiseStrategy, DepthwiseTensors, DepthwiseTiling,
+    components::ConvSetupError, launch_depthwise,
 };
 use cubek_test_utils::{HostData, HostDataType, TestInput};
 
@@ -277,4 +278,59 @@ fn depthwise_strided_weight() {
     }
     .check_with_weight_gap(DepthwiseTiling::default(), 2)
     .unwrap();
+}
+
+/// The filter must carry exactly one channel's filter for every input/output channel. Reject the
+/// mismatch before re-laying the binding under a larger logical shape.
+#[test]
+fn depthwise_rejects_mismatched_weight_shape() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::elem_type_native();
+    let input_channels = 8;
+
+    let input = TestInput::builder(client.clone(), Shape::new([1, 5, 5, input_channels]))
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+    let out = TestInput::builder(client.clone(), Shape::new([1, 5, 5, input_channels]))
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+
+    for (weight_shape, want_weight_channels, want_group_channels) in
+        [([7, 3, 3, 1], 7, 1), ([8, 3, 3, 2], 8, 2)]
+    {
+        let weight = TestInput::builder(client.clone(), Shape::new(weight_shape))
+            .dtype(dtype)
+            .zeros()
+            .generate_without_host_data();
+        let result = launch_depthwise::<TestRuntime>(
+            &client,
+            DepthwiseTensors {
+                input: input.binding(),
+                weight: weight.binding(),
+                out: out.binding(),
+            },
+            ConvolutionArgs::<2> {
+                stride: [1; 2],
+                padding: [1; 2],
+                dilation: [1; 2],
+            },
+            input_channels,
+            dtype,
+            DepthwiseStrategy::Routine,
+        );
+
+        assert!(matches!(
+            result,
+            Err(ConvSetupError::NotDepthwise {
+                groups: 8,
+                input_channels: 8,
+                output_channels: 8,
+                weight_channels,
+                weight_group_channels,
+            }) if weight_channels == want_weight_channels
+                && weight_group_channels == want_group_channels
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- reject inconsistent depthwise filter channel shapes before relayout
- validate fixed tilings and guard channel-tile arithmetic
- report effective bandwidth in depthwise benchmarks

## Validation

- rustfmt --check
- git diff --check
- Cargo commands were not run