### PR TITLE
Report compute throughput against a peak, like bandwidth already is

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -70,17 +70,26 @@ pub fn run_category(category: &dyn BenchmarkCategory) {
             println!("---- {} / {} ----", strategy.label, problem.label);
             match category.run(&strategy.id, &problem.id, samples) {
                 Ok(samples) => {
-                    if let Some(tflops) = samples.tflops {
-                        println!("{tflops:.3} TFLOPS");
+                    // Both ceilings, so a row says which one the kernel ran into
+                    // rather than only how fast it went.
+                    if let Some(compute) = &samples.compute {
+                        let achieved_tflops = compute.achieved_ops_per_s / 1e12;
+                        match compute.peak_ops_per_s {
+                            Some(peak) if peak > 0.0 => {
+                                let pct = 100.0 * compute.achieved_ops_per_s / peak;
+                                println!("{achieved_tflops:.3} TFLOPS ({pct:.0}% of compute peak)");
+                            }
+                            _ => println!("{achieved_tflops:.3} TFLOPS (compute peak unavailable)"),
+                        }
                     }
                     if let Some(bandwidth) = &samples.bandwidth {
                         let achieved_gb_s = bandwidth.achieved_bytes_per_s / 1e9;
                         match bandwidth.peak_bytes_per_s {
                             Some(peak) if peak > 0.0 => {
                                 let pct = 100.0 * bandwidth.achieved_bytes_per_s / peak;
-                                println!("{achieved_gb_s:.1} GB/s ({pct:.0}% of write peak)");
+                                println!("{achieved_gb_s:.1} GB/s ({pct:.0}% of memory peak)");
                             }
-                            _ => println!("{achieved_gb_s:.1} GB/s (write peak unavailable)"),
+                            _ => println!("{achieved_gb_s:.1} GB/s (memory peak unavailable)"),
                         }
                     }
                     let durations = BenchmarkDurations {

--- a/crates/cubek-convolution/src/eval/benchmarks/depthwise/benchmark.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/depthwise/benchmark.rs
@@ -36,7 +36,9 @@ pub fn bench(
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
-    Ok(RunSamples::new(durations).with_flops(problem.flops()))
+    // Too little arithmetic per byte to approach the flop ceiling, so there is no compute
+    // peak worth judging this against.
+    Ok(RunSamples::new(durations).with_flops(problem.flops(), None))
 }
 
 struct DepthwiseBench {

--- a/crates/cubek-matmul/src/definition/cost.rs
+++ b/crates/cubek-matmul/src/definition/cost.rs
@@ -1,11 +1,40 @@
 use cubecl::{
     client::ComputeClient,
     prelude::Runtime,
+    std::throughput::measure_peak_throughput,
     throughput::{ThroughputKey, compute_throughput_key, select_cmma_tile},
     tune::Work,
 };
 
 use crate::definition::{MatmulElems, MatmulGlobalElems, MatmulProblem};
+
+/// Unconstrained tile selection matches what the hardware can do rather than what a
+/// problem's own padding limits allow, so a small `m` is still judged against peak.
+const UNCONSTRAINED: (usize, usize, usize) = (usize::MAX, usize::MAX, usize::MAX);
+
+/// The throughput key a matmul over these register types probes.
+pub fn compute_key<R: Runtime>(client: &ComputeClient<R>, elems: &MatmulElems) -> ThroughputKey {
+    let cmma_tile = select_cmma_tile(
+        client,
+        elems.lhs_register,
+        elems.rhs_register,
+        elems.acc_register,
+        UNCONSTRAINED,
+    );
+
+    compute_throughput_key(cmma_tile, elems.lhs_register, elems.acc_register)
+}
+
+/// The device's measured arithmetic peak, in ops/s, for a bench row over these register
+/// types to be judged against. `None` when the probe reports nothing usable.
+pub fn compute_peak_ops_per_s<R: Runtime>(
+    client: &ComputeClient<R>,
+    elems: &MatmulElems,
+) -> Option<f64> {
+    let peak = measure_peak_throughput(client, compute_key(client, elems)).ops_per_s();
+
+    (peak > 0.0).then_some(peak)
+}
 
 /// Minimal representation of matmul cost dependencies, including dimensions and element types.
 #[derive(Debug, Clone)]
@@ -39,24 +68,8 @@ impl MatmulCost {
     }
 
     /// Generates a throughput key for compute probes representing peak hardware instruction throughput.
-    ///
-    /// Selects CMMA tiles without problem-size constraints to ensure small dimensions (e.g. `m = 1`)
-    /// evaluate against peak hardware throughput, using register element types.
     pub fn compute_key<R: Runtime>(&self, client: &ComputeClient<R>) -> ThroughputKey {
-        // Unconstrained selection allows matching hardware capability without problem-size padding limits.
-        const UNCONSTRAINED: (usize, usize, usize) = (usize::MAX, usize::MAX, usize::MAX);
-
-        let elems = MatmulElems::from_globals(&self.elems);
-
-        let cmma_tile = select_cmma_tile(
-            client,
-            elems.lhs_register,
-            elems.rhs_register,
-            elems.acc_register,
-            UNCONSTRAINED,
-        );
-
-        compute_throughput_key(cmma_tile, elems.lhs_register, elems.acc_register)
+        compute_key(client, &MatmulElems::from_globals(&self.elems))
     }
 }
 

--- a/crates/cubek-matmul/src/eval/benchmarks/gemm/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/gemm/benchmark.rs
@@ -11,7 +11,7 @@ use cubek_std::{InputBinding, MatrixLayout};
 use cubek_test_utils::{RunSamples, TestInput};
 
 use crate::{
-    definition::{MatmulElems, MatmulPrecision},
+    definition::{MatmulElems, MatmulPrecision, compute_peak_ops_per_s},
     eval::benchmarks::gemm::problem::{GemmProblem, Precision},
     launch::launch_ref,
     strategy::Strategy,
@@ -36,6 +36,7 @@ fn bench_with<MP: MatmulPrecision>(
     let device = <TestRuntime as Runtime>::Device::default();
     let client = <TestRuntime as Runtime>::client(&device);
     let flops = 2.0 * problem.b as f64 * problem.m as f64 * problem.n as f64 * problem.k as f64;
+    let elems = MatmulElems::new_deprecated::<MP>();
 
     let bench = GemmBench {
         b: problem.b,
@@ -45,9 +46,9 @@ fn bench_with<MP: MatmulPrecision>(
         lhs_layout: problem.lhs_layout,
         rhs_layout: problem.rhs_layout,
         strategy: strategy.clone(),
-        client,
+        client: client.clone(),
         device,
-        dtypes: MatmulElems::new_deprecated::<MP>(),
+        dtypes: elems.clone(),
         samples: num_samples,
     };
 
@@ -56,7 +57,7 @@ fn bench_with<MP: MatmulPrecision>(
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
-    Ok(RunSamples::new(durations).with_flops(flops))
+    Ok(RunSamples::new(durations).with_flops(flops, compute_peak_ops_per_s(&client, &elems)))
 }
 
 struct GemmBench {

--- a/crates/cubek-matmul/src/multi_level/eval/gemv/benchmark.rs
+++ b/crates/cubek-matmul/src/multi_level/eval/gemv/benchmark.rs
@@ -12,7 +12,7 @@ use cubek_std::InputBinding;
 use cubek_test_utils::{RunSamples, TestInput};
 
 use crate::{
-    definition::MatmulElems,
+    definition::{MatmulElems, compute_peak_ops_per_s},
     launch::launch_ref,
     multi_level::eval::gemv::problem::{GemvProblem, ProblemKind},
     strategy::Strategy,
@@ -27,6 +27,7 @@ pub fn bench(
     let client = <TestRuntime as Runtime>::client(&device);
 
     let flops = 2.0 * problem.batches as f64 * problem.out_dim as f64 * problem.k_dim as f64;
+    let elems = MatmulElems::from_single_dtype(f32::elem_type_native());
 
     let bench = GemvBench {
         kind: problem.kind,
@@ -37,8 +38,8 @@ pub fn bench(
         rhs_layout: problem.rhs_layout,
         strategy: strategy.clone(),
         device,
-        client,
-        dtypes: MatmulElems::from_single_dtype(f32::elem_type_native()),
+        client: client.clone(),
+        dtypes: elems.clone(),
         samples: num_samples,
     };
 
@@ -47,7 +48,7 @@ pub fn bench(
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
-    Ok(RunSamples::new(durations).with_flops(flops))
+    Ok(RunSamples::new(durations).with_flops(flops, compute_peak_ops_per_s(&client, &elems)))
 }
 
 struct GemvBench {

--- a/crates/cubek-matmul/src/multi_level/eval/quantized_matmul/benchmark.rs
+++ b/crates/cubek-matmul/src/multi_level/eval/quantized_matmul/benchmark.rs
@@ -17,7 +17,7 @@ use cubek_std::InputBinding;
 use cubek_test_utils::{RunSamples, TestInput};
 
 use crate::{
-    definition::{MatmulElems, MatmulGlobalElems},
+    definition::{MatmulElems, MatmulGlobalElems, compute_peak_ops_per_s},
     launch::launch_ref as matmul_launch_ref,
     multi_level::eval::quantized_matmul::problem::{
         Layout, Mode, QuantSide, QuantizedMatmulProblem,
@@ -36,12 +36,13 @@ pub fn bench(
     validate_spec(problem)?;
 
     let flops = 2.0 * problem.b as f64 * problem.m as f64 * problem.n as f64 * problem.k as f64;
+    let elems = matmul_elems::<f32>();
 
     let bench = QuantMatmulBench {
         problem: problem.clone(),
         strategy: strategy.clone(),
-        client,
-        dtypes: matmul_elems::<f32>(),
+        client: client.clone(),
+        dtypes: elems.clone(),
         samples: num_samples,
     };
 
@@ -59,7 +60,7 @@ pub fn bench(
         }
     };
 
-    Ok(RunSamples::new(durations).with_flops(flops))
+    Ok(RunSamples::new(durations).with_flops(flops, compute_peak_ops_per_s(&client, &elems)))
 }
 
 struct QuantMatmulBench {

--- a/crates/cubek-matmul/src/tiled/eval/gemm_cpu_tiled/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/gemm_cpu_tiled/mod.rs
@@ -26,7 +26,7 @@ use cubek_std::InputBinding;
 use cubek_test_utils::{CatalogEntry, RunSamples, TestInput};
 
 use crate::{
-    definition::MatmulElems,
+    definition::{MatmulElems, compute_peak_ops_per_s},
     routine::BlueprintStrategy,
     tiled::cpu_gemm::{CpuGemmBlueprint, InstructionShape, PlaneGrid, WithLayout, launch_ref},
 };
@@ -197,12 +197,13 @@ pub fn bench(
     let device = <TestRuntime as Runtime>::Device::default();
     let client = <TestRuntime as Runtime>::client(&device);
     let flops = 2.0 * problem.b as f64 * problem.m as f64 * problem.n as f64 * problem.k as f64;
+    let elems = MatmulElems::from_single_dtype(f32::elem_type_native());
 
     let bench = TiledBench {
         problem: *problem,
         strategy: *strategy,
-        client,
-        dtypes: MatmulElems::from_single_dtype(f32::elem_type_native()),
+        client: client.clone(),
+        dtypes: elems.clone(),
         samples: num_samples,
     };
 
@@ -211,7 +212,7 @@ pub fn bench(
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
-    Ok(RunSamples::new(durations).with_flops(flops))
+    Ok(RunSamples::new(durations).with_flops(flops, compute_peak_ops_per_s(&client, &elems)))
 }
 
 /// Square-ish shapes whose dims all divide `EDGE`, so both packings run maskless. `1536³` carries a

--- a/crates/cubek-matmul/src/tiled/eval/split_k/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/split_k/mod.rs
@@ -35,6 +35,7 @@
 //!
 //! Only meaningful on a GPU: `plane_size == 1` on CPU collapses every strategy to `seq_k`.
 
+use crate::definition::{MatmulElems, compute_peak_ops_per_s};
 use cubecl::{
     CubeCount, CubeDim, Runtime, TestRuntime,
     benchmark::{Benchmark, ProfileDuration, TimingMethod},
@@ -423,6 +424,8 @@ pub fn bench(
     let cube_count = space.cube_count();
     let cube_dim = mapping.cube_dim(&space, &client);
     let flops = 2.0 * problem.m as f64 * problem.n as f64 * problem.k as f64;
+    // The tile inputs are built as f32 and the accumulator contracts in f32.
+    let elems = MatmulElems::from_single_dtype(f32::elem_type_native());
 
     let a = TileInput::builder(&client, space.project(&[M, K]))
         .untiled()
@@ -435,7 +438,7 @@ pub fn bench(
     let bench = SplitKBench {
         problem: *problem,
         mapping,
-        client,
+        client: client.clone(),
         samples: num_samples,
         cube_count,
         cube_dim,
@@ -450,7 +453,7 @@ pub fn bench(
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
-    Ok(RunSamples::new(durations).with_flops(flops))
+    Ok(RunSamples::new(durations).with_flops(flops, compute_peak_ops_per_s(&client, &elems)))
 }
 
 /// The down-proj family: `m = 1`, `k = 8192`, N sweeping the regime where it stops being able to

--- a/crates/cubek-matmul/src/tiled/eval/tile_quant_stage/benchmark.rs
+++ b/crates/cubek-matmul/src/tiled/eval/tile_quant_stage/benchmark.rs
@@ -20,6 +20,7 @@ const INSTRUCTION: Instruction = Instruction::Registers {
     config: RegisterBlock::new(64, false, false),
 };
 use super::strategy::StageDepth;
+use crate::definition::{MatmulElems, compute_peak_ops_per_s};
 
 const M: Axis = Axis(0);
 const N: Axis = Axis(1);
@@ -85,7 +86,11 @@ pub fn bench(
         .durations;
 
     let flops = 2.0 * problem.m as f64 * problem.n as f64 * problem.k as f64;
-    Ok(RunSamples::new(durations).with_flops(flops))
+    // The mma contracts in f32; the packed u32 is how the RHS is stored, not what the
+    // arithmetic runs at.
+    let elems = MatmulElems::from_single_dtype(f32::elem_type_native());
+
+    Ok(RunSamples::new(durations).with_flops(flops, compute_peak_ops_per_s(&client, &elems)))
 }
 
 struct TileQuantStageBench {

--- a/crates/cubek-matmul/tests/multi_level/comparison.rs
+++ b/crates/cubek-matmul/tests/multi_level/comparison.rs
@@ -42,7 +42,7 @@ fn gemm_cmma_timing_vs_multi_level() {
             "{id}: median {:?} over {} samples, {:.2} TFLOPS",
             ds[ds.len() / 2],
             ds.len(),
-            samples.tflops.unwrap_or(0.0)
+            samples.tflops().unwrap_or(0.0)
         );
     }
 }
@@ -176,7 +176,7 @@ fn gemm_cyclic_cmma_crosspoint_timing() {
                     "{id}: median {:?} over {} samples, {:.2} TFLOPS",
                     ds[ds.len() / 2],
                     ds.len(),
-                    samples.tflops.unwrap_or(0.0)
+                    samples.tflops().unwrap_or(0.0)
                 );
             }
             Err(e) => println!("{id}: setup error: {e}"),
@@ -224,7 +224,7 @@ fn gemm_cyclic_cmma_sweep() {
             let samples = bench(s, &problem, 10).unwrap();
             let mut ds = samples.durations.clone();
             ds.sort();
-            (ds[ds.len() / 2], samples.tflops.unwrap_or(0.0))
+            (ds[ds.len() / 2], samples.tflops().unwrap_or(0.0))
         };
 
         // Multi-level flattens its cube count and wgpu rejects >= 65536 cubes (device-thread

--- a/crates/cubek-test-utils/src/lib.rs
+++ b/crates/cubek-test-utils/src/lib.rs
@@ -15,7 +15,8 @@ pub use correctness::{
 };
 pub use progress::Progress;
 pub use registry::{
-    BenchmarkCategory, CatalogEntry, Category, Correctness, ItemDescriptor, RunSamples,
+    Bandwidth, BenchmarkCategory, CatalogEntry, Category, Compute, Correctness, ItemDescriptor,
+    RunSamples,
 };
 pub use test_mode::*;
 pub use test_tensor::*;

--- a/crates/cubek-test-utils/src/registry.rs
+++ b/crates/cubek-test-utils/src/registry.rs
@@ -54,7 +54,7 @@ impl<T> CatalogEntry<T> {
     }
 }
 
-/// Achieved bandwidth for a bench row, alongside the device's measured write
+/// Achieved bandwidth for a bench row, alongside the device's measured memory
 /// peak it is judged against. `peak_bytes_per_s` is `None` when the category
 /// couldn't get a peak measurement for this access.
 #[derive(Debug, Clone, Copy)]
@@ -63,12 +63,24 @@ pub struct Bandwidth {
     pub peak_bytes_per_s: Option<f64>,
 }
 
+/// Achieved compute throughput for a bench row, alongside the device's measured
+/// arithmetic peak it is judged against. `peak_ops_per_s` is `None` when the
+/// category couldn't get a peak measurement for this operation mix.
+///
+/// Reported next to [`Bandwidth`] rather than alone: one number says how fast a
+/// kernel ran, the pair says which of the two ceilings it ran into.
+#[derive(Debug, Clone, Copy)]
+pub struct Compute {
+    pub achieved_ops_per_s: f64,
+    pub peak_ops_per_s: Option<f64>,
+}
+
 #[derive(Debug, Clone)]
 pub struct RunSamples {
     pub durations: Vec<Duration>,
-    /// Optional throughput, e.g. TFLOPS for matmul/attention. `None` when the
-    /// category doesn't have a meaningful FLOP count (memcpy, contiguous, ...).
-    pub tflops: Option<f64>,
+    /// Optional compute throughput, e.g. FLOPS for matmul/attention. `None` when
+    /// the category doesn't have a meaningful operation count (memcpy, ...).
+    pub compute: Option<Compute>,
     /// Optional achieved bandwidth, e.g. for store-bound kernels like random.
     /// `None` when the category doesn't have a meaningful byte count.
     pub bandwidth: Option<Bandwidth>,
@@ -78,13 +90,13 @@ impl RunSamples {
     pub fn new(durations: Vec<Duration>) -> Self {
         Self {
             durations,
-            tflops: None,
+            compute: None,
             bandwidth: None,
         }
     }
 
-    pub fn with_tflops(mut self, tflops: f64) -> Self {
-        self.tflops = Some(tflops);
+    pub fn with_compute(mut self, compute: Compute) -> Self {
+        self.compute = Some(compute);
         self
     }
 
@@ -93,14 +105,18 @@ impl RunSamples {
         self
     }
 
-    /// Convenience for matmul-style benches: turn a flop count into TFLOPS using
-    /// the median sample duration. Returns `self` unchanged if there are no
-    /// samples or the median is zero (avoiding NaN/inf in the dashboard).
-    pub fn with_flops(self, flops: f64) -> Self {
+    /// Convenience for compute-bound benches: turn an operation count into an
+    /// achieved ops/s using the median sample duration, alongside the device's
+    /// measured peak for the same arithmetic. Returns `self` unchanged if there
+    /// are no samples or the median is zero (avoiding NaN/inf in the dashboard).
+    pub fn with_flops(self, flops: f64, peak_ops_per_s: Option<f64>) -> Self {
         let Some(median_secs) = self.median_secs() else {
             return self;
         };
-        self.with_tflops(flops / median_secs / 1e12)
+        self.with_compute(Compute {
+            achieved_ops_per_s: flops / median_secs,
+            peak_ops_per_s,
+        })
     }
 
     /// Convenience for store/load-bound benches: turn a byte count into an
@@ -116,6 +132,11 @@ impl RunSamples {
             achieved_bytes_per_s: bytes as f64 / median_secs,
             peak_bytes_per_s,
         })
+    }
+
+    /// Achieved compute throughput in TFLOPS, for callers reporting that unit.
+    pub fn tflops(&self) -> Option<f64> {
+        self.compute.map(|it| it.achieved_ops_per_s / 1e12)
     }
 
     /// Median sample duration in seconds, or `None` when there are no samples


### PR DESCRIPTION
`RunSamples` carried bandwidth as an achieved rate next to the device peak it was
measured against, but compute as a bare TFLOPS number. One number says how fast a
kernel ran; the pair says which ceiling it ran into, and only the memory side could
say it.

## What changed

- `RunSamples.tflops: Option<f64>` becomes `compute: Option<Compute>`, mirroring the
  existing `Bandwidth { achieved, peak }`.
- `with_flops(flops, peak)` now takes the peak exactly as `with_bytes(bytes, peak)`
  does, so a category with no peak to offer says `None` at the call site rather than
  leaving it to a default nobody sees.
- Bench rows print both percentages. The higher one is the bound.
- `MatmulCost::compute_key` already knew which probe a matmul over given register
  types should be judged against, but it was reachable only through a `MatmulCost`,
  which four of the six matmul bench sites never build. The key construction and the
  probe move to free functions beside it, and the method delegates instead of
  carrying a second copy of the CMMA selection.
- The bandwidth line now reads "memory peak" rather than "write peak": the probe
  behind it is `ThroughputMode::Memory`, a copy, which was already only half a write
  peak for `random`.

All six matmul bench sites supply a real peak; no placeholder `None` remains.

## Testing

`cargo check -p benchmarks --all-targets` builds every category. `cargo clippy
--all-targets` is clean on `cubek-test-utils`, `benchmarks` and `cubek-matmul`.

Not verified at runtime: the printed percentages. `cargo bench --bench split_k`
aborts on its first row inside `cubek-tile`'s matmul lowering (`mma_leaf: a
Gmem/Smem accumulator contracts through the software instruction`), in code this
branch does not touch. Whether that failure predates this branch is unconfirmed.