### PR TITLE
perf(tile): cut the arithmetic in the cubic and Lanczos filters

### DIFF
--- a/crates/cubek-interpolate/src/definition/cost.rs
+++ b/crates/cubek-interpolate/src/definition/cost.rs
@@ -125,7 +125,7 @@ fn bound_check_ops(mode: InterpolateMode) -> usize {
 /// Arithmetic operations one `compute_weight` call emits.
 ///
 /// A transcendental counts as one operation, as everything else here does: this is an
-/// instruction count, not a cycle estimate, so Lanczos3's two sines are understated by
+/// instruction count, not a cycle estimate, so Lanczos3's sine and divide are understated by
 /// whatever their hardware cost is.
 fn weight_ops(mode: InterpolateMode) -> usize {
     match mode {
@@ -133,14 +133,16 @@ fn weight_ops(mode: InterpolateMode) -> usize {
         InterpolateMode::Nearest(_) => 0,
         // An abs, the comparison against one, the subtraction, and the select.
         InterpolateMode::Bilinear => 4,
-        // An abs and the two multiplies that raise it to the second and third powers, four
-        // operations for the inner cubic, six for the outer one, then the two comparisons
-        // and two selects that pick between them and zero.
-        InterpolateMode::Bicubic => 3 + 4 + 6 + 4,
-        // An abs, the scale by pi, the squared denominator and its third; the comparison
-        // and select guarding a zero denominator; the two sines, the argument's third, the
-        // product and the divide; then the two comparisons and two selects around them.
-        InterpolateMode::Lanczos3 => 4 + 2 + 5 + 4,
+        // An abs and the multiply that squares it, two fused multiply-adds for the inner
+        // cubic in Horner form, three for the outer one, then the two comparisons and two
+        // selects that pick between them and zero.
+        InterpolateMode::Bicubic => 2 + 2 + 3 + 4,
+        // An abs, the scale into `pi * x / 3`, and the one sine the triple-angle identity
+        // leaves; the squaring, multiply-add and multiply that finish the numerator; the
+        // squared denominator and its scale; the comparison and select guarding a zero
+        // denominator; then the divide, the support comparison and the two selects. The
+        // comparison against zero is shared with the guard rather than recomputed.
+        InterpolateMode::Lanczos3 => 3 + 3 + 2 + 2 + 4,
     }
 }
 

--- a/crates/cubek-tile/src/tile/procedural/filter/cubic.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/cubic.rs
@@ -39,13 +39,23 @@ pub struct Cubic<C: CubeType> {
 #[cube]
 impl<T: Float, C: Recipe<T>> Recipe<T> for Cubic<C> {
     fn evaluate(&self, coordinates: &RecipeCoords) -> T {
-        let a = T::new(comptime!(self.a.as_f32()));
+        let a = comptime!(self.a.as_f32());
         let x = self.coordinate.evaluate(coordinates).abs();
         let x2 = x * x;
-        let x3 = x2 * x;
-        let first = (a + T::new(2.0_f32)) * x3 - (a + T::new(3.0_f32)) * x2 + T::new(1.0_f32);
-        let second =
-            a * x3 - T::new(5.0_f32) * a * x2 + T::new(8.0_f32) * a * x - T::new(4.0_f32) * a;
+        let first = fma(
+            fma(T::new(comptime!(a + 2.0)), x, T::new(comptime!(-(a + 3.0)))),
+            x2,
+            T::new(1.0_f32),
+        );
+        let second = fma(
+            fma(
+                fma(T::new(comptime!(a)), x, T::new(comptime!(-5.0 * a))),
+                x,
+                T::new(comptime!(8.0 * a)),
+            ),
+            x,
+            T::new(comptime!(-4.0 * a)),
+        );
         select(
             x <= T::new(1.0_f32),
             first,

--- a/crates/cubek-tile/src/tile/procedural/filter/cubic.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/cubic.rs
@@ -42,19 +42,17 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Cubic<C> {
         let a = comptime!(self.a.as_f32());
         let x = self.coordinate.evaluate(coordinates).abs();
         let x2 = x * x;
+        // (a + 2)x^3 - (a + 3)x^2 + 1, the x^2 factored out so the constant term costs no step.
         let first = fma(
-            fma(T::new(comptime!(a + 2.0)), x, T::new(comptime!(-(a + 3.0)))),
+            fma(T::new(a + 2.0), x, T::new(-(a + 3.0))),
             x2,
             T::new(1.0_f32),
         );
+        // a*x^3 - 5a*x^2 + 8a*x - 4a
         let second = fma(
-            fma(
-                fma(T::new(comptime!(a)), x, T::new(comptime!(-5.0 * a))),
-                x,
-                T::new(comptime!(8.0 * a)),
-            ),
+            fma(fma(T::new(a), x, T::new(-5.0 * a)), x, T::new(8.0 * a)),
             x,
-            T::new(comptime!(-4.0 * a)),
+            T::new(-4.0 * a),
         );
         select(
             x <= T::new(1.0_f32),

--- a/crates/cubek-tile/src/tile/procedural/filter/lanczos.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/lanczos.rs
@@ -48,16 +48,16 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Lanczos<C> {
         let abs_x = x.abs();
         // With `u = pi * x / lobes` the kernel is `sin(lobes * u) * sin(u) / (lobes * u * u)`,
         // which folds both divisions by `lobes` into one comptime coefficient.
-        let u = T::new(comptime!(core::f32::consts::PI / lobes)) * x;
+        let u = T::new(core::f32::consts::PI / lobes) * x;
         let numerator = if comptime!(self.lobes == 3) {
             // sin(3u) = sin(u) * (3 - 4 sin^2 u), so the product needs a single sine.
             let s = u.sin();
             let s2 = s * s;
             s2 * fma(T::new(-4.0_f32), s2, T::new(3.0_f32))
         } else {
-            (T::new(comptime!(lobes)) * u).sin() * u.sin()
+            (T::new(lobes) * u).sin() * u.sin()
         };
-        let denominator = T::new(comptime!(lobes)) * (u * u);
+        let denominator = T::new(lobes) * (u * u);
         // `select` evaluates both arms, so the x = 0 arm still divides. Substituting a harmless
         // denominator there keeps that division finite; the outer `select` discards its result.
         let safe_denominator = select(abs_x < T::new(1e-7_f32), T::new(1.0_f32), denominator);
@@ -65,7 +65,7 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Lanczos<C> {
             abs_x < T::new(1e-7_f32),
             T::new(1.0_f32),
             select(
-                abs_x < T::new(comptime!(lobes)),
+                abs_x < T::new(lobes),
                 numerator / safe_denominator,
                 T::new(0.0_f32),
             ),

--- a/crates/cubek-tile/src/tile/procedural/filter/lanczos.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/lanczos.rs
@@ -38,15 +38,26 @@ pub struct Lanczos<C: CubeType> {
 #[cube]
 impl<T: Float, C: Recipe<T>> Recipe<T> for Lanczos<C> {
     fn evaluate(&self, coordinates: &RecipeCoords) -> T {
-        // Zero lobes would leave an empty support and divide by zero below. Checked here rather
-        // than in a constructor, which a struct literal can bypass. It fires while the kernel
-        // expands, so it surfaces on the client's compilation thread, not at the call site.
+        // Zero lobes would leave an empty support and divide by zero in the coefficient below.
+        // Checked here rather than in a constructor, which a struct literal can bypass. It fires
+        // while the kernel expands, so it surfaces on the client's compilation thread, not at the
+        // call site.
         comptime!(assert!(self.lobes > 0, "Lanczos: lobes must be non-zero"));
+        let lobes = comptime!(self.lobes as f32);
         let x = self.coordinate.evaluate(coordinates);
         let abs_x = x.abs();
-        let pi_x = T::new(core::f32::consts::PI) * x;
-        let lobes = T::cast_from(self.lobes);
-        let denominator = (pi_x * pi_x) / lobes;
+        // With `u = pi * x / lobes` the kernel is `sin(lobes * u) * sin(u) / (lobes * u * u)`,
+        // which folds both divisions by `lobes` into one comptime coefficient.
+        let u = T::new(comptime!(core::f32::consts::PI / lobes)) * x;
+        let numerator = if comptime!(self.lobes == 3) {
+            // sin(3u) = sin(u) * (3 - 4 sin^2 u), so the product needs a single sine.
+            let s = u.sin();
+            let s2 = s * s;
+            s2 * fma(T::new(-4.0_f32), s2, T::new(3.0_f32))
+        } else {
+            (T::new(comptime!(lobes)) * u).sin() * u.sin()
+        };
+        let denominator = T::new(comptime!(lobes)) * (u * u);
         // `select` evaluates both arms, so the x = 0 arm still divides. Substituting a harmless
         // denominator there keeps that division finite; the outer `select` discards its result.
         let safe_denominator = select(abs_x < T::new(1e-7_f32), T::new(1.0_f32), denominator);
@@ -54,8 +65,8 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Lanczos<C> {
             abs_x < T::new(1e-7_f32),
             T::new(1.0_f32),
             select(
-                abs_x < lobes,
-                (pi_x.sin() * (pi_x / lobes).sin()) / safe_denominator,
+                abs_x < T::new(comptime!(lobes)),
+                numerator / safe_denominator,
                 T::new(0.0_f32),
             ),
         )


### PR DESCRIPTION
Stacked on #560.

## What changed

**Cubic** in Horner form drops the cube of `x` and folds the coefficient products into fused multiply-adds: 17 emitted operations to 11, with the 13 arithmetic ops becoming 6.

**Lanczos** written as `sin(lobes * u) * sin(u) / (lobes * u * u)` with `u = pi * x / lobes` folds both divisions by `lobes` into one comptime coefficient, leaving one divide instead of three. For three lobes, the only value `Lanczos3Filter` instantiates, the triple-angle identity `sin(3u) = sin(u) * (3 - 4 sin^2 u)` derives the second sine from the first.

| | ops | sines | divides |
|---|---|---|---|
| Lanczos3 before | 14 | 2 | 3 |
| Lanczos3 after | 14 | **1** | **1** |
| Lanczos, other lobe counts | 14 | 2 | **1** |

The instruction count is flat because the trade is a sine and two divides for three multiplies. In the interpolate kernel that is 12 weight evaluations per output element, so 24 sines and 36 divides become 12 and 12.

`fma` is safe on the CPU backend: it lowers to `llvm.fmuladd`, which contracts where the target supports it and degrades to plain mul+add otherwise, never to a libm call.

## Cost model

`weight_ops` counts these instructions to pick a strategy, so its totals move: Bicubic 17 to 11, Lanczos3 15 to 14.

Lanczos3 only drops one because the old figure was already off by one, counting the zero-guard comparison separately when CSE emits it once. The real change there is not the count but that a sine and two divides became multiplies, which this model cannot express since it counts instructions rather than cycles. The doc comment now says so.

This makes the model *conservative* for Lanczos3: autotune will overestimate its compute cost relative to Bicubic slightly more than before. Weighting transcendentals and divides would fix it, but that changes strategy selection on its own, so it is left out of this PR.

## Accuracy

Unchanged in practice. Against an f64 reference, f32 Lanczos3 measures 2.2e-07 before and 3.1e-07 after, both within two to three ulp.

## Verification

- 14 `cubek-tile` procedural tests, including `cubic_matches_the_keys_convolution` and `lanczos_matches_the_windowed_sinc`, which covers both 2 and 3 lobes
- 20 `cubek-interpolate` tests, including `every_mode_and_transform` and `lanczos3_identity` against the CPU reference
- 6 cost model tests
- clippy and fmt clean on both crates

Op counts above are read off the generated WGSL, not estimated.
