### PR TITLE
refactor(interpolate): centralize mode properties and launch-path refusals

### DIFF
--- a/crates/cubek-interpolate/src/definition/cost.rs
+++ b/crates/cubek-interpolate/src/definition/cost.rs
@@ -2,7 +2,7 @@ use cubecl::{ir::ElemType, tune::Work};
 
 use crate::definition::{
     InterpolateBackwardProblem, InterpolateForwardProblem, InterpolateMode, InterpolateProblem,
-    get_halo, get_requires_bound_check,
+    mode_properties,
 };
 
 /// Minimal representation of interpolate cost dependencies: the shapes the resampling maps
@@ -38,14 +38,14 @@ impl InterpolateCost {
     fn forward_work(&self, prob: &InterpolateForwardProblem) -> Work {
         let planes = prob.batch * prob.channels;
         let outputs = planes * prob.output_height * prob.output_width;
-        let halo = get_halo(prob.options.mode);
+        let taps = mode_properties(prob.options.mode).taps;
 
         // Each output position pulls a `halo`-wide window, so the windows together span
         // `halo` times the output extent. An upsample re-reads rows the previous window
         // already covered, which the input extent caps; a downsample coarse enough to
         // outrun the window skips the rows no window reaches, which the product caps.
-        let rows_read = prob.input_height.min(prob.output_height * halo);
-        let cols_read = prob.input_width.min(prob.output_width * halo);
+        let rows_read = prob.input_height.min(prob.output_height * taps);
+        let cols_read = prob.input_width.min(prob.output_width * taps);
 
         Work {
             compute_ops: outputs * ops_per_output(prob.options.mode),
@@ -80,26 +80,26 @@ fn ops_per_output(mode: InterpolateMode) -> usize {
         return 4;
     }
 
-    let halo = get_halo(mode);
+    let taps = mode_properties(mode).taps;
     // One weight per tap on each of the two axes.
-    let weights = 2 * halo * weight_ops(mode);
+    let weights = 2 * taps * weight_ops(mode);
     // Every tap multiplies its column weight in and adds the product into the row.
-    let taps = halo * halo * 2;
+    let contraction = taps * taps * 2;
     // Every row multiplies its row weight in and adds the product into the total.
-    let rows = halo * 2;
+    let rows = taps * 2;
 
-    weights + taps + rows + bound_check_ops(mode)
+    weights + contraction + rows + bound_check_ops(mode)
 }
 
 /// What renormalizing against the in-bounds weight adds on top of the plain contraction.
 ///
 /// Zero for the modes whose weights vanish at the window edge, which need no such guard.
 fn bound_check_ops(mode: InterpolateMode) -> usize {
-    if !get_requires_bound_check(mode) {
+    if !mode_properties(mode).renormalizes {
         return 0;
     }
 
-    let halo = get_halo(mode);
+    let taps = mode_properties(mode).taps;
     // Per tap: four comparisons and the three ands that fold them into one flag, the two
     // selects that zero an out-of-bounds value and its weight, and the extra add that
     // accumulates the weight alongside the value.
@@ -107,7 +107,7 @@ fn bound_check_ops(mode: InterpolateMode) -> usize {
     // Per row: the row weight multiplied into the row's weight sum, and that added in.
     let per_row = 2;
     // Once: clamping the total weight away from zero, and the divide it guards.
-    halo * halo * per_tap + halo * per_row + 2
+    taps * taps * per_tap + taps * per_row + 2
 }
 
 /// Arithmetic operations one `compute_weight` call emits.

--- a/crates/cubek-interpolate/src/definition/error.rs
+++ b/crates/cubek-interpolate/src/definition/error.rs
@@ -10,6 +10,12 @@ pub enum InterpolateError {
     )]
     SharedMemoryLimitExceeded { requested: usize, available: usize },
 
+    #[error("Shared memory residence is not supported on CPU")]
+    SharedMemoryUnsupportedOnCpu,
+
+    #[error("Requested {requested} units per cube exceeds the device limit of {available} units")]
+    UnitsPerCubeExceeded { requested: usize, available: usize },
+
     #[error(
         "Interpolate expects 4D tensors (NHWC), but got input rank {input} and output rank {output}"
     )]

--- a/crates/cubek-interpolate/src/definition/modes.rs
+++ b/crates/cubek-interpolate/src/definition/modes.rs
@@ -1,14 +1,35 @@
 use super::InterpolateMode;
+use cubek_tile::Boundary;
 
-pub fn get_halo(mode: InterpolateMode) -> usize {
-    match mode {
-        InterpolateMode::Nearest(_) => 1,
-        InterpolateMode::Bilinear => 2,
-        InterpolateMode::Bicubic => 4,
-        InterpolateMode::Lanczos3 => 6,
-    }
+/// Filter behavior shared by the forward kernel and the cost model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModeProperties {
+    pub taps: usize,
+    pub renormalizes: bool,
+    pub boundary: Boundary,
 }
 
-pub fn get_requires_bound_check(mode: InterpolateMode) -> bool {
-    matches!(mode, InterpolateMode::Lanczos3)
+pub const fn mode_properties(mode: InterpolateMode) -> ModeProperties {
+    match mode {
+        InterpolateMode::Nearest(_) => ModeProperties {
+            taps: 1,
+            renormalizes: false,
+            boundary: Boundary::Clamp,
+        },
+        InterpolateMode::Bilinear => ModeProperties {
+            taps: 2,
+            renormalizes: false,
+            boundary: Boundary::Clamp,
+        },
+        InterpolateMode::Bicubic => ModeProperties {
+            taps: 4,
+            renormalizes: false,
+            boundary: Boundary::Clamp,
+        },
+        InterpolateMode::Lanczos3 => ModeProperties {
+            taps: 6,
+            renormalizes: true,
+            boundary: Boundary::Zero,
+        },
+    }
 }

--- a/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
@@ -10,7 +10,6 @@ use cubecl::{
     zspace::Shape,
 };
 use cubek_test_utils::{RunSamples, TestInput};
-use cubek_tile::Residence;
 
 use crate::{
     definition::{InterpolateCost, InterpolateProblem},
@@ -27,23 +26,7 @@ pub fn bench(
     let device = <TestRuntime as Runtime>::Device::default();
     let client = <TestRuntime as Runtime>::client(&device);
 
-    let hardware = &client.properties().hardware;
-    let is_cpu = hardware.num_cpu_cores.is_some();
-
-    if is_cpu && strategy.input_residence == Residence::Smem {
-        return Err("interpolation shared memory strategy is not used on CPU".to_string());
-    }
-
     let dtype = f32::elem_type_native();
-
-    let lanes = hardware.plane_size_max as usize;
-    let units_per_cube = strategy.planes_per_cube * lanes;
-    if units_per_cube > hardware.max_units_per_cube as usize {
-        return Err(format!(
-            "kernel units per cube ({units_per_cube}) exceeds device max ({})",
-            hardware.max_units_per_cube
-        ));
-    }
 
     let bench = InterpolateBench {
         problem: problem.clone(),

--- a/crates/cubek-interpolate/src/kernel/forward/filter.rs
+++ b/crates/cubek-interpolate/src/kernel/forward/filter.rs
@@ -2,8 +2,8 @@ use crate::definition::{InterpolateMode, ModeProperties, mode_properties};
 use cubecl::prelude::*;
 use cubecl_common::Ratio;
 use cubek_tile::{
-    AffineCoordinate, Constant, Cubic, DivGuard, Lanczos, Linear, Phase, Recipe,
-    SeparableProduct, Sum, TapMask,
+    AffineCoordinate, Constant, Cubic, DivGuard, Lanczos, Linear, Phase, Recipe, SeparableProduct,
+    Sum, TapMask,
 };
 
 pub type TapDistance<E> = Sum<AffineCoordinate<E>, Phase<E>>;
@@ -103,5 +103,24 @@ impl<E: Float> SeparableFilter<E> for Lanczos3Filter {
             coordinate: distance,
             lobes: 3,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_mode_properties<F: SeparableFilterFamily>(mode: InterpolateMode) {
+        assert_eq!(mode_properties(mode), F::mode_properties());
+    }
+
+    #[test]
+    fn filters_use_the_mode_properties() {
+        assert_mode_properties::<NearestFilter>(InterpolateMode::Nearest(
+            crate::definition::NearestMode::Exact,
+        ));
+        assert_mode_properties::<BilinearFilter>(InterpolateMode::Bilinear);
+        assert_mode_properties::<BicubicFilter>(InterpolateMode::Bicubic);
+        assert_mode_properties::<Lanczos3Filter>(InterpolateMode::Lanczos3);
     }
 }

--- a/crates/cubek-interpolate/src/kernel/forward/filter.rs
+++ b/crates/cubek-interpolate/src/kernel/forward/filter.rs
@@ -1,7 +1,8 @@
+use crate::definition::{InterpolateMode, ModeProperties, mode_properties};
 use cubecl::prelude::*;
 use cubecl_common::Ratio;
 use cubek_tile::{
-    AffineCoordinate, Boundary, Constant, Cubic, DivGuard, Lanczos, Linear, Phase, Recipe,
+    AffineCoordinate, Constant, Cubic, DivGuard, Lanczos, Linear, Phase, Recipe,
     SeparableProduct, Sum, TapMask,
 };
 
@@ -11,16 +12,8 @@ type BilinearAxis<E> = Linear<TapDistance<E>>;
 type BicubicAxis<E> = Cubic<TapDistance<E>>;
 type Lanczos3Axis<E> = Lanczos<TapDistance<E>>;
 
-pub trait TapSupport {
-    const TAPS: usize;
-    const BOUNDARY: Boundary;
-    fn radius() -> usize {
-        (Self::TAPS - 1) / 2
-    }
-}
-
 #[cube]
-pub trait SeparableFilter<E: Float>: TapSupport + Send + std::marker::Sync + 'static {
+pub trait SeparableFilter<E: Float>: Send + std::marker::Sync + 'static {
     type Axis: Recipe<E> + 'static;
     fn along(distance: TapDistance<E>) -> Self::Axis;
 }
@@ -29,18 +22,24 @@ pub trait SeparableFilter<E: Float>: TapSupport + Send + std::marker::Sync + 'st
 pub type SeparableWeights<E, F> = SeparableProduct<<F as SeparableFilter<E>>::Axis>;
 
 /// Bridges host-side mode selection to the element type selected when a kernel is launched.
-pub trait SeparableFilterFamily: TapSupport + Send + std::marker::Sync + 'static {
+pub trait SeparableFilterFamily: Send + std::marker::Sync + 'static {
     type Filter<E: Float>: SeparableFilter<E>;
+    const MODE: InterpolateMode;
     const NORMALIZATION: Option<(TapMask, DivGuard)> = None;
+
+    fn mode_properties() -> ModeProperties {
+        mode_properties(Self::MODE)
+    }
+
+    fn radius() -> usize {
+        (Self::mode_properties().taps - 1) / 2
+    }
 }
 
 pub struct NearestFilter;
-impl TapSupport for NearestFilter {
-    const TAPS: usize = 1;
-    const BOUNDARY: Boundary = Boundary::Clamp;
-}
 impl SeparableFilterFamily for NearestFilter {
     type Filter<E: Float> = Self;
+    const MODE: InterpolateMode = InterpolateMode::Nearest(crate::definition::NearestMode::Exact);
 }
 #[cube]
 impl<E: Float> SeparableFilter<E> for NearestFilter {
@@ -53,12 +52,9 @@ impl<E: Float> SeparableFilter<E> for NearestFilter {
 }
 
 pub struct BilinearFilter;
-impl TapSupport for BilinearFilter {
-    const TAPS: usize = 2;
-    const BOUNDARY: Boundary = Boundary::Clamp;
-}
 impl SeparableFilterFamily for BilinearFilter {
     type Filter<E: Float> = Self;
+    const MODE: InterpolateMode = InterpolateMode::Bilinear;
 }
 #[cube]
 impl<E: Float> SeparableFilter<E> for BilinearFilter {
@@ -71,12 +67,9 @@ impl<E: Float> SeparableFilter<E> for BilinearFilter {
 }
 
 pub struct BicubicFilter;
-impl TapSupport for BicubicFilter {
-    const TAPS: usize = 4;
-    const BOUNDARY: Boundary = Boundary::Clamp;
-}
 impl SeparableFilterFamily for BicubicFilter {
     type Filter<E: Float> = Self;
+    const MODE: InterpolateMode = InterpolateMode::Bicubic;
 }
 #[cube]
 impl<E: Float> SeparableFilter<E> for BicubicFilter {
@@ -91,12 +84,9 @@ impl<E: Float> SeparableFilter<E> for BicubicFilter {
 
 /// Six-tap Lanczos filtering.
 pub struct Lanczos3Filter;
-impl TapSupport for Lanczos3Filter {
-    const TAPS: usize = 6;
-    const BOUNDARY: Boundary = Boundary::Zero;
-}
 impl SeparableFilterFamily for Lanczos3Filter {
     type Filter<E: Float> = Self;
+    const MODE: InterpolateMode = InterpolateMode::Lanczos3;
     const NORMALIZATION: Option<(TapMask, DivGuard)> = Some((
         TapMask::Masked,
         DivGuard {

--- a/crates/cubek-interpolate/src/kernel/forward/launch.rs
+++ b/crates/cubek-interpolate/src/kernel/forward/launch.rs
@@ -136,7 +136,7 @@ fn launch<R: Runtime, F: SeparableFilterFamily>(
         output_w,
         output.shape[3],
         lanes,
-        F::TAPS,
+        F::mode_properties().taps,
         geometry,
         space::instruction(client),
         dtype,
@@ -150,8 +150,9 @@ fn launch<R: Runtime, F: SeparableFilterFamily>(
         dtype.size(),
     );
 
-    let in_bounds = tap_range_in_bounds(row, output_h, input_h, F::TAPS, F::radius())
-        && tap_range_in_bounds(col, output_w, input_w, F::TAPS, F::radius());
+    let properties = F::mode_properties();
+    let in_bounds = tap_range_in_bounds(row, output_h, input_h, properties.taps, F::radius())
+        && tap_range_in_bounds(col, output_w, input_w, properties.taps, F::radius());
 
     // The channel block is the lane's channel run, so it is the width the contraction wants its
     // lines in. Where the tensor's own channel count cannot serve them (`C = 3` has no 4-aligned
@@ -176,7 +177,7 @@ fn launch<R: Runtime, F: SeparableFilterFamily>(
     let requested_smem = space::stage_window_bytes(
         row,
         col,
-        F::TAPS,
+        properties.taps,
         F::radius(),
         geometry,
         stage_width.unwrap_or(vector_size),
@@ -197,7 +198,7 @@ fn launch<R: Runtime, F: SeparableFilterFamily>(
         .operand(&in_operand)
         .gathered(space::input_projection(row, col, F::radius()))
         .checked(checked)
-        .with_boundary(checked.then_some(F::BOUNDARY))
+        .with_boundary(checked.then_some(properties.boundary))
         .vectorize(vector_size);
     if let Some(width) = stage_width {
         input_arg = input_arg.stage_width(width);

--- a/crates/cubek-interpolate/src/kernel/forward/launch.rs
+++ b/crates/cubek-interpolate/src/kernel/forward/launch.rs
@@ -86,6 +86,12 @@ pub(crate) fn interpolate_launch<R: Runtime>(
     dtype: ElemType,
     config: InterpolateConfig,
 ) -> Result<(), InterpolateError> {
+    if config.input_residence == Residence::Smem
+        && client.properties().hardware.num_cpu_cores.is_some()
+    {
+        return Err(InterpolateError::SharedMemoryUnsupportedOnCpu);
+    }
+
     let geometry = config.geometry(
         output.shape[3],
         client.properties().hardware.plane_size_max as usize,
@@ -130,6 +136,18 @@ fn launch<R: Runtime, F: SeparableFilterFamily>(
     let row = Rational::of(get_transform(input_h, output_h, options));
     let col = Rational::of(get_transform(input_w, output_w, options));
     let lanes = client.properties().hardware.plane_size_max as usize;
+
+    // Cheap to check before any of the space/vectorization work below: a cube this wide is
+    // refused outright rather than built and then rejected by the device at dispatch.
+    let max_units = client.properties().hardware.max_units_per_cube as usize;
+    let units_per_cube = geometry.planes_per_cube * lanes;
+    if units_per_cube > max_units {
+        return Err(InterpolateError::UnitsPerCubeExceeded {
+            requested: units_per_cube,
+            available: max_units,
+        });
+    }
+
     let (space, in_operand) = space::interpolate_space(
         output.shape[0],
         output_h,


### PR DESCRIPTION
## Summary
- centralize taps, renormalization, and tiled boundary behavior in ModeProperties
- keep multi-level and tiled paths responsible only for their filter-weight implementations
- add mode-to-filter mapping guards for both architectures
- move the CPU-refuses-shared-memory and units-per-cube-exceeds-device-max checks out of the bench harness and into `interpolate_launch`, as `InterpolateError`, so any caller gets the refusal, not only benchmarks
- shrink `eval/benchmarks/benchmark.rs::bench()` to build the problem, call `interpolate`, and map the error to a string

## Validation
- cargo check -p cubek-interpolate --all-features
- cargo clippy -p cubek-interpolate --all-features -- -D warnings
- cargo test -p cubek-interpolate --all-features --lib (23 passed)
- focused forward interpolation integration tests
- git diff --check

## Note
The untracked INTERPOLATE_CLEANUP_PLAN.md is intentionally excluded. A full integration-suite attempt encountered two large benchmark-catalog cases; the Phase 7 catalogue and Phase 8 tune-key areas are unchanged by this PR.