### PR TITLE
refactor(interpolate): widen autotune key

### DIFF
--- a/crates/cubek-interpolate/src/definition/cost.rs
+++ b/crates/cubek-interpolate/src/definition/cost.rs
@@ -1,4 +1,8 @@
-use cubecl::{ir::ElemType, tune::Work};
+use cubecl::{
+    ir::ElemType,
+    throughput::{ThroughputKey, ThroughputMode},
+    tune::Work,
+};
 
 use crate::definition::{
     InterpolateBackwardProblem, InterpolateForwardProblem, InterpolateMode, InterpolateProblem,
@@ -32,6 +36,14 @@ impl InterpolateCost {
         match &self.problem {
             InterpolateProblem::Forward(prob) => self.forward_work(prob),
             InterpolateProblem::Backward(prob) => self.backward_work(prob),
+        }
+    }
+
+    /// Throughput key for the filter's arithmetic, which runs at the element type the
+    /// tensors are read and written in.
+    pub fn compute_key(&self) -> ThroughputKey {
+        ThroughputKey {
+            mode: ThroughputMode::ComputeDirect { dtype: self.dtype },
         }
     }
 

--- a/crates/cubek-interpolate/src/definition/error.rs
+++ b/crates/cubek-interpolate/src/definition/error.rs
@@ -16,6 +16,31 @@ pub enum InterpolateError {
     #[error("Requested {requested} units per cube exceeds the device limit of {available} units")]
     UnitsPerCubeExceeded { requested: usize, available: usize },
 
+    #[error("Interpolation config must use at least one plane per cube")]
+    ZeroPlanesPerCube,
+
+    #[error("Interpolation config must use at least one row per plane")]
+    ZeroRowsPerPlane,
+
+    #[error("Interpolation config must use at least one column per lane")]
+    ZeroColsPerLane,
+
+    #[error("Interpolation config channel block must contain at least one channel")]
+    ZeroChannelBlock,
+
+    #[error("Tensor shape {shape:?} has a zero-sized dimension at axis {axis}")]
+    ZeroDimension { shape: Vec<usize>, axis: usize },
+
+    #[error(
+        "Tensor shape {shape:?} has spatial dimension {axis} of size {size}, which exceeds the maximum of {max}"
+    )]
+    SpatialDimensionTooLarge {
+        shape: Vec<usize>,
+        axis: usize,
+        size: usize,
+        max: usize,
+    },
+
     #[error(
         "Interpolate expects 4D tensors (NHWC), but got input rank {input} and output rank {output}"
     )]
@@ -28,11 +53,11 @@ pub enum InterpolateError {
     ChannelMismatch { input: usize, output: usize },
 
     #[error(
-        "Shape mismatch: input shape {input:?} and output gradient shape {output:?} must match exactly"
+        "Shape mismatch: input shape {input:?} and input gradient shape {input_grad:?} must match exactly"
     )]
     ShapeMismatch {
         input: Vec<usize>,
-        output: Vec<usize>,
+        input_grad: Vec<usize>,
     },
 }
 

--- a/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
@@ -16,10 +16,10 @@ use crate::{
     interpolate, interpolate_backward,
 };
 
-use super::InterpolateBenchmarkStrategy;
+use crate::InterpolateConfig;
 
 pub fn bench(
-    strategy: &InterpolateBenchmarkStrategy,
+    strategy: &InterpolateConfig,
     problem: &InterpolateProblem,
     num_samples: usize,
 ) -> Result<RunSamples, String> {
@@ -65,7 +65,7 @@ fn memory_peak_bytes_per_s(client: &ComputeClient<TestRuntime>) -> Option<f64> {
 
 struct InterpolateBench {
     problem: InterpolateProblem,
-    strategy: InterpolateBenchmarkStrategy,
+    strategy: InterpolateConfig,
     device: <TestRuntime as Runtime>::Device,
     client: ComputeClient<TestRuntime>,
     dtype: ElemType,
@@ -116,19 +116,19 @@ impl Benchmark for InterpolateBench {
                         .uniform(0, -1., 1.)
                         .generate_without_host_data();
 
-                let output = TensorHandle::empty(&self.client, input_grad_shape, self.dtype);
+                let input_grad = TensorHandle::empty(&self.client, input_grad_shape, self.dtype);
 
                 interpolate_backward(
                     &self.client,
                     backward_input.binding(),
                     input.clone().binding(),
-                    output.clone().binding(),
+                    input_grad.clone().binding(),
                     prob.options,
                     self.dtype,
                 )
                 .map_err(|err| format!("{err}"))?;
 
-                Ok(output)
+                Ok(input_grad)
             }
         }
     }

--- a/crates/cubek-interpolate/src/eval/benchmarks/correctness.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/correctness.rs
@@ -2,21 +2,20 @@ use cubecl::{Runtime, TestRuntime};
 use cubek_test_utils::{HostData, Progress};
 
 use crate::{
+    InterpolateConfig,
     definition::InterpolateProblem,
     eval::cpu_reference::{cpu_reference_result, kernel_result},
 };
-
-use super::InterpolateBenchmarkStrategy;
 
 pub struct InterpolateCorrectness;
 
 impl cubek_test_utils::Correctness for InterpolateCorrectness {
     type Problem = InterpolateProblem;
-    type Strategy = InterpolateBenchmarkStrategy;
+    type Strategy = InterpolateConfig;
 
     fn kernel_result(
         &self,
-        strategy: &InterpolateBenchmarkStrategy,
+        strategy: &InterpolateConfig,
         problem: &InterpolateProblem,
         seeds: &[u64],
     ) -> Result<HostData, String> {

--- a/crates/cubek-interpolate/src/eval/benchmarks/mod.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/mod.rs
@@ -7,20 +7,18 @@ mod strategy;
 pub use benchmark::bench;
 pub use correctness::InterpolateCorrectness;
 pub use problem::{problems, problems_scaled};
-pub use strategy::{
-    BenchTarget, BenchTier, InterpolateBenchmarkStrategy, every_strategy, strategies, strategies_at,
-};
+pub use strategy::{BenchTarget, BenchTier, every_strategy, strategies, strategies_at};
 
 use cubecl::benchmark::TimingMethod;
 use cubek_test_utils::{CatalogEntry, RunSamples};
 
-use crate::definition::InterpolateProblem;
+use crate::{InterpolateConfig, definition::InterpolateProblem};
 
 pub struct Category;
 
 impl cubek_test_utils::Category for Category {
     type Problem = InterpolateProblem;
-    type Strategy = InterpolateBenchmarkStrategy;
+    type Strategy = InterpolateConfig;
 
     fn id(&self) -> &'static str {
         "interpolate"
@@ -34,13 +32,13 @@ impl cubek_test_utils::Category for Category {
         problems()
     }
 
-    fn strategies(&self) -> Vec<CatalogEntry<InterpolateBenchmarkStrategy>> {
+    fn strategies(&self) -> Vec<CatalogEntry<InterpolateConfig>> {
         strategies(BenchTarget::Gpu)
     }
 
     fn bench(
         &self,
-        strategy: &InterpolateBenchmarkStrategy,
+        strategy: &InterpolateConfig,
         problem: &InterpolateProblem,
         num_samples: usize,
     ) -> Result<RunSamples, String> {
@@ -55,7 +53,7 @@ impl cubek_test_utils::Category for Category {
     ) -> Option<
         &dyn cubek_test_utils::Correctness<
             Problem = InterpolateProblem,
-            Strategy = InterpolateBenchmarkStrategy,
+            Strategy = InterpolateConfig,
         >,
     > {
         Some(&InterpolateCorrectness)
@@ -75,7 +73,7 @@ pub struct CpuCategory;
 
 impl cubek_test_utils::Category for CpuCategory {
     type Problem = InterpolateProblem;
-    type Strategy = InterpolateBenchmarkStrategy;
+    type Strategy = InterpolateConfig;
 
     fn id(&self) -> &'static str {
         "interpolate_cpu"
@@ -89,13 +87,13 @@ impl cubek_test_utils::Category for CpuCategory {
         problems_scaled(CPU_DIVISOR)
     }
 
-    fn strategies(&self) -> Vec<CatalogEntry<InterpolateBenchmarkStrategy>> {
+    fn strategies(&self) -> Vec<CatalogEntry<InterpolateConfig>> {
         strategies(BenchTarget::Cpu)
     }
 
     fn bench(
         &self,
-        strategy: &InterpolateBenchmarkStrategy,
+        strategy: &InterpolateConfig,
         problem: &InterpolateProblem,
         num_samples: usize,
     ) -> Result<RunSamples, String> {
@@ -111,7 +109,7 @@ impl cubek_test_utils::Category for CpuCategory {
     ) -> Option<
         &dyn cubek_test_utils::Correctness<
             Problem = InterpolateProblem,
-            Strategy = InterpolateBenchmarkStrategy,
+            Strategy = InterpolateConfig,
         >,
     > {
         Some(&InterpolateCorrectness)

--- a/crates/cubek-interpolate/src/eval/benchmarks/strategy.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/strategy.rs
@@ -1,9 +1,7 @@
 use cubek_test_utils::CatalogEntry;
 use cubek_tile::Residence;
 
-use crate::kernel::InterpolateConfig;
-
-pub type InterpolateBenchmarkStrategy = InterpolateConfig;
+use crate::InterpolateConfig;
 
 /// How much of the tile geometry space one run sweeps.
 ///
@@ -133,7 +131,7 @@ fn powers_of_two(max: usize) -> impl Iterator<Item = usize> {
 fn kernel_entry(
     residence: Residence,
     (planes, rows, cols): (usize, usize, usize),
-) -> CatalogEntry<InterpolateBenchmarkStrategy> {
+) -> CatalogEntry<InterpolateConfig> {
     let (tag, label) = match residence {
         Residence::Smem => ("smem", "staged"),
         _ => ("in_place", "in-place"),
@@ -146,10 +144,7 @@ fn kernel_entry(
 }
 
 /// The catalogue at a stated tier and target.
-pub fn strategies_at(
-    tier: BenchTier,
-    target: BenchTarget,
-) -> Vec<CatalogEntry<InterpolateBenchmarkStrategy>> {
+pub fn strategies_at(tier: BenchTier, target: BenchTarget) -> Vec<CatalogEntry<InterpolateConfig>> {
     let mut entries = Vec::new();
     for &residence in target.residences() {
         for geometry in target.geometries(tier) {
@@ -160,7 +155,7 @@ pub fn strategies_at(
 }
 
 /// The catalogue a bench run sweeps: the tier named by `CUBEK_BENCH_TIER`.
-pub fn strategies(target: BenchTarget) -> Vec<CatalogEntry<InterpolateBenchmarkStrategy>> {
+pub fn strategies(target: BenchTarget) -> Vec<CatalogEntry<InterpolateConfig>> {
     strategies_at(BenchTier::from_env(), target)
 }
 
@@ -168,7 +163,7 @@ pub fn strategies(target: BenchTarget) -> Vec<CatalogEntry<InterpolateBenchmarkS
 ///
 /// Lookup by id goes through here, so a correctness test naming a geometry keeps resolving when
 /// the tier narrows what a bench run measures.
-pub fn every_strategy() -> Vec<CatalogEntry<InterpolateBenchmarkStrategy>> {
+pub fn every_strategy() -> Vec<CatalogEntry<InterpolateConfig>> {
     strategies_at(BenchTier::Full, BenchTarget::Gpu)
 }
 

--- a/crates/cubek-interpolate/src/eval/cpu_reference/backward/mod.rs
+++ b/crates/cubek-interpolate/src/eval/cpu_reference/backward/mod.rs
@@ -11,7 +11,7 @@ use cubek_test_utils::{
 
 use crate::interpolate_backward;
 
-pub fn strategy_result(
+pub fn kernel_result(
     client: ComputeClient<TestRuntime>,
     problem: InterpolateBackwardProblem,
     seed: u64,
@@ -93,8 +93,8 @@ pub fn reference_for_backward_interpolation_mode(
     progress: Option<&Progress>,
 ) -> HostData {
     match options.mode {
-        InterpolateMode::Nearest(_) => {
-            reference_nearest_backward(out_grad, output_shape, options.align_corners, progress)
+        InterpolateMode::Nearest(nearest_mode) => {
+            reference_nearest_backward(out_grad, output_shape, nearest_mode, progress)
         }
         InterpolateMode::Bilinear => {
             panic!("Bilinear interpolation backward is not supported by CPU reference")

--- a/crates/cubek-interpolate/src/eval/cpu_reference/backward/nearest.rs
+++ b/crates/cubek-interpolate/src/eval/cpu_reference/backward/nearest.rs
@@ -1,12 +1,14 @@
 use cubecl::zspace::Shape;
 use cubek_test_utils::{HostData, HostDataVec, Progress};
 
+use crate::definition::NearestMode;
+
 use super::super::{contiguous_strides, for_each_output_coord};
 
 pub fn reference_nearest_backward(
     out_grad: &HostData,
     output_shape: &[usize],
-    _: bool,
+    nearest_mode: NearestMode,
     progress: Option<&Progress>,
 ) -> HostData {
     let (out_h, out_w) = (output_shape[1], output_shape[2]);
@@ -19,10 +21,10 @@ pub fn reference_nearest_backward(
         let out_x = out_coord[2];
         let c = out_coord[3];
 
-        let grad_y_start = start_index(out_y, grad_h, out_h);
-        let grad_y_end = end_index(out_y, grad_h, out_h);
-        let grad_x_start = start_index(out_x, grad_w, out_w);
-        let grad_x_end = end_index(out_x, grad_w, out_w);
+        let grad_y_start = start_index(out_y, grad_h, out_h, nearest_mode);
+        let grad_y_end = end_index(out_y, grad_h, out_h, nearest_mode);
+        let grad_x_start = start_index(out_x, grad_w, out_w, nearest_mode);
+        let grad_x_end = end_index(out_x, grad_w, out_w, nearest_mode);
 
         let mut sum = 0.0f32;
         for grad_y in grad_y_start..grad_y_end {
@@ -45,16 +47,42 @@ pub fn reference_nearest_backward(
     }
 }
 
-fn start_index(input_index: usize, output_size: usize, input_size: usize) -> usize {
-    let numerator = (input_index * output_size) as f32;
-    let div = (numerator / input_size as f32).ceil();
-
-    div as usize
+fn start_index(
+    input_index: usize,
+    output_size: usize,
+    input_size: usize,
+    nearest_mode: NearestMode,
+) -> usize {
+    let ratio = (input_index * output_size) as f32 / input_size as f32;
+    match nearest_mode {
+        NearestMode::Floor => ratio.ceil() as usize,
+        NearestMode::Exact => (ratio - 0.5).ceil().max(0.0) as usize,
+    }
 }
 
-fn end_index(input_index: usize, output_size: usize, input_size: usize) -> usize {
-    let numerator = ((input_index + 1) * output_size) as f32;
-    let div = (numerator / input_size as f32).ceil() as usize;
+fn end_index(
+    input_index: usize,
+    output_size: usize,
+    input_size: usize,
+    nearest_mode: NearestMode,
+) -> usize {
+    start_index(input_index + 1, output_size, input_size, nearest_mode).min(output_size)
+}
 
-    div.min(output_size)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floor_and_exact_have_distinct_inverse_boundaries() {
+        let floor: Vec<_> = (0..=4)
+            .map(|index| start_index(index, 10, 4, NearestMode::Floor).min(10))
+            .collect();
+        let exact: Vec<_> = (0..=4)
+            .map(|index| start_index(index, 10, 4, NearestMode::Exact).min(10))
+            .collect();
+
+        assert_eq!(floor, [0, 3, 5, 8, 10]);
+        assert_eq!(exact, [0, 2, 5, 7, 10]);
+    }
 }

--- a/crates/cubek-interpolate/src/eval/cpu_reference/forward/mod.rs
+++ b/crates/cubek-interpolate/src/eval/cpu_reference/forward/mod.rs
@@ -10,9 +10,9 @@ pub(crate) use nearest::reference_nearest;
 
 use super::{f32_elem_type, make_random_f32_host, make_zero_handle};
 use crate::{
+    InterpolateConfig,
     definition::{InterpolateForwardProblem, InterpolateMode, InterpolateOptions},
     interpolate,
-    kernel::InterpolateConfig,
 };
 use cubecl::{TestRuntime, client::ComputeClient};
 use cubek_test_utils::{

--- a/crates/cubek-interpolate/src/eval/cpu_reference/mod.rs
+++ b/crates/cubek-interpolate/src/eval/cpu_reference/mod.rs
@@ -2,8 +2,8 @@ mod backward;
 mod forward;
 
 use crate::{
+    InterpolateConfig,
     definition::{InterpolateOptions, InterpolateProblem},
-    kernel::InterpolateConfig,
 };
 use cubecl::std::tensor::TensorHandle;
 use cubecl::{TestRuntime, client::ComputeClient, prelude::*, zspace::Strides};
@@ -42,7 +42,7 @@ pub fn kernel_result(
 ) -> Result<HostData, String> {
     match problem {
         InterpolateProblem::Forward(prob) => forward::kernel_result(client, prob, config, seed),
-        InterpolateProblem::Backward(prob) => backward::strategy_result(client, prob, seed),
+        InterpolateProblem::Backward(prob) => backward::kernel_result(client, prob, seed),
     }
 }
 

--- a/crates/cubek-interpolate/src/kernel/backward.rs
+++ b/crates/cubek-interpolate/src/kernel/backward.rs
@@ -17,7 +17,7 @@ use cubecl::{
 pub(crate) fn interpolate_nearest_backward_launch<R: Runtime>(
     client: &ComputeClient<R>,
     out_grad: TensorBinding<R>,
-    output: TensorBinding<R>,
+    input_grad: TensorBinding<R>,
     nearest_mode: NearestMode,
     dtype: ElemType,
 ) -> Result<(), crate::definition::InterpolateError> {
@@ -27,14 +27,14 @@ pub(crate) fn interpolate_nearest_backward_launch<R: Runtime>(
         &out_grad.strides,
         out_grad.shape.len() - 1,
     );
-    let shape_out = shape_divmod(&output);
-    let out_layout = linear_layout(&output, vector_size);
-    let working_units = output.shape.iter().product::<usize>() / vector_size as usize;
+    let input_grad_shape = shape_divmod(&input_grad);
+    let input_grad_layout = linear_layout(&input_grad, vector_size);
+    let working_units = input_grad.shape.iter().product::<usize>() / vector_size as usize;
     let cube_dim = CubeDim::new(client, working_units);
     let cube_count = calculate_cube_count_elemwise(client, working_units, cube_dim);
     let address_type = out_grad
         .required_address_type(dtype.size())
-        .max(output.required_address_type(dtype.size()));
+        .max(input_grad.required_address_type(dtype.size()));
 
     unsafe {
         execute_interpolate_nearest_backward::launch_unchecked(
@@ -44,9 +44,9 @@ pub(crate) fn interpolate_nearest_backward_launch<R: Runtime>(
             address_type,
             vector_size,
             out_grad.into_tensor_arg(),
-            output.clone().into_tensor_arg(),
-            shape_out,
-            out_layout,
+            input_grad.clone().into_tensor_arg(),
+            input_grad_shape,
+            input_grad_layout,
             nearest_mode,
             dtype,
         )
@@ -77,27 +77,27 @@ fn linear_layout<R: Runtime>(
 #[cube(launch_unchecked, address_type = "dynamic")]
 pub fn execute_interpolate_nearest_backward<F: Float, N: Size>(
     grad: &Tensor<Vector<F, N>>,
-    output: &mut Tensor<Vector<F, N>>,
-    shape_out: Sequence<FastDivmod<usize>>,
-    out_layout: LinearLayout,
+    input_grad: &mut Tensor<Vector<F, N>>,
+    input_grad_shape: Sequence<FastDivmod<usize>>,
+    input_grad_layout: LinearLayout,
     #[comptime] nearest_mode: NearestMode,
     #[define(F)] _dtype: ElemType,
 ) {
-    if ABSOLUTE_POS >= output.len() {
+    if ABSOLUTE_POS >= input_grad.len() {
         terminate!();
     }
 
     let vector_size = grad.vector_size();
-    let out_idx = out_layout.to_source_pos(ABSOLUTE_POS);
+    let input_grad_idx = input_grad_layout.to_source_pos(ABSOLUTE_POS);
 
-    let out_h = output.shape(1);
-    let out_w = output.shape(2);
+    let out_h = input_grad.shape(1);
+    let out_w = input_grad.shape(2);
     let grad_h = grad.shape(1);
     let grad_w = grad.shape(2);
 
-    let (rem, c) = shape_out[3].div_mod(ABSOLUTE_POS * vector_size);
-    let (rem, out_x) = shape_out[2].div_mod(rem);
-    let (b, out_y) = shape_out[1].div_mod(rem);
+    let (rem, c) = input_grad_shape[3].div_mod(ABSOLUTE_POS * vector_size);
+    let (rem, out_x) = input_grad_shape[2].div_mod(rem);
+    let (b, out_y) = input_grad_shape[1].div_mod(rem);
 
     let grad_y_start = start_index::<F>(out_y, grad_h, out_h, nearest_mode);
     let grad_y_end = end_index::<F>(out_y, grad_h, out_h, nearest_mode);
@@ -116,7 +116,7 @@ pub fn execute_interpolate_nearest_backward<F: Float, N: Size>(
         }
     }
 
-    output[out_idx] = sum;
+    input_grad[input_grad_idx] = sum;
 }
 
 #[cube]
@@ -135,7 +135,7 @@ fn start_index<F: Float>(
         NearestMode::Exact => {
             let num = F::cast_from(input_index * output_size);
             let den = F::cast_from(input_size);
-            let div = (num / den).ceil() - F::new(0.5_f32);
+            let div = num / den - F::new(0.5_f32);
 
             let mask = F::cast_from((div >= F::zero()) as usize);
             usize::cast_from(div.ceil() * mask)

--- a/crates/cubek-interpolate/src/kernel/forward/launch.rs
+++ b/crates/cubek-interpolate/src/kernel/forward/launch.rs
@@ -53,7 +53,8 @@ impl InterpolateConfig {
         }
     }
 
-    /// Pin the lane's channel run rather than solving it. Must divide the channel count.
+    /// Pin the lane's channel run rather than solving it. A final block may overhang the channel
+    /// count; reads and writes in that padded tail are masked.
     pub const fn with_channel_block(self, block: usize) -> Self {
         Self {
             channel_block: Some(block),
@@ -62,7 +63,7 @@ impl InterpolateConfig {
     }
 
     /// The geometry these choices describe, over a plane of `lanes`.
-    pub fn geometry(&self, channels: usize, lanes: usize) -> TileGeometry {
+    pub(crate) fn geometry(&self, channels: usize, lanes: usize) -> TileGeometry {
         TileGeometry::from_config(
             channels,
             lanes,
@@ -71,6 +72,22 @@ impl InterpolateConfig {
             self.cols_per_lane,
             self.channel_block,
         )
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), InterpolateError> {
+        if self.planes_per_cube == 0 {
+            return Err(InterpolateError::ZeroPlanesPerCube);
+        }
+        if self.rows_per_plane == 0 {
+            return Err(InterpolateError::ZeroRowsPerPlane);
+        }
+        if self.cols_per_lane == 0 {
+            return Err(InterpolateError::ZeroColsPerLane);
+        }
+        if self.channel_block == Some(0) {
+            return Err(InterpolateError::ZeroChannelBlock);
+        }
+        Ok(())
     }
 }
 
@@ -127,12 +144,6 @@ fn launch<R: Runtime, F: SeparableFilterFamily>(
         output.shape[1],
         output.shape[2],
     );
-    assert!(
-        input_h <= i32::MAX as usize
-            && input_w <= i32::MAX as usize
-            && output_h <= i32::MAX as usize
-            && output_w <= i32::MAX as usize
-    );
     let row = Rational::of(get_transform(input_h, output_h, options));
     let col = Rational::of(get_transform(input_w, output_w, options));
     let lanes = client.properties().hardware.plane_size_max as usize;
@@ -140,7 +151,7 @@ fn launch<R: Runtime, F: SeparableFilterFamily>(
     // Cheap to check before any of the space/vectorization work below: a cube this wide is
     // refused outright rather than built and then rejected by the device at dispatch.
     let max_units = client.properties().hardware.max_units_per_cube as usize;
-    let units_per_cube = geometry.planes_per_cube * lanes;
+    let units_per_cube = geometry.planes_per_cube.saturating_mul(lanes);
     if units_per_cube > max_units {
         return Err(InterpolateError::UnitsPerCubeExceeded {
             requested: units_per_cube,
@@ -191,24 +202,25 @@ fn launch<R: Runtime, F: SeparableFilterFamily>(
     // own overhang mask drops those columns), but the reads still have to be in bounds.
     let checked = !in_bounds || stage_width.is_some();
 
-    let max_smem = client.properties().hardware.max_shared_memory_size;
-    let requested_smem = space::stage_window_bytes(
-        row,
-        col,
-        properties.taps,
-        F::radius(),
-        geometry,
-        stage_width.unwrap_or(vector_size),
-        dtype.size(),
-    );
-
     // The residence is stated, so the only thing left to decide is whether the device can serve
     // it. Capacity is a hard limit rather than a preference, so it refuses instead of falling back.
-    if residence == Residence::Smem && requested_smem > max_smem {
-        return Err(InterpolateError::SharedMemoryLimitExceeded {
-            requested: requested_smem,
-            available: max_smem,
-        });
+    if residence == Residence::Smem {
+        let available = client.properties().hardware.max_shared_memory_size;
+        let requested = space::stage_window_bytes(
+            row,
+            col,
+            properties.taps,
+            F::radius(),
+            geometry,
+            stage_width.unwrap_or(vector_size),
+            dtype.size(),
+        );
+        if requested > available {
+            return Err(InterpolateError::SharedMemoryLimitExceeded {
+                requested,
+                available,
+            });
+        }
     }
 
     let mut input_arg = launch

--- a/crates/cubek-interpolate/src/kernel/forward/mod.rs
+++ b/crates/cubek-interpolate/src/kernel/forward/mod.rs
@@ -11,5 +11,5 @@ mod geometry;
 mod launch;
 mod space;
 
-pub use geometry::*;
-pub use launch::*;
+pub use launch::InterpolateConfig;
+pub(crate) use launch::interpolate_launch;

--- a/crates/cubek-interpolate/src/kernel/mod.rs
+++ b/crates/cubek-interpolate/src/kernel/mod.rs
@@ -1,6 +1,8 @@
-pub mod backward;
-pub mod forward;
+mod backward;
+mod forward;
 
+pub use cubek_tile::Residence;
 pub use forward::InterpolateConfig;
 
 pub(crate) use backward::interpolate_nearest_backward_launch;
+pub(crate) use forward::interpolate_launch;

--- a/crates/cubek-interpolate/src/lib.rs
+++ b/crates/cubek-interpolate/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod definition;
 #[cfg(any(feature = "cpu-reference", feature = "benchmarks"))]
 pub mod eval;
-pub mod kernel;
+mod kernel;
 pub mod tune_key;
+
+pub use kernel::{InterpolateConfig, Residence};
 
 use crate::{
     definition::{InterpolateError, InterpolateMode, InterpolateOptions},
-    kernel::{InterpolateConfig, forward::interpolate_launch, interpolate_nearest_backward_launch},
+    kernel::{interpolate_launch, interpolate_nearest_backward_launch},
 };
 use core::result::Result;
 use cubecl::{Runtime, client::ComputeClient, prelude::TensorBinding, prelude::*};
@@ -25,7 +27,10 @@ pub fn interpolate<R: Runtime>(
     dtype: ElemType,
 ) -> Result<(), InterpolateError> {
     validate_rank(input.shape.len(), output.shape.len())?;
+    validate_shape(&input.shape)?;
+    validate_shape(&output.shape)?;
     validate_nhwc_consistency(&input.shape, &output.shape)?;
+    config.validate()?;
 
     interpolate_launch(client, input, output, options, dtype, config)
 }
@@ -39,25 +44,28 @@ pub fn interpolate_backward<R: Runtime>(
     client: &ComputeClient<R>,
     input: TensorBinding<R>,
     out_grad: TensorBinding<R>,
-    output: TensorBinding<R>,
+    input_grad: TensorBinding<R>,
     options: InterpolateOptions,
     dtype: ElemType,
 ) -> Result<(), InterpolateError> {
-    validate_rank(input.shape.len(), output.shape.len())?;
-    validate_rank(out_grad.shape.len(), output.shape.len())?;
-    validate_nhwc_consistency(&input.shape, &output.shape)?;
-    validate_nhwc_consistency(&out_grad.shape, &output.shape)?;
+    validate_rank(input.shape.len(), input_grad.shape.len())?;
+    validate_rank(out_grad.shape.len(), input_grad.shape.len())?;
+    validate_shape(&input.shape)?;
+    validate_shape(&out_grad.shape)?;
+    validate_shape(&input_grad.shape)?;
+    validate_nhwc_consistency(&input.shape, &input_grad.shape)?;
+    validate_nhwc_consistency(&out_grad.shape, &input_grad.shape)?;
 
-    if input.shape != output.shape {
+    if input.shape != input_grad.shape {
         return Err(InterpolateError::ShapeMismatch {
             input: input.shape.to_vec(),
-            output: output.shape.to_vec(),
+            input_grad: input_grad.shape.to_vec(),
         });
     }
 
     match options.mode {
         InterpolateMode::Nearest(nearest_mode) => {
-            interpolate_nearest_backward_launch(client, out_grad, output, nearest_mode, dtype)
+            interpolate_nearest_backward_launch(client, out_grad, input_grad, nearest_mode, dtype)
         }
         _ => Err(InterpolateError::UnsupportedMode(format!(
             "{:?} interpolation backward is not supported by JIT backend",
@@ -73,6 +81,26 @@ fn validate_rank(input_rank: usize, output_rank: usize) -> Result<(), Interpolat
             input: input_rank,
             output: output_rank,
         });
+    }
+    Ok(())
+}
+
+fn validate_shape(shape: &[usize]) -> Result<(), InterpolateError> {
+    for (axis, &size) in shape.iter().enumerate() {
+        if size == 0 {
+            return Err(InterpolateError::ZeroDimension {
+                shape: shape.to_vec(),
+                axis,
+            });
+        }
+        if matches!(axis, 1 | 2) && size > i32::MAX as usize {
+            return Err(InterpolateError::SpatialDimensionTooLarge {
+                shape: shape.to_vec(),
+                axis,
+                size,
+                max: i32::MAX as usize,
+            });
+        }
     }
     Ok(())
 }

--- a/crates/cubek-interpolate/src/tune_key.rs
+++ b/crates/cubek-interpolate/src/tune_key.rs
@@ -1,69 +1,174 @@
 use crate::definition::InterpolateMode;
-use cubecl::{AutotuneKey, ir::ElemType};
+use cubecl::{ir::ElemType, tune::anchor, AutotuneKey};
 use serde::{Deserialize, Serialize};
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, AutotuneKey)]
-/// Autotune key representative of interpolation versions
+/// Autotune key representative of interpolation kernel shapes.
 pub struct InterpolateAutotuneKey {
     elem_input: ElemType,
     elem_output: ElemType,
     mode: InterpolateMode,
+    align_corners: bool,
 
-    /// Whether the number of channels is a power of 4, which allows for more efficient vectorized processing.
-    ///
-    /// # Notes
-    ///
-    /// This is a boolean flag that can be true or false, so 2 values are possible.
-    pub channels_power_of_4: bool,
+    /// Input height, anchored with the same bucket as the output height.
+    #[autotune(anchor(exp(max = 8192, base = 2)))]
+    pub input_height: usize,
+    /// Input width, anchored with the same bucket as the output width.
+    #[autotune(anchor(exp(max = 8192, base = 2)))]
+    pub input_width: usize,
+    /// Output height.
+    #[autotune(anchor(exp(max = 8192, base = 2)))]
+    pub output_height: usize,
+    /// Output width.
+    #[autotune(anchor(exp(max = 8192, base = 2)))]
+    pub output_width: usize,
 
-    /// Number of channels
-    ///
-    /// # Notes
-    ///
-    /// Max is 4096, so 12 values are possible.
+    /// Number of channels.
     #[autotune(anchor(exp(max = 4096, base = 2)))]
     pub channels: usize,
-
-    /// Height of the interpolated output.
-    ///
-    /// # Notes
-    ///
-    /// Max is 8192, so 14 values are possible.
-    #[autotune(anchor(exp(max = 8192, base = 2)))]
-    pub out_height: usize,
-
-    /// Width of the interpolated output.
-    ///
-    /// # Notes
-    ///
-    /// Max is 8192, so 14 values are possible.
-    #[autotune(anchor(exp(max = 8192, base = 2)))]
-    pub out_width: usize,
+    /// Alignment of the contiguous channel axis, which bounds vectorization.
+    pub channels_pow2_factor: u8,
+    /// Alignment in bytes of the contiguous row stride, which also bounds vectorization.
+    pub channels_stride_factor: u8,
 }
 
 impl InterpolateAutotuneKey {
+    /// Creates a key from the extents of the NHWC tensors passed to the interpolation kernel.
+    #[allow(clippy::too_many_arguments)]
     pub fn generate(
         elem_input: ElemType,
         elem_output: ElemType,
         mode: InterpolateMode,
-        input_shape: &[usize],
-        output_size: &[usize; 2],
+        align_corners: bool,
+        input_height: usize,
+        input_width: usize,
+        channels: usize,
+        output_height: usize,
+        output_width: usize,
     ) -> Self {
-        let channels = input_shape[3];
+        let channels_anchored = anchor(channels, Some(4096), None, Some(2));
 
-        let output_height = output_size[0];
-        let output_width = output_size[1];
-
-        let channels_power_of_4 = channels.is_multiple_of(4);
-
-        InterpolateAutotuneKey::new(
+        Self::new(
             elem_input,
             elem_output,
             mode,
-            channels_power_of_4,
+            align_corners,
+            input_height,
+            input_width,
+            output_height,
+            output_width,
+            channels,
+            pow2_factor(channels_anchored),
+            stride_factor(channels_anchored, elem_input),
+        )
+    }
+}
+
+/// The largest vector alignment relevant to CubeCL's optimized vector sizes.
+fn pow2_factor(extent: usize) -> u8 {
+    extent.trailing_zeros().min(4) as u8
+}
+
+/// Maximum factor relevant to strides: CubeCL's largest swizzle repeat is 128 bytes.
+const MAX_STRIDE_FACTOR: u32 = 10;
+
+/// Alignment in powers of two of the contiguous NHWC row stride.
+fn stride_factor(channels: usize, elem: ElemType) -> u8 {
+    let bytes = (channels * elem.size_bits()) / 8;
+    bytes.trailing_zeros().min(MAX_STRIDE_FACTOR) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cubecl::ir::{ElemType, FloatKind};
+
+    const F32: ElemType = ElemType::Float(FloatKind::F32);
+
+    // Keep this next to the key fields. A kernel comptime input added to either interpolation
+    // architecture must be represented here and in `InterpolateAutotuneKey` before it can share
+    // autotune results safely.
+    const KERNEL_COMPTIME_INPUTS: &[&str] = &[
+        "mode",
+        "align_corners",
+        "height transform (input and output height)",
+        "width transform (input and output width)",
+        "vector size (channel and row-stride alignment)",
+        "input dtype",
+        "accumulator dtype",
+        "tiled bounds check and boundary",
+    ];
+
+    fn key(
+        input_height: usize,
+        input_width: usize,
+        channels: usize,
+        output_height: usize,
+        output_width: usize,
+        align_corners: bool,
+    ) -> InterpolateAutotuneKey {
+        InterpolateAutotuneKey::generate(
+            F32,
+            F32,
+            InterpolateMode::Bilinear,
+            align_corners,
+            input_height,
+            input_width,
             channels,
             output_height,
             output_width,
         )
+    }
+
+    fn key_with_mode(mode: InterpolateMode, elem: ElemType) -> InterpolateAutotuneKey {
+        InterpolateAutotuneKey::generate(elem, elem, mode, true, 64, 64, 64, 128, 128)
+    }
+
+    #[test]
+    fn raw_extents_within_anchored_buckets_share_a_key() {
+        let reference = key(69, 70, 69, 130, 129, true);
+        for (input_height, input_width, channels, output_height, output_width) in [
+            (70, 76, 76, 140, 140),
+            (88, 96, 96, 192, 192),
+            (128, 128, 128, 256, 256),
+        ] {
+            assert_eq!(
+                reference,
+                key(
+                    input_height,
+                    input_width,
+                    channels,
+                    output_height,
+                    output_width,
+                    true
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn anchored_kernel_shape_inputs_change_the_key() {
+        let reference = key(64, 64, 64, 128, 128, true);
+        assert_ne!(reference, key(128, 64, 64, 128, 128, true));
+        assert_ne!(reference, key(64, 128, 64, 128, 128, true));
+        assert_ne!(reference, key(64, 64, 64, 64, 128, true));
+        assert_ne!(reference, key(64, 64, 64, 128, 64, true));
+        assert_ne!(reference, key(64, 64, 64, 128, 128, false));
+        assert_ne!(reference, key(64, 64, 128, 128, 128, true));
+        assert_ne!(
+            key_with_mode(InterpolateMode::Bilinear, F32),
+            key_with_mode(InterpolateMode::Bicubic, F32)
+        );
+        assert_ne!(
+            key_with_mode(InterpolateMode::Bilinear, F32),
+            key_with_mode(InterpolateMode::Bilinear, ElemType::Float(FloatKind::F16))
+        );
+    }
+
+    #[test]
+    fn comptime_inputs_are_documented_with_the_key() {
+        assert_eq!(KERNEL_COMPTIME_INPUTS.len(), 8);
+        assert!(KERNEL_COMPTIME_INPUTS.contains(&"align_corners"));
+        assert!(KERNEL_COMPTIME_INPUTS.contains(&"vector size (channel and row-stride alignment)"));
     }
 }

--- a/crates/cubek-interpolate/tests/interpolate/bench_catalog.rs
+++ b/crates/cubek-interpolate/tests/interpolate/bench_catalog.rs
@@ -3,9 +3,7 @@
 #![cfg(feature = "benchmarks")]
 
 use cubek_interpolate::eval::benchmarks::InterpolateCorrectness;
-use cubek_interpolate::{
-    definition::InterpolateProblem, eval::benchmarks::InterpolateBenchmarkStrategy,
-};
+use cubek_interpolate::{InterpolateConfig, definition::InterpolateProblem};
 use cubek_test_utils::{CatalogEntry, Correctness, TestOutcome, assert_equals_approx};
 
 const SEEDS: [u64; 2] = [12, 34];
@@ -23,7 +21,7 @@ fn lookup<T>(entries: Vec<CatalogEntry<T>>, id: &str) -> T {
 fn run(strategy_id: &str, problem_id: &str) {
     use cubek_interpolate::eval::benchmarks::{every_strategy, problems};
 
-    let strategy: InterpolateBenchmarkStrategy = lookup(every_strategy(), strategy_id);
+    let strategy: InterpolateConfig = lookup(every_strategy(), strategy_id);
     let problem: InterpolateProblem = lookup(problems(), problem_id);
 
     let actual = match InterpolateCorrectness.kernel_result(&strategy, &problem, &SEEDS) {

--- a/crates/cubek-interpolate/tests/interpolate/forward/kernel.rs
+++ b/crates/cubek-interpolate/tests/interpolate/forward/kernel.rs
@@ -2,13 +2,12 @@
 
 use cubecl::{TestRuntime, prelude::*};
 use cubek_interpolate::{
+    InterpolateConfig, Residence,
     definition::{InterpolateMode, InterpolateOptions, NearestMode},
     eval::cpu_reference::cpu_reference_interpolate_from_host,
     interpolate,
-    kernel::InterpolateConfig,
 };
 use cubek_test_utils::{TestInput, assert_equals_approx};
-use cubek_tile::Residence;
 
 use super::super::{build_output_tensor, output_host_f32, validate_test};
 use super::make_problem;


### PR DESCRIPTION
Keys interpolation autotuning by anchored input/output extents, align-corners mode, and channel vectorization factors. Validation: cargo test -p cubek-interpolate --all-features --lib; cargo clippy -p cubek-interpolate --all-features --lib -- -D warnings.