### PR TITLE
perf(tile): reuse separable factors across output cells

### DIFF
--- a/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
@@ -42,28 +42,11 @@ pub fn bench(
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
-    let cost = InterpolateCost::new(problem.clone(), dtype);
-    let work = cost.work();
+    let work = InterpolateCost::new(problem.clone(), dtype).work();
 
     Ok(RunSamples::new(durations)
-        .with_flops(
-            work.compute_ops as f64,
-            compute_peak_ops_per_s(&client, &cost),
-        )
+        .with_flops(work.compute_ops as f64, None)
         .with_bytes(work.bytes, memory_peak_bytes_per_s(&client)))
-}
-
-/// The device's measured arithmetic peak, in ops/s, for the resampling to be judged against.
-///
-/// [`ThroughputMode::ComputeDirect`] is the direct ALU arithmetic the reference filter emits.
-/// `measure_peak_throughput` caches per device, so this does not need to as well.
-fn compute_peak_ops_per_s(
-    client: &ComputeClient<TestRuntime>,
-    cost: &InterpolateCost,
-) -> Option<f64> {
-    let peak = measure_peak_throughput(client, cost.compute_key()).ops_per_s();
-
-    (peak > 0.0).then_some(peak)
 }
 
 /// The device's measured copy peak, in bytes/s, for the resampling to be judged against.

--- a/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
@@ -42,11 +42,28 @@ pub fn bench(
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
-    let work = InterpolateCost::new(problem.clone(), dtype).work();
+    let cost = InterpolateCost::new(problem.clone(), dtype);
+    let work = cost.work();
 
     Ok(RunSamples::new(durations)
-        .with_flops(work.compute_ops as f64, None)
+        .with_flops(
+            work.compute_ops as f64,
+            compute_peak_ops_per_s(&client, &cost),
+        )
         .with_bytes(work.bytes, memory_peak_bytes_per_s(&client)))
+}
+
+/// The device's measured arithmetic peak, in ops/s, for the resampling to be judged against.
+///
+/// [`ThroughputMode::ComputeDirect`] is the direct ALU arithmetic the reference filter emits.
+/// `measure_peak_throughput` caches per device, so this does not need to as well.
+fn compute_peak_ops_per_s(
+    client: &ComputeClient<TestRuntime>,
+    cost: &InterpolateCost,
+) -> Option<f64> {
+    let peak = measure_peak_throughput(client, cost.compute_key()).ops_per_s();
+
+    (peak > 0.0).then_some(peak)
 }
 
 /// The device's measured copy peak, in bytes/s, for the resampling to be judged against.

--- a/crates/cubek-interpolate/src/kernel/forward/filter.rs
+++ b/crates/cubek-interpolate/src/kernel/forward/filter.rs
@@ -2,8 +2,8 @@ use crate::definition::{InterpolateMode, ModeProperties, mode_properties};
 use cubecl::prelude::*;
 use cubecl_common::Ratio;
 use cubek_tile::{
-    AffineCoordinate, Constant, Cubic, DivGuard, Lanczos, Linear, Phase, Recipe, RecipeAxisDeps,
-    SeparableProduct, Sum, TapMask,
+    AffineCoordinate, Constant, Cubic, DivGuard, Lanczos, Linear, Phase, Recipe,
+    RecipeAxisDependencies, SeparableProduct, Sum, TapMask,
 };
 
 pub type TapDistance<E> = Sum<AffineCoordinate<E>, Phase<E>>;
@@ -15,7 +15,7 @@ type Lanczos3Axis<E> = Lanczos<TapDistance<E>>;
 #[cube]
 pub trait SeparableFilter<E: Float>: Send + std::marker::Sync + 'static
 where
-    <Self::Axis as CubeType>::ExpandType: RecipeAxisDeps,
+    <Self::Axis as CubeType>::ExpandType: RecipeAxisDependencies,
 {
     type Axis: Recipe<E> + 'static;
     fn along(distance: TapDistance<E>) -> Self::Axis;

--- a/crates/cubek-interpolate/src/kernel/forward/filter.rs
+++ b/crates/cubek-interpolate/src/kernel/forward/filter.rs
@@ -2,8 +2,8 @@ use crate::definition::{InterpolateMode, ModeProperties, mode_properties};
 use cubecl::prelude::*;
 use cubecl_common::Ratio;
 use cubek_tile::{
-    AffineCoordinate, Constant, Cubic, DivGuard, Lanczos, Linear, Phase, Recipe, SeparableProduct,
-    Sum, TapMask,
+    AffineCoordinate, Constant, Cubic, DivGuard, Lanczos, Linear, Phase, Recipe, RecipeAxisDeps,
+    SeparableProduct, Sum, TapMask,
 };
 
 pub type TapDistance<E> = Sum<AffineCoordinate<E>, Phase<E>>;
@@ -13,7 +13,10 @@ type BicubicAxis<E> = Cubic<TapDistance<E>>;
 type Lanczos3Axis<E> = Lanczos<TapDistance<E>>;
 
 #[cube]
-pub trait SeparableFilter<E: Float>: Send + std::marker::Sync + 'static {
+pub trait SeparableFilter<E: Float>: Send + std::marker::Sync + 'static
+where
+    <Self::Axis as CubeType>::ExpandType: RecipeAxisDeps,
+{
     type Axis: Recipe<E> + 'static;
     fn along(distance: TapDistance<E>) -> Self::Axis;
 }

--- a/crates/cubek-tile/src/instruction/registers/contract/gather/mod.rs
+++ b/crates/cubek-tile/src/instruction/registers/contract/gather/mod.rs
@@ -41,6 +41,15 @@ pub(super) enum RhsRole {
     PerCell,
 }
 
+/// The accumulator coordinate(s) across which one factor's complete tap walk can be reused.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub(super) enum FactorReuse {
+    Block,
+    Row,
+    Column,
+    Cell,
+}
+
 /// The gather-specific half of a contraction's comptime geometry, over the
 /// [`ContractShape`] every schedule shares.
 ///
@@ -62,19 +71,24 @@ pub(super) struct GatherProblem {
     pub taps: usize,
     /// Where each factor's taps start in that walk.
     pub offsets: Vec<usize>,
+    /// Maximal reuse of each factor's tap walk within one accumulator block.
+    pub factor_reuse: Vec<FactorReuse>,
     /// How each operand varies over the accumulator's own axes.
     pub lhs: LhsRole,
     pub rhs: RhsRole,
 }
 
 impl GatherProblem {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         lhs: &Space,
         rhs: &Space,
         rhs_projection: &Projection,
         block: ContractShape,
         factors: Option<usize>,
+        factor_dependencies: Option<Vec<(bool, bool)>>,
         normalization: Option<(TapMask, DivGuard, Space)>,
+        rhs_boundaries: &[Option<Boundary>],
     ) -> Self {
         let rank = block.space.rank();
         let col = block.space.axis_at(rank - 1);
@@ -129,13 +143,35 @@ impl GatherProblem {
             (mask, guard)
         });
         if matches!(normalization, Some((TapMask::Masked, _))) {
-            assert_factorized_mask(
-                rhs_projection,
-                &block.reduce,
-                col,
-                lhs_role != LhsRole::FreeOfColumn,
-            );
+            assert_factorized_mask(rhs_projection, &block.reduce);
         }
+        let row = block.space.axis_at(rank - 2);
+        let factor_reuse = match (factors, factor_dependencies) {
+            (Some(factors), Some(dependencies)) => {
+                assert_eq!(dependencies.len(), factors);
+                dependencies
+                    .into_iter()
+                    .enumerate()
+                    .map(|(f, (mut varies_row, mut varies_col))| {
+                        if matches!(normalization, Some((TapMask::Masked, _))) {
+                            let tap = block.reduce[f];
+                            varies_row |=
+                                masked_bound_addresses(rhs_projection, rhs_boundaries, tap, row);
+                            varies_col |=
+                                masked_bound_addresses(rhs_projection, rhs_boundaries, tap, col);
+                        }
+                        match (varies_row, varies_col) {
+                            (false, false) => FactorReuse::Block,
+                            (true, false) => FactorReuse::Row,
+                            (false, true) => FactorReuse::Column,
+                            (true, true) => FactorReuse::Cell,
+                        }
+                    })
+                    .collect()
+            }
+            (None, None) => Vec::new(),
+            _ => panic!("contract gather: factor dependencies must accompany the factorization"),
+        };
         let offsets = block
             .reduce_extents
             .iter()
@@ -152,6 +188,7 @@ impl GatherProblem {
             lhs_space: lhs.clone(),
             rhs_space: rhs.clone(),
             offsets,
+            factor_reuse,
             factors,
             normalization,
             lhs: lhs_role,
@@ -163,22 +200,12 @@ impl GatherProblem {
 /// A rectangular source mask factorizes only when no physical input axis is moved by two
 /// contracted axes. Output axes may share the same physical axis: they are fixed for one cached
 /// tap walk and therefore do not couple factor sums.
-fn assert_factorized_mask(rhs: &Projection, reduce: &[Axis], acc_col: Axis, lhs_spans_col: bool) {
+fn assert_factorized_mask(rhs: &Projection, reduce: &[Axis]) {
     for (f, &axis) in reduce.iter().enumerate() {
         if !rhs.logical_axes().contains(&axis) {
             continue;
         }
         for pa in rhs.carriers(axis) {
-            assert!(
-                lhs_spans_col
-                    || !rhs
-                        .physical_axis(pa)
-                        .terms()
-                        .iter()
-                        .any(|term| term.axis == acc_col),
-                "contract gather: TapMask::Masked cannot cache weights across {acc_col:?} when \
-                 that axis shares a source coordinate with contracted axis {axis:?}"
-            );
             for &other in &reduce[(f + 1)..] {
                 assert!(
                     !rhs.physical_axis(pa)
@@ -191,6 +218,24 @@ fn assert_factorized_mask(rhs: &Projection, reduce: &[Axis], acc_col: Axis, lhs_
             }
         }
     }
+}
+
+/// Whether the physical bound tested for `tap` also moves with accumulator `axis`.
+fn masked_bound_addresses(
+    rhs: &Projection,
+    boundaries: &[Option<Boundary>],
+    tap: Axis,
+    axis: Axis,
+) -> bool {
+    rhs.logical_axes().contains(&tap)
+        && rhs.carriers(tap).iter().any(|&pa| {
+            boundaries.get(pa).copied().flatten() == Some(Boundary::Zero)
+                && rhs
+                    .physical_axis(pa)
+                    .terms()
+                    .iter()
+                    .any(|term| term.axis == axis)
+        })
 }
 
 /// N-D variant of [`direct::contract`](super::direct::contract) for operations with
@@ -232,6 +277,13 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric>(
     let factors = lhs.factors();
     let normalization = lhs.factor_normalization();
     let rhs_projection = rhs.projection();
+    let rhs_boundaries = rhs.separable_boundaries();
+    let rank = comptime!(space.rank());
+    let factor_dependencies = lhs.factor_dependencies(
+        factors,
+        comptime!(space.axis_at(rank - 2)),
+        comptime!(space.axis_at(rank - 1)),
+    );
 
     let problem = comptime!(GatherProblem::new(
         &lhs.space,
@@ -239,7 +291,9 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric>(
         &rhs_projection,
         ContractShape::new(&lhs.space, &rhs.space, space, served, lw, rw, aw),
         factors,
+        factor_dependencies,
         normalization,
+        &rhs_boundaries,
     ));
 
     if comptime!(factors.is_some()) {
@@ -287,7 +341,16 @@ mod tests {
         let (lhs, rhs, acc) = spaces();
         let projection = Projection::direct(&[K0, K1, N]);
         let block = ContractShape::new(&lhs, &rhs, acc, 1, 1, vw, vw);
-        GatherProblem::new(&lhs, &rhs, &projection, block, factors, None)
+        GatherProblem::new(
+            &lhs,
+            &rhs,
+            &projection,
+            block,
+            factors,
+            factors.map(|n| vec![(true, true); n]),
+            None,
+            &[],
+        )
     }
 
     #[test]
@@ -333,7 +396,9 @@ mod tests {
             &projection,
             block,
             Some(2),
+            Some(vec![(true, true); 2]),
             Some((TapMask::Unmasked, DivGuard::default(), original)),
+            &[],
         );
     }
 
@@ -353,29 +418,58 @@ mod tests {
             &projection,
             block,
             Some(2),
+            Some(vec![(true, true); 2]),
             Some((TapMask::Masked, DivGuard::default(), lhs.clone())),
+            &[],
         );
     }
 
     #[test]
-    #[should_panic(expected = "TapMask::Masked cannot cache weights across")]
-    fn problem_rejects_masked_normalization_caching_across_shared_column_axis() {
+    fn a_masked_bound_blocks_only_the_unsafe_column_hoist() {
         let (lhs, rhs, acc) = spaces();
-        // Fixture targets the column-caching check: K0 shares physical axis 0 with N, while
-        // physical axis 1 carries N to satisfy assert_separable_shapes.
+        // K0's checked carrier also moves with N. K1 has its own carrier, while the final N
+        // carrier satisfies the separable reader's innermost-axis requirement.
         let map = vec![
             PhysicalAxisMap::affine(&[(K0, 1), (N, 1)]),
+            PhysicalAxisMap::of(K1),
             PhysicalAxisMap::of(N),
         ];
         let projection = Projection::new(&[K0, K1, N], &map);
         let block = ContractShape::new(&lhs, &rhs, acc, 1, 1, 1, 1);
-        GatherProblem::new(
+        let problem = GatherProblem::new(
             &lhs,
             &rhs,
             &projection,
             block,
             Some(2),
+            Some(vec![(false, false); 2]),
             Some((TapMask::Masked, DivGuard::default(), lhs.clone())),
+            &[Some(Boundary::Zero), None, None],
+        );
+
+        assert_eq!(problem.factor_reuse[0], FactorReuse::Column);
+        assert_eq!(problem.factor_reuse[1], FactorReuse::Block);
+    }
+
+    #[test]
+    fn recipe_dependencies_choose_the_maximal_factor_cache() {
+        let (lhs, rhs, acc) = spaces();
+        let projection = Projection::direct(&[K0, K1, N]);
+        let block = ContractShape::new(&lhs, &rhs, acc, 1, 1, 1, 1);
+        let problem = GatherProblem::new(
+            &lhs,
+            &rhs,
+            &projection,
+            block,
+            Some(2),
+            Some(vec![(true, false), (false, true)]),
+            None,
+            &[],
+        );
+
+        assert_eq!(
+            problem.factor_reuse,
+            vec![FactorReuse::Row, FactorReuse::Column]
         );
     }
 
@@ -394,7 +488,16 @@ mod tests {
         let acc = Space::new(&[(M, 4), (N, 8)]);
         let projection = Projection::direct(&[M, K0, K1, N]);
         let block = ContractShape::new(&lhs, &rhs, acc, 1, width, width, width);
-        GatherProblem::new(&lhs, &rhs, &projection, block, factors, None)
+        GatherProblem::new(
+            &lhs,
+            &rhs,
+            &projection,
+            block,
+            factors,
+            factors.map(|n| vec![(true, true); n]),
+            None,
+            &[],
+        )
     }
 
     /// An lhs lined along the accumulator's column reads its line *as* the cell, with no `K`

--- a/crates/cubek-tile/src/instruction/registers/contract/gather/mod.rs
+++ b/crates/cubek-tile/src/instruction/registers/contract/gather/mod.rs
@@ -41,12 +41,16 @@ pub(super) enum RhsRole {
     PerCell,
 }
 
-/// The accumulator coordinate(s) across which one factor's complete tap walk can be reused.
+/// The accumulator scope at which one factor's complete tap walk is computed and cached.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(super) enum FactorReuse {
+    /// Once for the entire accumulator block.
     Block,
+    /// Once for each accumulator row.
     Row,
+    /// Once for each accumulator column.
     Column,
+    /// Once for each accumulator cell.
     Cell,
 }
 
@@ -156,9 +160,9 @@ impl GatherProblem {
                         if matches!(normalization, Some((TapMask::Masked, _))) {
                             let tap = block.reduce[f];
                             varies_row |=
-                                masked_bound_addresses(rhs_projection, rhs_boundaries, tap, row);
+                                masked_bound_depends_on(rhs_projection, rhs_boundaries, tap, row);
                             varies_col |=
-                                masked_bound_addresses(rhs_projection, rhs_boundaries, tap, col);
+                                masked_bound_depends_on(rhs_projection, rhs_boundaries, tap, col);
                         }
                         match (varies_row, varies_col) {
                             (false, false) => FactorReuse::Block,
@@ -221,7 +225,7 @@ fn assert_factorized_mask(rhs: &Projection, reduce: &[Axis]) {
 }
 
 /// Whether the physical bound tested for `tap` also moves with accumulator `axis`.
-fn masked_bound_addresses(
+fn masked_bound_depends_on(
     rhs: &Projection,
     boundaries: &[Option<Boundary>],
     tap: Axis,
@@ -470,6 +474,28 @@ mod tests {
         assert_eq!(
             problem.factor_reuse,
             vec![FactorReuse::Row, FactorReuse::Column]
+        );
+    }
+
+    #[test]
+    fn constant_and_fully_dependent_factors_choose_the_extreme_caches() {
+        let (lhs, rhs, acc) = spaces();
+        let projection = Projection::direct(&[K0, K1, N]);
+        let block = ContractShape::new(&lhs, &rhs, acc, 1, 1, 1, 1);
+        let problem = GatherProblem::new(
+            &lhs,
+            &rhs,
+            &projection,
+            block,
+            Some(2),
+            Some(vec![(false, false), (true, true)]),
+            None,
+            &[],
+        );
+
+        assert_eq!(
+            problem.factor_reuse,
+            vec![FactorReuse::Block, FactorReuse::Cell]
         );
     }
 

--- a/crates/cubek-tile/src/instruction/registers/contract/gather/separable.rs
+++ b/crates/cubek-tile/src/instruction/registers/contract/gather/separable.rs
@@ -7,21 +7,19 @@ use crate::instruction::registers::block;
 use crate::*;
 
 use super::{
-    GatherProblem, LhsRole,
+    FactorReuse, GatherProblem,
     coords::{cell_position, offset_last},
 };
 
-/// Cache each factor's 1-D tap walk before consuming their Cartesian product for one cell.
+/// Cache each factor's 1-D tap walk at its maximal reuse level before consuming the Cartesian
+/// product: once per block, row, column or cell. Recipe coordinate dependencies decide where the
+/// factor itself varies; masked normalization adds any accumulator axes that also move the
+/// physical bound checked for that factor.
 ///
-/// The walk is cached per accumulator row unless the lhs spans the column: with no factor
-/// reading the accumulator's innermost axis the weights cannot vary along it, so evaluating them
-/// per cell repeats one identical walk `nr` times.
-///
-/// That same condition decides the nesting. Where no factor reads the innermost axis, a tap's
-/// coordinate and its factor product are invariant along it, so the taps go outside the lines and
-/// each is resolved once per tap rather than `nr` times. The schedule's cost is per tap, so that
-/// factor is the whole gap against a walk that hoists them by hand. A spanning lhs needs its walk
-/// per line, which has to stay outside the taps, so it nests the other way.
+/// Whether any factor varies over the innermost accumulator axis decides the contraction nesting.
+/// Where none does, a tap's factor product is invariant along the output line, so taps stay outside
+/// lines and the rhs position is resolved once per tap. Otherwise lines stay outside taps, while
+/// row- and column-local factor caches still avoid repeating the orthogonal factor walk.
 ///
 /// Both nestings fold the map by hand ([`Tile::nd_split`]) rather than re-running it per read. The
 /// lines of one run are adjacent on the operand's innermost physical axis, which is the
@@ -59,6 +57,12 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
     );
     let kc = comptime!(problem.block.kc);
     let taps = comptime!(problem.taps);
+    let factors_span_col = comptime!(
+        problem
+            .factor_reuse
+            .iter()
+            .any(|reuse| matches!(reuse, FactorReuse::Column | FactorReuse::Cell))
+    );
 
     for mat in 0..matrices {
         let batch = unravel_const(comptime!(batch_extents.clone()), mat.fcast::<u32>());
@@ -88,9 +92,107 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
             unroll,
         );
 
+        let mut block_weights = Array::<EL>::new(taps);
+        let block_anchor = rhs_reader.map.anchor(
+            cell_position(
+                &batch,
+                0u32,
+                0u32,
+                &factor_coords(comptime!(factors), 0usize, 0usize),
+                comptime!(problem.rhs_space.clone()),
+                comptime!(problem.clone()),
+                comptime!(problem.block.vw),
+            ),
+            comptime!(problem.block.reduce.clone()),
+        );
+        #[unroll]
+        for f in 0..factors {
+            if comptime!(problem.factor_reuse[f] == FactorReuse::Block) {
+                factor_walk::<EL, ER>(
+                    &mut block_weights,
+                    comptime!(problem.offsets[f]),
+                    lhs,
+                    rhs,
+                    &rhs_reader.map,
+                    &block_anchor,
+                    &batch,
+                    0u32,
+                    0u32,
+                    f,
+                    comptime!(problem.clone()),
+                );
+            }
+        }
+
+        let mut column_weights = Array::<EL>::new(taps * nr);
+        #[unroll]
+        for f in 0..factors {
+            if comptime!(problem.factor_reuse[f] == FactorReuse::Column) {
+                #[unroll(unroll)]
+                for n in 0..nr {
+                    let anchor = rhs_reader.map.anchor(
+                        cell_position(
+                            &batch,
+                            0u32,
+                            n as u32,
+                            &factor_coords(comptime!(factors), f, 0usize),
+                            comptime!(problem.rhs_space.clone()),
+                            comptime!(problem.clone()),
+                            comptime!(problem.block.vw),
+                        ),
+                        comptime!(problem.block.reduce.clone()),
+                    );
+                    factor_walk::<EL, ER>(
+                        &mut column_weights,
+                        n * comptime!(taps) + comptime!(problem.offsets[f]),
+                        lhs,
+                        rhs,
+                        &rhs_reader.map,
+                        &anchor,
+                        &batch,
+                        0u32,
+                        n as u32,
+                        f,
+                        comptime!(problem.clone()),
+                    );
+                }
+            }
+        }
+
         #[unroll(unroll)]
         for i in 0..mr {
-            if comptime!(problem.lhs != LhsRole::FreeOfColumn) {
+            let mut row_weights = Array::<EL>::new(taps);
+            #[unroll]
+            for f in 0..factors {
+                if comptime!(problem.factor_reuse[f] == FactorReuse::Row) {
+                    let anchor = rhs_reader.map.anchor(
+                        cell_position(
+                            &batch,
+                            i as u32,
+                            0u32,
+                            &factor_coords(comptime!(factors), f, 0usize),
+                            comptime!(problem.rhs_space.clone()),
+                            comptime!(problem.clone()),
+                            comptime!(problem.block.vw),
+                        ),
+                        comptime!(problem.block.reduce.clone()),
+                    );
+                    factor_walk::<EL, ER>(
+                        &mut row_weights,
+                        comptime!(problem.offsets[f]),
+                        lhs,
+                        rhs,
+                        &rhs_reader.map,
+                        &anchor,
+                        &batch,
+                        i as u32,
+                        0u32,
+                        f,
+                        comptime!(problem.clone()),
+                    );
+                }
+            }
+            if comptime!(factors_span_col) {
                 #[unroll(unroll)]
                 for n in 0..nr {
                     let anchor = rhs_reader.map.anchor(
@@ -105,19 +207,25 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
                         ),
                         comptime!(problem.block.reduce.clone()),
                     );
-                    let mut weights = Array::<EL>::new(taps);
-                    tap_walk::<EL, ER>(
-                        &mut weights,
-                        lhs,
-                        rhs,
-                        &rhs_reader.map,
-                        &anchor,
-                        &batch,
-                        i as u32,
-                        n as u32,
-                        comptime!(factors),
-                        comptime!(problem.clone()),
-                    );
+                    let mut cell_weights = Array::<EL>::new(taps);
+                    #[unroll]
+                    for f in 0..factors {
+                        if comptime!(problem.factor_reuse[f] == FactorReuse::Cell) {
+                            factor_walk::<EL, ER>(
+                                &mut cell_weights,
+                                comptime!(problem.offsets[f]),
+                                lhs,
+                                rhs,
+                                &rhs_reader.map,
+                                &anchor,
+                                &batch,
+                                i as u32,
+                                n as u32,
+                                f,
+                                comptime!(problem.clone()),
+                            );
+                        }
+                    }
 
                     #[unroll(unroll_taps)]
                     for p in 0..kc {
@@ -125,11 +233,17 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
                             comptime!(problem.block.reduce_extents.clone()),
                             p.fcast::<u32>(),
                         );
-                        let weight = tap_weight::<EL>(
-                            &weights,
+                        let weight = tap_weight_reused::<EL>(
+                            &block_weights,
+                            &row_weights,
+                            &column_weights,
+                            &cell_weights,
                             &reduce_coords,
+                            n,
                             comptime!(factors),
+                            comptime!(taps),
                             comptime!(problem.offsets.clone()),
+                            comptime!(problem.factor_reuse.clone()),
                         );
                         let base = rhs_reader.map.advance(
                             &anchor,
@@ -170,31 +284,19 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
                     comptime!(problem.block.reduce.clone()),
                 );
 
-                let mut weights = Array::<EL>::new(taps);
-                tap_walk::<EL, ER>(
-                    &mut weights,
-                    lhs,
-                    rhs,
-                    &rhs_reader.map,
-                    &anchor,
-                    &batch,
-                    i as u32,
-                    0u32,
-                    comptime!(factors),
-                    comptime!(problem.clone()),
-                );
-
                 #[unroll(unroll_taps)]
                 for p in 0..kc {
                     let reduce_coords = unravel_const(
                         comptime!(problem.block.reduce_extents.clone()),
                         p.fcast::<u32>(),
                     );
-                    let weight = Vector::<E, V>::cast_from(tap_weight::<EL>(
-                        &weights,
+                    let weight = Vector::<E, V>::cast_from(tap_weight_row_reused::<EL>(
+                        &block_weights,
+                        &row_weights,
                         &reduce_coords,
                         comptime!(factors),
                         comptime!(problem.offsets.clone()),
+                        comptime!(problem.factor_reuse.clone()),
                     ));
 
                     let base = rhs_reader.map.advance(
@@ -238,11 +340,12 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
     }
 }
 
-/// Evaluate every factor's 1-D tap walk at one accumulator cell.
+/// Evaluate one factor's complete 1-D tap walk at the accumulator coordinate where it is cached.
 #[cube]
 #[allow(clippy::too_many_arguments)]
-fn tap_walk<EL: Numeric, ER: Numeric>(
+fn factor_walk<EL: Numeric, ER: Numeric>(
     weights: &mut Array<EL>,
+    offset: usize,
     lhs: &Tile<EL>,
     rhs: &Tile<ER>,
     rhs_map: &AxisProjection,
@@ -250,100 +353,173 @@ fn tap_walk<EL: Numeric, ER: Numeric>(
     batch: &Coords<u32>,
     row: u32,
     col: u32,
-    #[comptime] factors: usize,
+    #[comptime] factor: usize,
     #[comptime] problem: GatherProblem,
 ) {
     match comptime!(problem.normalization) {
         None =>
         {
             #[unroll]
-            for f in 0..factors {
-                #[unroll]
-                for k in 0..comptime!(problem.block.reduce_extents[f]) {
-                    let pos = cell_position(
-                        batch,
-                        row,
-                        col,
-                        &factor_coords(comptime!(factors), f, k),
-                        comptime!(problem.lhs_space.clone()),
-                        comptime!(problem.clone()),
-                        1usize,
-                    );
-                    weights[comptime!(problem.offsets[f] + k)] = lhs.separable_factor(pos, f);
-                }
+            for k in 0..comptime!(problem.block.reduce_extents[factor]) {
+                let pos = cell_position(
+                    batch,
+                    row,
+                    col,
+                    &factor_coords(comptime!(problem.factors.unwrap()), factor, k),
+                    comptime!(problem.lhs_space.clone()),
+                    comptime!(problem.clone()),
+                    1usize,
+                );
+                weights[offset + comptime!(k)] = lhs.separable_factor(pos, factor);
             }
         }
-        Some((mask, guard)) =>
-        {
+        Some((mask, guard)) => {
+            let mut sum = EL::from_int(0);
             #[unroll]
-            for f in 0..factors {
-                let mut sum = EL::from_int(0);
-                #[unroll]
-                for k in 0..comptime!(problem.block.reduce_extents[f]) {
-                    let reduce_coords = factor_coords(comptime!(factors), f, k);
-                    let lhs_pos = cell_position(
-                        batch,
-                        row,
-                        col,
-                        &reduce_coords,
-                        comptime!(problem.lhs_space.clone()),
-                        comptime!(problem.clone()),
-                        1usize,
-                    );
-                    let weight = lhs.separable_factor(lhs_pos, f);
-                    let weight = match comptime!(mask) {
-                        TapMask::Masked => {
-                            let rhs_pos = cell_position(
-                                batch,
-                                row,
-                                col,
-                                &reduce_coords,
-                                comptime!(problem.rhs_space.clone()),
-                                comptime!(problem.clone()),
-                                comptime!(problem.block.vw),
-                            );
-                            let physical_pos = rhs_map.advance(
-                                anchor,
-                                rhs_pos,
-                                comptime!(problem.block.reduce.clone()),
-                            );
-                            select(
-                                rhs.separable_physical_tap_in_bounds(
-                                    &physical_pos,
-                                    comptime!(problem.block.reduce[f]),
-                                ),
-                                weight,
-                                EL::from_int(0),
-                            )
-                        }
-                        TapMask::Unmasked => weight,
-                    };
-                    weights[comptime!(problem.offsets[f] + k)] = weight;
-                    sum += weight;
-                }
+            for k in 0..comptime!(problem.block.reduce_extents[factor]) {
+                let reduce_coords = factor_coords(comptime!(problem.factors.unwrap()), factor, k);
+                let lhs_pos = cell_position(
+                    batch,
+                    row,
+                    col,
+                    &reduce_coords,
+                    comptime!(problem.lhs_space.clone()),
+                    comptime!(problem.clone()),
+                    1usize,
+                );
+                let weight = lhs.separable_factor(lhs_pos, factor);
+                let weight = match comptime!(mask) {
+                    TapMask::Masked => {
+                        let rhs_pos = cell_position(
+                            batch,
+                            row,
+                            col,
+                            &reduce_coords,
+                            comptime!(problem.rhs_space.clone()),
+                            comptime!(problem.clone()),
+                            comptime!(problem.block.vw),
+                        );
+                        let physical_pos = rhs_map.advance(
+                            anchor,
+                            rhs_pos,
+                            comptime!(problem.block.reduce.clone()),
+                        );
+                        select(
+                            rhs.separable_physical_tap_in_bounds(
+                                &physical_pos,
+                                comptime!(problem.block.reduce[factor]),
+                            ),
+                            weight,
+                            EL::from_int(0),
+                        )
+                    }
+                    TapMask::Unmasked => weight,
+                };
+                weights[offset + comptime!(k)] = weight;
+                sum += weight;
+            }
 
-                let reciprocal = guarded_recip_numeric::<EL>(sum, guard);
-                #[unroll]
-                for k in 0..comptime!(problem.block.reduce_extents[f]) {
-                    weights[comptime!(problem.offsets[f] + k)] *= reciprocal;
-                }
+            let reciprocal = guarded_recip_numeric::<EL>(sum, guard);
+            #[unroll]
+            for k in 0..comptime!(problem.block.reduce_extents[factor]) {
+                weights[offset + comptime!(k)] *= reciprocal;
             }
         }
     }
 }
 
-/// Fold one tap's per-factor weights into the product its cell accumulates.
+/// Fold one tap's per-factor weights from their maximal cache levels.
 #[cube]
-fn tap_weight<EL: Numeric>(
-    weights: &Array<EL>,
+#[allow(clippy::too_many_arguments)]
+fn tap_weight_reused<EL: Numeric>(
+    block: &Array<EL>,
+    row: &Array<EL>,
+    column: &Array<EL>,
+    cell: &Array<EL>,
+    reduce_coords: &Coords<u32>,
+    column_index: usize,
+    #[comptime] factors: usize,
+    #[comptime] taps: usize,
+    #[comptime] offsets: Vec<usize>,
+    #[comptime] reuse: Vec<FactorReuse>,
+) -> EL {
+    let mut weight = factor_weight(
+        block,
+        row,
+        column,
+        cell,
+        reduce_coords,
+        column_index,
+        0usize,
+        taps,
+        comptime!(offsets[0]),
+        comptime!(reuse[0]),
+    );
+    #[unroll]
+    for f in 1..factors {
+        weight *= factor_weight(
+            block,
+            row,
+            column,
+            cell,
+            reduce_coords,
+            column_index,
+            f,
+            taps,
+            comptime!(offsets[f]),
+            comptime!(reuse[f]),
+        );
+    }
+    weight
+}
+
+#[cube]
+#[allow(clippy::too_many_arguments)]
+fn factor_weight<EL: Numeric>(
+    block: &Array<EL>,
+    row: &Array<EL>,
+    column: &Array<EL>,
+    cell: &Array<EL>,
+    reduce_coords: &Coords<u32>,
+    column_index: usize,
+    #[comptime] factor: usize,
+    #[comptime] taps: usize,
+    #[comptime] offset: usize,
+    #[comptime] reuse: FactorReuse,
+) -> EL {
+    let tap = factor_tap(reduce_coords, factor, offset);
+    match comptime!(reuse) {
+        FactorReuse::Block => block[tap],
+        FactorReuse::Row => row[tap],
+        FactorReuse::Column => column[column_index * comptime!(taps) + tap],
+        FactorReuse::Cell => cell[tap],
+    }
+}
+
+/// The column-free nesting only needs block- and row-cached factors.
+#[cube]
+fn tap_weight_row_reused<EL: Numeric>(
+    block: &Array<EL>,
+    row: &Array<EL>,
     reduce_coords: &Coords<u32>,
     #[comptime] factors: usize,
     #[comptime] offsets: Vec<usize>,
+    #[comptime] reuse: Vec<FactorReuse>,
 ) -> EL {
-    let mut weight = weights[factor_tap(reduce_coords, 0usize, comptime!(offsets[0]))];
+    let first = factor_tap(reduce_coords, 0usize, comptime!(offsets[0]));
+    let mut weight = match comptime!(reuse[0]) {
+        FactorReuse::Block => block[first],
+        FactorReuse::Row => row[first],
+        FactorReuse::Column | FactorReuse::Cell => unreachable!(),
+    };
     #[unroll]
     for f in 1..factors {
-        weight *= weights[factor_tap(reduce_coords, f, comptime!(offsets[f]))];
+        let tap = factor_tap(reduce_coords, f, comptime!(offsets[f]));
+        weight *= match comptime!(reuse[f]) {
+            FactorReuse::Block => block[tap],
+            FactorReuse::Row => row[tap],
+            FactorReuse::Column | FactorReuse::Cell => unreachable!(),
+        };
     }
     weight
 }

--- a/crates/cubek-tile/src/instruction/registers/contract/gather/separable.rs
+++ b/crates/cubek-tile/src/instruction/registers/contract/gather/separable.rs
@@ -26,9 +26,9 @@ use super::{
 /// accumulator's own column axis at coefficient `1`
 /// ([`assert_separable_shapes`](super::coords::assert_separable_shapes)), so their source
 /// coordinates differ in that axis alone and one cell apart. The taps above them move only the
-/// contracted axes, which a resampling map steps outside its floor. Where the lhs does not span the
-/// column axis, the whole run shares one anchor ([`AxisProjection::anchor`]) per row; where it
-/// spans the column axis, each `(i, n)` cell anchors once and steps its taps via
+/// contracted axes, which a resampling map steps outside its floor. When every factor is free of
+/// the column axis, the whole run shares one anchor ([`AxisProjection::anchor`]) per row; otherwise
+/// each `(i, n)` cell anchors once and steps its taps via
 /// [`AxisProjection::advance`]. In both cases, reads and mask tests use the stepped physical
 /// coordinates rather than evaluating the projection terms per tap.
 #[cube]
@@ -57,6 +57,8 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
     );
     let kc = comptime!(problem.block.kc);
     let taps = comptime!(problem.taps);
+    let caches_block = comptime!(problem.factor_reuse.contains(&FactorReuse::Block));
+    let caches_column = comptime!(problem.factor_reuse.contains(&FactorReuse::Column));
     let factors_span_col = comptime!(
         problem
             .factor_reuse
@@ -93,65 +95,27 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
         );
 
         let mut block_weights = Array::<EL>::new(taps);
-        let block_anchor = rhs_reader.map.anchor(
-            cell_position(
+        if comptime!(caches_block) {
+            let block_anchor = rhs_anchor(
+                &rhs_reader.map,
                 &batch,
                 0u32,
                 0u32,
-                &factor_coords(comptime!(factors), 0usize, 0usize),
-                comptime!(problem.rhs_space.clone()),
                 comptime!(problem.clone()),
-                comptime!(problem.block.vw),
-            ),
-            comptime!(problem.block.reduce.clone()),
-        );
-        #[unroll]
-        for f in 0..factors {
-            if comptime!(problem.factor_reuse[f] == FactorReuse::Block) {
-                factor_walk::<EL, ER>(
-                    &mut block_weights,
-                    comptime!(problem.offsets[f]),
-                    lhs,
-                    rhs,
-                    &rhs_reader.map,
-                    &block_anchor,
-                    &batch,
-                    0u32,
-                    0u32,
-                    f,
-                    comptime!(problem.clone()),
-                );
-            }
-        }
-
-        let mut column_weights = Array::<EL>::new(taps * nr);
-        #[unroll]
-        for f in 0..factors {
-            if comptime!(problem.factor_reuse[f] == FactorReuse::Column) {
-                #[unroll(unroll)]
-                for n in 0..nr {
-                    let anchor = rhs_reader.map.anchor(
-                        cell_position(
-                            &batch,
-                            0u32,
-                            n as u32,
-                            &factor_coords(comptime!(factors), f, 0usize),
-                            comptime!(problem.rhs_space.clone()),
-                            comptime!(problem.clone()),
-                            comptime!(problem.block.vw),
-                        ),
-                        comptime!(problem.block.reduce.clone()),
-                    );
+            );
+            #[unroll]
+            for f in 0..factors {
+                if comptime!(problem.factor_reuse[f] == FactorReuse::Block) {
                     factor_walk::<EL, ER>(
-                        &mut column_weights,
-                        n * comptime!(taps) + comptime!(problem.offsets[f]),
+                        &mut block_weights,
+                        comptime!(problem.offsets[f]),
                         lhs,
                         rhs,
                         &rhs_reader.map,
-                        &anchor,
+                        &block_anchor,
                         &batch,
                         0u32,
-                        n as u32,
+                        0u32,
                         f,
                         comptime!(problem.clone()),
                     );
@@ -159,31 +123,58 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
             }
         }
 
+        let mut column_weights = Array::<EL>::new(taps * nr);
+        if comptime!(caches_column) {
+            #[unroll(unroll)]
+            for n in 0..nr {
+                let anchor = rhs_anchor(
+                    &rhs_reader.map,
+                    &batch,
+                    0u32,
+                    n as u32,
+                    comptime!(problem.clone()),
+                );
+                #[unroll]
+                for f in 0..factors {
+                    if comptime!(problem.factor_reuse[f] == FactorReuse::Column) {
+                        factor_walk::<EL, ER>(
+                            &mut column_weights,
+                            n * comptime!(taps) + comptime!(problem.offsets[f]),
+                            lhs,
+                            rhs,
+                            &rhs_reader.map,
+                            &anchor,
+                            &batch,
+                            0u32,
+                            n as u32,
+                            f,
+                            comptime!(problem.clone()),
+                        );
+                    }
+                }
+            }
+        }
+
         #[unroll(unroll)]
         for i in 0..mr {
             let mut row_weights = Array::<EL>::new(taps);
+            let row_anchor = rhs_anchor(
+                &rhs_reader.map,
+                &batch,
+                i as u32,
+                0u32,
+                comptime!(problem.clone()),
+            );
             #[unroll]
             for f in 0..factors {
                 if comptime!(problem.factor_reuse[f] == FactorReuse::Row) {
-                    let anchor = rhs_reader.map.anchor(
-                        cell_position(
-                            &batch,
-                            i as u32,
-                            0u32,
-                            &factor_coords(comptime!(factors), f, 0usize),
-                            comptime!(problem.rhs_space.clone()),
-                            comptime!(problem.clone()),
-                            comptime!(problem.block.vw),
-                        ),
-                        comptime!(problem.block.reduce.clone()),
-                    );
                     factor_walk::<EL, ER>(
                         &mut row_weights,
                         comptime!(problem.offsets[f]),
                         lhs,
                         rhs,
                         &rhs_reader.map,
-                        &anchor,
+                        &row_anchor,
                         &batch,
                         i as u32,
                         0u32,
@@ -195,17 +186,12 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
             if comptime!(factors_span_col) {
                 #[unroll(unroll)]
                 for n in 0..nr {
-                    let anchor = rhs_reader.map.anchor(
-                        cell_position(
-                            &batch,
-                            i as u32,
-                            n as u32,
-                            &factor_coords(comptime!(factors), 0usize, 0usize),
-                            comptime!(problem.rhs_space.clone()),
-                            comptime!(problem.clone()),
-                            comptime!(problem.block.vw),
-                        ),
-                        comptime!(problem.block.reduce.clone()),
+                    let anchor = rhs_anchor(
+                        &rhs_reader.map,
+                        &batch,
+                        i as u32,
+                        n as u32,
+                        comptime!(problem.clone()),
                     );
                     let mut cell_weights = Array::<EL>::new(taps);
                     #[unroll]
@@ -233,7 +219,7 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
                             comptime!(problem.block.reduce_extents.clone()),
                             p.fcast::<u32>(),
                         );
-                        let weight = tap_weight_reused::<EL>(
+                        let weight = tap_weight::<EL>(
                             &block_weights,
                             &row_weights,
                             &column_weights,
@@ -271,26 +257,13 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
                 // The taps are the only coordinates moving under this row, so the map's rational
                 // axes carry the same numerator at all `kc` of them: their floor is taken once
                 // here and each tap steps the result.
-                let anchor = rhs_reader.map.anchor(
-                    cell_position(
-                        &batch,
-                        i as u32,
-                        0u32,
-                        &factor_coords(comptime!(factors), 0usize, 0usize),
-                        comptime!(problem.rhs_space.clone()),
-                        comptime!(problem.clone()),
-                        comptime!(problem.block.vw),
-                    ),
-                    comptime!(problem.block.reduce.clone()),
-                );
-
                 #[unroll(unroll_taps)]
                 for p in 0..kc {
                     let reduce_coords = unravel_const(
                         comptime!(problem.block.reduce_extents.clone()),
                         p.fcast::<u32>(),
                     );
-                    let weight = Vector::<E, V>::cast_from(tap_weight_row_reused::<EL>(
+                    let weight = Vector::<E, V>::cast_from(row_cached_tap_weight::<EL>(
                         &block_weights,
                         &row_weights,
                         &reduce_coords,
@@ -300,7 +273,7 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
                     ));
 
                     let base = rhs_reader.map.advance(
-                        &anchor,
+                        &row_anchor,
                         cell_position(
                             &batch,
                             i as u32,
@@ -338,6 +311,29 @@ pub(super) fn contract<E: Numeric, EL: Numeric, ER: Numeric, V: Size, A: Size>(
             unroll,
         );
     }
+}
+
+/// Anchor the rhs projection at one accumulator cell with every contracted coordinate at zero.
+#[cube]
+fn rhs_anchor(
+    rhs_map: &AxisProjection,
+    batch: &Coords<u32>,
+    row: u32,
+    col: u32,
+    #[comptime] problem: GatherProblem,
+) -> CoordsDyn {
+    rhs_map.anchor(
+        cell_position(
+            batch,
+            row,
+            col,
+            &factor_coords(comptime!(problem.factors.unwrap()), 0usize, 0usize),
+            comptime!(problem.rhs_space.clone()),
+            comptime!(problem.clone()),
+            comptime!(problem.block.vw),
+        ),
+        comptime!(problem.block.reduce.clone()),
+    )
 }
 
 /// Evaluate one factor's complete 1-D tap walk at the accumulator coordinate where it is cached.
@@ -431,7 +427,7 @@ fn factor_walk<EL: Numeric, ER: Numeric>(
 /// Fold one tap's per-factor weights from their maximal cache levels.
 #[cube]
 #[allow(clippy::too_many_arguments)]
-fn tap_weight_reused<EL: Numeric>(
+fn tap_weight<EL: Numeric>(
     block: &Array<EL>,
     row: &Array<EL>,
     column: &Array<EL>,
@@ -443,62 +439,29 @@ fn tap_weight_reused<EL: Numeric>(
     #[comptime] offsets: Vec<usize>,
     #[comptime] reuse: Vec<FactorReuse>,
 ) -> EL {
-    let mut weight = factor_weight(
-        block,
-        row,
-        column,
-        cell,
-        reduce_coords,
-        column_index,
-        0usize,
-        taps,
-        comptime!(offsets[0]),
-        comptime!(reuse[0]),
-    );
+    let first = factor_tap(reduce_coords, 0usize, comptime!(offsets[0]));
+    let mut weight = match comptime!(reuse[0]) {
+        FactorReuse::Block => block[first],
+        FactorReuse::Row => row[first],
+        FactorReuse::Column => column[column_index * comptime!(taps) + first],
+        FactorReuse::Cell => cell[first],
+    };
     #[unroll]
     for f in 1..factors {
-        weight *= factor_weight(
-            block,
-            row,
-            column,
-            cell,
-            reduce_coords,
-            column_index,
-            f,
-            taps,
-            comptime!(offsets[f]),
-            comptime!(reuse[f]),
-        );
+        let tap = factor_tap(reduce_coords, f, comptime!(offsets[f]));
+        weight *= match comptime!(reuse[f]) {
+            FactorReuse::Block => block[tap],
+            FactorReuse::Row => row[tap],
+            FactorReuse::Column => column[column_index * comptime!(taps) + tap],
+            FactorReuse::Cell => cell[tap],
+        };
     }
     weight
 }
 
-#[cube]
-#[allow(clippy::too_many_arguments)]
-fn factor_weight<EL: Numeric>(
-    block: &Array<EL>,
-    row: &Array<EL>,
-    column: &Array<EL>,
-    cell: &Array<EL>,
-    reduce_coords: &Coords<u32>,
-    column_index: usize,
-    #[comptime] factor: usize,
-    #[comptime] taps: usize,
-    #[comptime] offset: usize,
-    #[comptime] reuse: FactorReuse,
-) -> EL {
-    let tap = factor_tap(reduce_coords, factor, offset);
-    match comptime!(reuse) {
-        FactorReuse::Block => block[tap],
-        FactorReuse::Row => row[tap],
-        FactorReuse::Column => column[column_index * comptime!(taps) + tap],
-        FactorReuse::Cell => cell[tap],
-    }
-}
-
 /// The column-free nesting only needs block- and row-cached factors.
 #[cube]
-fn tap_weight_row_reused<EL: Numeric>(
+fn row_cached_tap_weight<EL: Numeric>(
     block: &Array<EL>,
     row: &Array<EL>,
     reduce_coords: &Coords<u32>,

--- a/crates/cubek-tile/src/instruction/registers/contract/gather/separable.rs
+++ b/crates/cubek-tile/src/instruction/registers/contract/gather/separable.rs
@@ -439,24 +439,57 @@ fn tap_weight<EL: Numeric>(
     #[comptime] offsets: Vec<usize>,
     #[comptime] reuse: Vec<FactorReuse>,
 ) -> EL {
-    let first = factor_tap(reduce_coords, 0usize, comptime!(offsets[0]));
-    let mut weight = match comptime!(reuse[0]) {
-        FactorReuse::Block => block[first],
-        FactorReuse::Row => row[first],
-        FactorReuse::Column => column[column_index * comptime!(taps) + first],
-        FactorReuse::Cell => cell[first],
-    };
+    let mut weight = factor_weight(
+        block,
+        row,
+        column,
+        cell,
+        reduce_coords,
+        column_index,
+        0usize,
+        taps,
+        comptime!(offsets[0]),
+        comptime!(reuse[0]),
+    );
     #[unroll]
     for f in 1..factors {
-        let tap = factor_tap(reduce_coords, f, comptime!(offsets[f]));
-        weight *= match comptime!(reuse[f]) {
-            FactorReuse::Block => block[tap],
-            FactorReuse::Row => row[tap],
-            FactorReuse::Column => column[column_index * comptime!(taps) + tap],
-            FactorReuse::Cell => cell[tap],
-        };
+        weight *= factor_weight(
+            block,
+            row,
+            column,
+            cell,
+            reduce_coords,
+            column_index,
+            f,
+            taps,
+            comptime!(offsets[f]),
+            comptime!(reuse[f]),
+        );
     }
     weight
+}
+
+#[cube]
+#[allow(clippy::too_many_arguments)]
+fn factor_weight<EL: Numeric>(
+    block: &Array<EL>,
+    row: &Array<EL>,
+    column: &Array<EL>,
+    cell: &Array<EL>,
+    reduce_coords: &Coords<u32>,
+    column_index: usize,
+    #[comptime] factor: usize,
+    #[comptime] taps: usize,
+    #[comptime] offset: usize,
+    #[comptime] reuse: FactorReuse,
+) -> EL {
+    let tap = factor_tap(reduce_coords, factor, offset);
+    match comptime!(reuse) {
+        FactorReuse::Block => block[tap],
+        FactorReuse::Row => row[tap],
+        FactorReuse::Column => column[column_index * comptime!(taps) + tap],
+        FactorReuse::Cell => cell[tap],
+    }
 }
 
 /// The column-free nesting only needs block- and row-cached factors.

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -57,10 +57,10 @@ impl<T: Numeric> Tile<T> {
 
     /// Create a procedural tile while preserving the recipe's factorization for contraction: the
     /// consumer sees one factor per contracted axis instead of one opaque field.
-    pub fn procedural_separable<R: SeparableRecipe<T> + 'static>(
-        _space: Space,
-        _recipe: R,
-    ) -> Self {
+    pub fn procedural_separable<R: SeparableRecipe<T> + 'static>(_space: Space, _recipe: R) -> Self
+    where
+        R::ExpandType: RecipeAxisDeps,
+    {
         unexpanded!()
     }
 
@@ -68,7 +68,10 @@ impl<T: Numeric> Tile<T> {
         scope: &Scope,
         space: Space,
         recipe: R::ExpandType,
-    ) -> TileExpand<T> {
+    ) -> TileExpand<T>
+    where
+        R::ExpandType: SeparableRecipeOps<T>,
+    {
         // A separable procedural tile is always evaluated in place. This invariant is load-bearing
         // for normalization: staging a recipe into shared memory would drop its factorization and
         // normalization metadata without diagnostic.
@@ -716,6 +719,23 @@ impl<T: Numeric> Tile<T> {
         }
     }
 
+    /// Whether a selected separable factor reads an axis of its recipe coordinates. Backed and
+    /// opaque tiles answer conservatively because no separable schedule may index them anyway.
+    pub(crate) fn factor_addresses(
+        &self,
+        #[comptime] factor: usize,
+        #[comptime] axis: Axis,
+    ) -> comptime_type!(bool) {
+        match &self.tile_kind {
+            TileKind::Procedural(data) => data.factor_addresses(factor, axis),
+            TileKind::Gmem(_)
+            | TileKind::Smem(_)
+            | TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::TmaGmem(_) => comptime!(true),
+        }
+    }
+
     /// This operand's window sign, for a stage recording where it was filled from.
     pub(crate) fn window_signed(&self) -> comptime_type!(bool) {
         match &self.tile_kind {
@@ -732,6 +752,28 @@ impl<T: Numeric> Tile<T> {
         match &self.tile_kind {
             TileKind::Gmem(d) | TileKind::Smem(d) => comptime!(d.window.boundaries.clone()),
             _ => comptime!(SmallVec::new()),
+        }
+    }
+
+    /// The physical boundaries factor-local normalization tests. A shared-memory tile preserves
+    /// these on its source window even though its resident window itself no longer overhangs.
+    pub(crate) fn separable_boundaries(
+        &self,
+    ) -> comptime_type!(SmallVec<[Option<Boundary>; MAX_AXES]>) {
+        match &self.tile_kind {
+            TileKind::Gmem(d) => comptime!(d.window.boundaries.clone()),
+            TileKind::Smem(d) =>
+            {
+                #[comptime]
+                match &d.source_window {
+                    ComptimeOption::Some(source) => comptime!(source.boundaries.clone()),
+                    ComptimeOption::None => comptime!(SmallVec::new()),
+                }
+            }
+            TileKind::Procedural(_)
+            | TileKind::PlaneTile(_)
+            | TileKind::PlanePartition(_)
+            | TileKind::TmaGmem(_) => comptime!(SmallVec::new()),
         }
     }
 
@@ -1150,6 +1192,43 @@ impl<T: Numeric> Tile<T> {
                 )
             }
         }
+    }
+}
+
+impl<T: Numeric> Tile<T> {
+    pub(crate) fn factor_dependencies(
+        &self,
+        _factors: Option<usize>,
+        _row: Axis,
+        _col: Axis,
+    ) -> comptime_type!(Option<Vec<(bool, bool)>>) {
+        unexpanded!()
+    }
+}
+
+impl<T: Numeric> TileExpand<T> {
+    pub(crate) fn __expand_factor_dependencies_method(
+        &self,
+        scope: &Scope,
+        factors: Option<usize>,
+        row: Axis,
+        col: Axis,
+    ) -> Option<Vec<(bool, bool)>> {
+        factors.map(|factors| {
+            (0..factors)
+                .map(|f| match &self.tile_kind {
+                    TileKindExpand::Procedural(data) => (
+                        data.__expand_factor_addresses_method(scope, f, row),
+                        data.__expand_factor_addresses_method(scope, f, col),
+                    ),
+                    TileKindExpand::Gmem(_)
+                    | TileKindExpand::Smem(_)
+                    | TileKindExpand::PlaneTile(_)
+                    | TileKindExpand::PlanePartition(_)
+                    | TileKindExpand::TmaGmem(_) => (true, true),
+                })
+                .collect()
+        })
     }
 }
 

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -59,7 +59,7 @@ impl<T: Numeric> Tile<T> {
     /// consumer sees one factor per contracted axis instead of one opaque field.
     pub fn procedural_separable<R: SeparableRecipe<T> + 'static>(_space: Space, _recipe: R) -> Self
     where
-        R::ExpandType: RecipeAxisDeps,
+        R::ExpandType: SeparableRecipeAxisDependencies,
     {
         unexpanded!()
     }
@@ -719,23 +719,6 @@ impl<T: Numeric> Tile<T> {
         }
     }
 
-    /// Whether a selected separable factor reads an axis of its recipe coordinates. Backed and
-    /// opaque tiles answer conservatively because no separable schedule may index them anyway.
-    pub(crate) fn factor_addresses(
-        &self,
-        #[comptime] factor: usize,
-        #[comptime] axis: Axis,
-    ) -> comptime_type!(bool) {
-        match &self.tile_kind {
-            TileKind::Procedural(data) => data.factor_addresses(factor, axis),
-            TileKind::Gmem(_)
-            | TileKind::Smem(_)
-            | TileKind::PlaneTile(_)
-            | TileKind::PlanePartition(_)
-            | TileKind::TmaGmem(_) => comptime!(true),
-        }
-    }
-
     /// This operand's window sign, for a stage recording where it was filled from.
     pub(crate) fn window_signed(&self) -> comptime_type!(bool) {
         match &self.tile_kind {
@@ -1214,20 +1197,20 @@ impl<T: Numeric> TileExpand<T> {
         row: Axis,
         col: Axis,
     ) -> Option<Vec<(bool, bool)>> {
-        factors.map(|factors| {
-            (0..factors)
-                .map(|f| match &self.tile_kind {
-                    TileKindExpand::Procedural(data) => (
-                        data.__expand_factor_addresses_method(scope, f, row),
-                        data.__expand_factor_addresses_method(scope, f, col),
-                    ),
-                    TileKindExpand::Gmem(_)
-                    | TileKindExpand::Smem(_)
-                    | TileKindExpand::PlaneTile(_)
-                    | TileKindExpand::PlanePartition(_)
-                    | TileKindExpand::TmaGmem(_) => (true, true),
+        factors.map(|factors| match &self.tile_kind {
+            TileKindExpand::Procedural(data) => (0..factors)
+                .map(|f| {
+                    (
+                        data.__expand_factor_reads_axis_method(scope, f, row),
+                        data.__expand_factor_reads_axis_method(scope, f, col),
+                    )
                 })
-                .collect()
+                .collect(),
+            TileKindExpand::Gmem(_)
+            | TileKindExpand::Smem(_)
+            | TileKindExpand::PlaneTile(_)
+            | TileKindExpand::PlanePartition(_)
+            | TileKindExpand::TmaGmem(_) => (0..factors).map(|_| (true, true)).collect(),
         })
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/affine.rs
+++ b/crates/cubek-tile/src/tile/procedural/affine.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 
 use crate::Axis;
 
-use super::{Recipe, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
 
 /// A one-dimensional affine coordinate expression, `offset + coefficient * coordinate[axis]`.
 /// The axis is compile-time metadata; offset and coefficient can be runtime values.
@@ -32,5 +32,11 @@ pub fn affine_along<T: Numeric>(
 impl<T: Numeric> Recipe<T> for AffineCoordinate<T> {
     fn evaluate(&self, coordinates: &RecipeCoords) -> T {
         self.offset + self.coefficient * T::cast_from(coordinates.along(self.axis))
+    }
+}
+
+impl<T: Numeric> RecipeAxisDeps for AffineCoordinateExpand<T> {
+    fn addresses(&self, _scope: &Scope, axis: Axis) -> bool {
+        self.axis == axis
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/affine.rs
+++ b/crates/cubek-tile/src/tile/procedural/affine.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 
 use crate::Axis;
 
-use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDependencies, RecipeCoords, RecipeExpand};
 
 /// A one-dimensional affine coordinate expression, `offset + coefficient * coordinate[axis]`.
 /// The axis is compile-time metadata; offset and coefficient can be runtime values.
@@ -35,8 +35,8 @@ impl<T: Numeric> Recipe<T> for AffineCoordinate<T> {
     }
 }
 
-impl<T: Numeric> RecipeAxisDeps for AffineCoordinateExpand<T> {
-    fn addresses(&self, _scope: &Scope, axis: Axis) -> bool {
+impl<T: Numeric> RecipeAxisDependencies for AffineCoordinateExpand<T> {
+    fn reads_axis(&self, _scope: &Scope, axis: Axis) -> bool {
         self.axis == axis
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/base.rs
+++ b/crates/cubek-tile/src/tile/procedural/base.rs
@@ -117,12 +117,12 @@ impl<T: Numeric> ProceduralData<T> {
         self.recipe.factors()
     }
 
-    pub(crate) fn factor_addresses(
+    pub(crate) fn factor_reads_axis(
         &self,
         #[comptime] factor: usize,
         #[comptime] axis: Axis,
     ) -> comptime_type!(bool) {
-        self.recipe.factor_addresses(factor, axis)
+        self.recipe.factor_reads_axis(factor, axis)
     }
 
     pub(crate) fn evaluate_factor_dyn(

--- a/crates/cubek-tile/src/tile/procedural/base.rs
+++ b/crates/cubek-tile/src/tile/procedural/base.rs
@@ -117,6 +117,14 @@ impl<T: Numeric> ProceduralData<T> {
         self.recipe.factors()
     }
 
+    pub(crate) fn factor_addresses(
+        &self,
+        #[comptime] factor: usize,
+        #[comptime] axis: Axis,
+    ) -> comptime_type!(bool) {
+        self.recipe.factor_addresses(factor, axis)
+    }
+
     pub(crate) fn evaluate_factor_dyn(
         &self,
         pos: &CoordsDyn,

--- a/crates/cubek-tile/src/tile/procedural/constant.rs
+++ b/crates/cubek-tile/src/tile/procedural/constant.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 
-use super::{Recipe, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
 
 /// A procedural field holding one value, which may be a runtime scalar.
 #[derive(CubeType, Clone)]
@@ -12,6 +12,12 @@ pub struct Constant<T: Numeric> {
 impl<T: Numeric> Recipe<T> for Constant<T> {
     fn evaluate(&self, _coordinates: &RecipeCoords) -> T {
         self.value
+    }
+}
+
+impl<T: Numeric> RecipeAxisDeps for ConstantExpand<T> {
+    fn addresses(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
+        false
     }
 }
 
@@ -27,6 +33,12 @@ impl<T: Numeric> Recipe<T> for Zeros {
     }
 }
 
+impl RecipeAxisDeps for ZerosExpand {
+    fn addresses(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
+        false
+    }
+}
+
 /// Constant one, carrying no value for the same reason as [`Zeros`].
 #[derive(CubeType, Clone, Copy, Default)]
 pub struct Ones;
@@ -35,5 +47,11 @@ pub struct Ones;
 impl<T: Numeric> Recipe<T> for Ones {
     fn evaluate(&self, _coordinates: &RecipeCoords) -> T {
         T::from_int(1)
+    }
+}
+
+impl RecipeAxisDeps for OnesExpand {
+    fn addresses(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
+        false
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/constant.rs
+++ b/crates/cubek-tile/src/tile/procedural/constant.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 
-use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDependencies, RecipeCoords, RecipeExpand};
 
 /// A procedural field holding one value, which may be a runtime scalar.
 #[derive(CubeType, Clone)]
@@ -15,8 +15,8 @@ impl<T: Numeric> Recipe<T> for Constant<T> {
     }
 }
 
-impl<T: Numeric> RecipeAxisDeps for ConstantExpand<T> {
-    fn addresses(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
+impl<T: Numeric> RecipeAxisDependencies for ConstantExpand<T> {
+    fn reads_axis(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
         false
     }
 }
@@ -33,8 +33,8 @@ impl<T: Numeric> Recipe<T> for Zeros {
     }
 }
 
-impl RecipeAxisDeps for ZerosExpand {
-    fn addresses(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
+impl RecipeAxisDependencies for ZerosExpand {
+    fn reads_axis(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
         false
     }
 }
@@ -50,8 +50,8 @@ impl<T: Numeric> Recipe<T> for Ones {
     }
 }
 
-impl RecipeAxisDeps for OnesExpand {
-    fn addresses(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
+impl RecipeAxisDependencies for OnesExpand {
+    fn reads_axis(&self, _scope: &Scope, _axis: crate::Axis) -> bool {
         false
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/filter/cubic.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/cubic.rs
@@ -3,7 +3,7 @@ use cubecl_common::Ratio;
 
 use crate::Axis;
 
-use super::super::{AffineCoordinate, Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
+use super::super::{AffineCoordinate, Recipe, RecipeAxisDependencies, RecipeCoords, RecipeExpand};
 
 /// Keys' cubic-convolution filter over an [`AffineCoordinate`].
 pub type CubicAxis<T> = Cubic<AffineCoordinate<T>>;
@@ -62,11 +62,11 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Cubic<C> {
     }
 }
 
-impl<C: CubeType> RecipeAxisDeps for CubicExpand<C>
+impl<C: CubeType> RecipeAxisDependencies for CubicExpand<C>
 where
-    C::ExpandType: RecipeAxisDeps,
+    C::ExpandType: RecipeAxisDependencies,
 {
-    fn addresses(&self, scope: &Scope, axis: Axis) -> bool {
-        self.coordinate.addresses(scope, axis)
+    fn reads_axis(&self, scope: &Scope, axis: Axis) -> bool {
+        self.coordinate.reads_axis(scope, axis)
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/filter/cubic.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/cubic.rs
@@ -3,7 +3,7 @@ use cubecl_common::Ratio;
 
 use crate::Axis;
 
-use super::super::{AffineCoordinate, Recipe, RecipeCoords, RecipeExpand};
+use super::super::{AffineCoordinate, Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
 
 /// Keys' cubic-convolution filter over an [`AffineCoordinate`].
 pub type CubicAxis<T> = Cubic<AffineCoordinate<T>>;
@@ -59,5 +59,14 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Cubic<C> {
             first,
             select(x <= T::new(2.0_f32), second, T::new(0.0_f32)),
         )
+    }
+}
+
+impl<C: CubeType> RecipeAxisDeps for CubicExpand<C>
+where
+    C::ExpandType: RecipeAxisDeps,
+{
+    fn addresses(&self, scope: &Scope, axis: Axis) -> bool {
+        self.coordinate.addresses(scope, axis)
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/filter/lanczos.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/lanczos.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 
 use crate::Axis;
 
-use super::super::{AffineCoordinate, Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
+use super::super::{AffineCoordinate, Recipe, RecipeAxisDependencies, RecipeCoords, RecipeExpand};
 
 /// Windowed-sinc Lanczos filter over an [`AffineCoordinate`].
 pub type LanczosAxis<T> = Lanczos<AffineCoordinate<T>>;
@@ -73,11 +73,11 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Lanczos<C> {
     }
 }
 
-impl<C: CubeType> RecipeAxisDeps for LanczosExpand<C>
+impl<C: CubeType> RecipeAxisDependencies for LanczosExpand<C>
 where
-    C::ExpandType: RecipeAxisDeps,
+    C::ExpandType: RecipeAxisDependencies,
 {
-    fn addresses(&self, scope: &Scope, axis: Axis) -> bool {
-        self.coordinate.addresses(scope, axis)
+    fn reads_axis(&self, scope: &Scope, axis: Axis) -> bool {
+        self.coordinate.reads_axis(scope, axis)
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/filter/lanczos.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/lanczos.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 
 use crate::Axis;
 
-use super::super::{AffineCoordinate, Recipe, RecipeCoords, RecipeExpand};
+use super::super::{AffineCoordinate, Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
 
 /// Windowed-sinc Lanczos filter over an [`AffineCoordinate`].
 pub type LanczosAxis<T> = Lanczos<AffineCoordinate<T>>;
@@ -70,5 +70,14 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Lanczos<C> {
                 T::new(0.0_f32),
             ),
         )
+    }
+}
+
+impl<C: CubeType> RecipeAxisDeps for LanczosExpand<C>
+where
+    C::ExpandType: RecipeAxisDeps,
+{
+    fn addresses(&self, scope: &Scope, axis: Axis) -> bool {
+        self.coordinate.addresses(scope, axis)
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/filter/linear.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/linear.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 
 use crate::Axis;
 
-use super::super::{AffineCoordinate, Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
+use super::super::{AffineCoordinate, Recipe, RecipeAxisDependencies, RecipeCoords, RecipeExpand};
 
 /// A [`Linear`] filter applied directly to an [`AffineCoordinate`].
 pub type LinearAxis<T> = Linear<AffineCoordinate<T>>;
@@ -33,11 +33,11 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Linear<C> {
     }
 }
 
-impl<C: CubeType> RecipeAxisDeps for LinearExpand<C>
+impl<C: CubeType> RecipeAxisDependencies for LinearExpand<C>
 where
-    C::ExpandType: RecipeAxisDeps,
+    C::ExpandType: RecipeAxisDependencies,
 {
-    fn addresses(&self, scope: &Scope, axis: Axis) -> bool {
-        self.coordinate.addresses(scope, axis)
+    fn reads_axis(&self, scope: &Scope, axis: Axis) -> bool {
+        self.coordinate.reads_axis(scope, axis)
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/filter/linear.rs
+++ b/crates/cubek-tile/src/tile/procedural/filter/linear.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 
 use crate::Axis;
 
-use super::super::{AffineCoordinate, Recipe, RecipeCoords, RecipeExpand};
+use super::super::{AffineCoordinate, Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
 
 /// A [`Linear`] filter applied directly to an [`AffineCoordinate`].
 pub type LinearAxis<T> = Linear<AffineCoordinate<T>>;
@@ -30,5 +30,14 @@ impl<T: Float, C: Recipe<T>> Recipe<T> for Linear<C> {
     fn evaluate(&self, coordinates: &RecipeCoords) -> T {
         let x = self.coordinate.evaluate(coordinates).abs();
         select(x < T::new(1.0_f32), T::new(1.0_f32) - x, T::new(0.0_f32))
+    }
+}
+
+impl<C: CubeType> RecipeAxisDeps for LinearExpand<C>
+where
+    C::ExpandType: RecipeAxisDeps,
+{
+    fn addresses(&self, scope: &Scope, axis: Axis) -> bool {
+        self.coordinate.addresses(scope, axis)
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/phase.rs
+++ b/crates/cubek-tile/src/tile/procedural/phase.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 
 use crate::{Axis, Fold, FoldExpand, floor_div_rem};
 
-use super::{Recipe, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
 
 /// The fractional part a rational coordinate mapping leaves behind, scaled:
 /// `coefficient * frac((coord[axis] * numerator_scale + numerator_offset) / divisor)`.
@@ -58,5 +58,11 @@ impl<T: Float> Recipe<T> for Phase<T> {
             residue / T::cast_from(self.divisor)
         };
         self.coefficient * fraction
+    }
+}
+
+impl<T: Float> RecipeAxisDeps for PhaseExpand<T> {
+    fn addresses(&self, _scope: &Scope, axis: Axis) -> bool {
+        self.axis == axis
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/phase.rs
+++ b/crates/cubek-tile/src/tile/procedural/phase.rs
@@ -2,7 +2,7 @@ use cubecl::prelude::*;
 
 use crate::{Axis, Fold, FoldExpand, floor_div_rem};
 
-use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDependencies, RecipeCoords, RecipeExpand};
 
 /// The fractional part a rational coordinate mapping leaves behind, scaled:
 /// `coefficient * frac((coord[axis] * numerator_scale + numerator_offset) / divisor)`.
@@ -61,8 +61,8 @@ impl<T: Float> Recipe<T> for Phase<T> {
     }
 }
 
-impl<T: Float> RecipeAxisDeps for PhaseExpand<T> {
-    fn addresses(&self, _scope: &Scope, axis: Axis) -> bool {
+impl<T: Float> RecipeAxisDependencies for PhaseExpand<T> {
+    fn reads_axis(&self, _scope: &Scope, axis: Axis) -> bool {
         self.axis == axis
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/product.rs
+++ b/crates/cubek-tile/src/tile/procedural/product.rs
@@ -1,6 +1,8 @@
 use cubecl::prelude::*;
 
-use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
+use super::{
+    Recipe, RecipeAxisDependencies, RecipeCoords, RecipeExpand, SeparableRecipeAxisDependencies,
+};
 
 /// A recipe that factorizes into one factor per contracted axis, `R(coords) = ∏ᵢ Rᵢ(coords)`,
 /// factor `i` varying only along the `i`-th contracted axis. The gather microkernel uses this
@@ -39,13 +41,13 @@ impl<T: Numeric, A: Recipe<T>, B: Recipe<T>> Recipe<T> for Product<A, B> {
     }
 }
 
-impl<A: CubeType, B: CubeType> RecipeAxisDeps for ProductExpand<A, B>
+impl<A: CubeType, B: CubeType> RecipeAxisDependencies for ProductExpand<A, B>
 where
-    A::ExpandType: RecipeAxisDeps,
-    B::ExpandType: RecipeAxisDeps,
+    A::ExpandType: RecipeAxisDependencies,
+    B::ExpandType: RecipeAxisDependencies,
 {
-    fn addresses(&self, scope: &Scope, axis: crate::Axis) -> bool {
-        self.lhs.addresses(scope, axis) || self.rhs.addresses(scope, axis)
+    fn reads_axis(&self, scope: &Scope, axis: crate::Axis) -> bool {
+        self.lhs.reads_axis(scope, axis) || self.rhs.reads_axis(scope, axis)
     }
 }
 
@@ -62,17 +64,15 @@ pub struct SeparableProduct<R: CubeType> {
     pub factors: Sequence<R>,
 }
 
-impl<R: CubeType> RecipeAxisDeps for SeparableProductExpand<R>
+impl<R: CubeType> SeparableRecipeAxisDependencies for SeparableProductExpand<R>
 where
-    R::ExpandType: RecipeAxisDeps,
+    R::ExpandType: RecipeAxisDependencies,
 {
-    fn addresses(&self, scope: &Scope, axis: crate::Axis) -> bool {
-        (0..self.factors.len()).any(|f| {
-            let f = NativeExpand::from_lit(scope, f);
-            self.factors
-                .__expand_index_method(scope, f)
-                .addresses(scope, axis)
-        })
+    fn factor_reads_axis(&self, scope: &Scope, factor: usize, axis: crate::Axis) -> bool {
+        let factor = NativeExpand::from_lit(scope, factor);
+        self.factors
+            .__expand_index_method(scope, factor)
+            .reads_axis(scope, axis)
     }
 }
 

--- a/crates/cubek-tile/src/tile/procedural/product.rs
+++ b/crates/cubek-tile/src/tile/procedural/product.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 
-use super::{Recipe, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
 
 /// A recipe that factorizes into one factor per contracted axis, `R(coords) = ∏ᵢ Rᵢ(coords)`,
 /// factor `i` varying only along the `i`-th contracted axis. The gather microkernel uses this
@@ -39,6 +39,16 @@ impl<T: Numeric, A: Recipe<T>, B: Recipe<T>> Recipe<T> for Product<A, B> {
     }
 }
 
+impl<A: CubeType, B: CubeType> RecipeAxisDeps for ProductExpand<A, B>
+where
+    A::ExpandType: RecipeAxisDeps,
+    B::ExpandType: RecipeAxisDeps,
+{
+    fn addresses(&self, scope: &Scope, axis: crate::Axis) -> bool {
+        self.lhs.addresses(scope, axis) || self.rhs.addresses(scope, axis)
+    }
+}
+
 /// The product of one factor per contracted axis, in contraction order: the separable kernel
 /// `K₀ ⊗ K₁ ⊗ … ⊗ Kₙ₋₁`. Rank is the sequence's length, so one type serves a 1-D, 2-D or
 /// volumetric filter, and each factor is free to read a different axis of the same recipe
@@ -50,6 +60,20 @@ impl<T: Numeric, A: Recipe<T>, B: Recipe<T>> Recipe<T> for Product<A, B> {
 #[derive(CubeType, Clone)]
 pub struct SeparableProduct<R: CubeType> {
     pub factors: Sequence<R>,
+}
+
+impl<R: CubeType> RecipeAxisDeps for SeparableProductExpand<R>
+where
+    R::ExpandType: RecipeAxisDeps,
+{
+    fn addresses(&self, scope: &Scope, axis: crate::Axis) -> bool {
+        (0..self.factors.len()).any(|f| {
+            let f = NativeExpand::from_lit(scope, f);
+            self.factors
+                .__expand_index_method(scope, f)
+                .addresses(scope, axis)
+        })
+    }
 }
 
 /// Construct a [`SeparableProduct`] from its factors, for the reason [`sum_of`](super::sum_of)

--- a/crates/cubek-tile/src/tile/procedural/recipe.rs
+++ b/crates/cubek-tile/src/tile/procedural/recipe.rs
@@ -9,6 +9,15 @@ use cubecl::unexpanded;
 use super::SeparableRecipeExpand;
 use crate::{Axis, Coords, Space};
 
+/// Coordinate dependence of a recipe, queried while a kernel is expanded.
+///
+/// This deliberately lives on expand types: axes are compile-time state of recipe values, not a
+/// runtime GPU value, and composing the answer in ordinary Rust avoids turning a collected list
+/// of axes into mutable kernel state.
+pub trait RecipeAxisDeps {
+    fn addresses(&self, scope: &Scope, axis: Axis) -> bool;
+}
+
 /// The absolute logical coordinates a [`Recipe`] is evaluated at: the source's `origin` plus the
 /// position it is read at, within its [`Space`]. Rebased one axis at a time on demand, so a recipe
 /// emits an add only for the axes it actually reads, and one that ignores its coordinates emits none.
@@ -56,12 +65,15 @@ pub trait Recipe<T: Numeric> {
     fn evaluate(&self, coordinates: &RecipeCoords) -> T;
 }
 
-pub(crate) trait RecipeOps<T: Numeric> {
+#[doc(hidden)]
+pub trait RecipeOps<T: Numeric> {
     fn evaluate_virtual(&self, scope: &Scope, coordinates: &RecipeCoordsExpand) -> NativeExpand<T>;
 }
 
-pub(crate) trait SeparableRecipeOps<T: Numeric>: RecipeOps<T> {
+#[doc(hidden)]
+pub trait SeparableRecipeOps<T: Numeric>: RecipeOps<T> {
     fn factors_virtual(&self, scope: &Scope) -> usize;
+    fn factor_addresses_virtual(&self, scope: &Scope, factor: usize, axis: Axis) -> bool;
     fn evaluate_factor_virtual(
         &self,
         scope: &Scope,
@@ -70,9 +82,19 @@ pub(crate) trait SeparableRecipeOps<T: Numeric>: RecipeOps<T> {
     ) -> NativeExpand<T>;
 }
 
-impl<T: Numeric, R: SeparableRecipeExpand<T> + RecipeExpand<T>> SeparableRecipeOps<T> for R {
+impl<T: Numeric, R> SeparableRecipeOps<T> for super::SeparableProductExpand<R>
+where
+    R: Recipe<T>,
+    R::ExpandType: RecipeAxisDeps,
+{
     fn factors_virtual(&self, scope: &Scope) -> usize {
         self.__expand_factors_method(scope)
+    }
+    fn factor_addresses_virtual(&self, scope: &Scope, factor: usize, axis: Axis) -> bool {
+        let factor = NativeExpand::from_lit(scope, factor);
+        self.factors
+            .__expand_index_method(scope, factor)
+            .addresses(scope, axis)
     }
     fn evaluate_factor_virtual(
         &self,
@@ -114,7 +136,10 @@ impl<T: Numeric> VirtualRecipe<T> {
     pub fn __expand_new_separable<R: super::SeparableRecipe<T> + 'static>(
         _scope: &Scope,
         recipe: R::ExpandType,
-    ) -> VirtualRecipeExpand<T> {
+    ) -> VirtualRecipeExpand<T>
+    where
+        R::ExpandType: SeparableRecipeOps<T>,
+    {
         let recipe = Arc::new(recipe);
         VirtualRecipeExpand {
             state: recipe.clone(),
@@ -134,6 +159,11 @@ impl<T: Numeric> VirtualRecipe<T> {
     }
 
     pub fn evaluate_factor(&self, _coordinates: &RecipeCoords, _factor: usize) -> T {
+        unexpanded!()
+    }
+
+    /// Whether one separable factor reads `axis` from its recipe coordinates.
+    pub fn factor_addresses(&self, _factor: usize, _axis: Axis) -> comptime_type!(bool) {
         unexpanded!()
     }
 }
@@ -167,6 +197,18 @@ impl<T: Numeric> VirtualRecipeExpand<T> {
                 assert_eq!(factor, 0, "recipe states no factorization beyond itself");
                 self.state.evaluate_virtual(scope, coordinates)
             }
+        }
+    }
+
+    pub fn __expand_factor_addresses_method(
+        &self,
+        scope: &Scope,
+        factor: usize,
+        axis: Axis,
+    ) -> bool {
+        match &self.separable {
+            Some(separable) => separable.factor_addresses_virtual(scope, factor, axis),
+            None => true,
         }
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/recipe.rs
+++ b/crates/cubek-tile/src/tile/procedural/recipe.rs
@@ -14,8 +14,13 @@ use crate::{Axis, Coords, Space};
 /// This deliberately lives on expand types: axes are compile-time state of recipe values, not a
 /// runtime GPU value, and composing the answer in ordinary Rust avoids turning a collected list
 /// of axes into mutable kernel state.
-pub trait RecipeAxisDeps {
-    fn addresses(&self, scope: &Scope, axis: Axis) -> bool;
+pub trait RecipeAxisDependencies {
+    fn reads_axis(&self, scope: &Scope, axis: Axis) -> bool;
+}
+
+/// Per-factor coordinate dependencies of a separable recipe, queried during expansion.
+pub trait SeparableRecipeAxisDependencies {
+    fn factor_reads_axis(&self, scope: &Scope, factor: usize, axis: Axis) -> bool;
 }
 
 /// The absolute logical coordinates a [`Recipe`] is evaluated at: the source's `origin` plus the
@@ -73,7 +78,7 @@ pub trait RecipeOps<T: Numeric> {
 #[doc(hidden)]
 pub trait SeparableRecipeOps<T: Numeric>: RecipeOps<T> {
     fn factors_virtual(&self, scope: &Scope) -> usize;
-    fn factor_addresses_virtual(&self, scope: &Scope, factor: usize, axis: Axis) -> bool;
+    fn factor_reads_axis_virtual(&self, scope: &Scope, factor: usize, axis: Axis) -> bool;
     fn evaluate_factor_virtual(
         &self,
         scope: &Scope,
@@ -82,19 +87,15 @@ pub trait SeparableRecipeOps<T: Numeric>: RecipeOps<T> {
     ) -> NativeExpand<T>;
 }
 
-impl<T: Numeric, R> SeparableRecipeOps<T> for super::SeparableProductExpand<R>
+impl<T: Numeric, R> SeparableRecipeOps<T> for R
 where
-    R: Recipe<T>,
-    R::ExpandType: RecipeAxisDeps,
+    R: SeparableRecipeExpand<T> + RecipeExpand<T> + SeparableRecipeAxisDependencies,
 {
     fn factors_virtual(&self, scope: &Scope) -> usize {
         self.__expand_factors_method(scope)
     }
-    fn factor_addresses_virtual(&self, scope: &Scope, factor: usize, axis: Axis) -> bool {
-        let factor = NativeExpand::from_lit(scope, factor);
-        self.factors
-            .__expand_index_method(scope, factor)
-            .addresses(scope, axis)
+    fn factor_reads_axis_virtual(&self, scope: &Scope, factor: usize, axis: Axis) -> bool {
+        self.factor_reads_axis(scope, factor, axis)
     }
     fn evaluate_factor_virtual(
         &self,
@@ -163,7 +164,7 @@ impl<T: Numeric> VirtualRecipe<T> {
     }
 
     /// Whether one separable factor reads `axis` from its recipe coordinates.
-    pub fn factor_addresses(&self, _factor: usize, _axis: Axis) -> comptime_type!(bool) {
+    pub fn factor_reads_axis(&self, _factor: usize, _axis: Axis) -> comptime_type!(bool) {
         unexpanded!()
     }
 }
@@ -200,14 +201,14 @@ impl<T: Numeric> VirtualRecipeExpand<T> {
         }
     }
 
-    pub fn __expand_factor_addresses_method(
+    pub fn __expand_factor_reads_axis_method(
         &self,
         scope: &Scope,
         factor: usize,
         axis: Axis,
     ) -> bool {
         match &self.separable {
-            Some(separable) => separable.factor_addresses_virtual(scope, factor, axis),
+            Some(separable) => separable.factor_reads_axis_virtual(scope, factor, axis),
             None => true,
         }
     }

--- a/crates/cubek-tile/src/tile/procedural/sum.rs
+++ b/crates/cubek-tile/src/tile/procedural/sum.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 
-use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDependencies, RecipeCoords, RecipeExpand};
 
 /// Pointwise sum of two recipes: `(A + B)(coords) = A(coords) + B(coords)`. Composing
 /// [`AffineCoordinate`](super::AffineCoordinate) terms through it is how a recipe reads more than
@@ -25,12 +25,12 @@ impl<T: Numeric, A: Recipe<T>, B: Recipe<T>> Recipe<T> for Sum<A, B> {
     }
 }
 
-impl<A: CubeType, B: CubeType> RecipeAxisDeps for SumExpand<A, B>
+impl<A: CubeType, B: CubeType> RecipeAxisDependencies for SumExpand<A, B>
 where
-    A::ExpandType: RecipeAxisDeps,
-    B::ExpandType: RecipeAxisDeps,
+    A::ExpandType: RecipeAxisDependencies,
+    B::ExpandType: RecipeAxisDependencies,
 {
-    fn addresses(&self, scope: &Scope, axis: crate::Axis) -> bool {
-        self.lhs.addresses(scope, axis) || self.rhs.addresses(scope, axis)
+    fn reads_axis(&self, scope: &Scope, axis: crate::Axis) -> bool {
+        self.lhs.reads_axis(scope, axis) || self.rhs.reads_axis(scope, axis)
     }
 }

--- a/crates/cubek-tile/src/tile/procedural/sum.rs
+++ b/crates/cubek-tile/src/tile/procedural/sum.rs
@@ -1,6 +1,6 @@
 use cubecl::prelude::*;
 
-use super::{Recipe, RecipeCoords, RecipeExpand};
+use super::{Recipe, RecipeAxisDeps, RecipeCoords, RecipeExpand};
 
 /// Pointwise sum of two recipes: `(A + B)(coords) = A(coords) + B(coords)`. Composing
 /// [`AffineCoordinate`](super::AffineCoordinate) terms through it is how a recipe reads more than
@@ -22,5 +22,15 @@ pub fn sum_of<A: CubeType, B: CubeType>(lhs: A, rhs: B) -> Sum<A, B> {
 impl<T: Numeric, A: Recipe<T>, B: Recipe<T>> Recipe<T> for Sum<A, B> {
     fn evaluate(&self, coordinates: &RecipeCoords) -> T {
         self.lhs.evaluate(coordinates) + self.rhs.evaluate(coordinates)
+    }
+}
+
+impl<A: CubeType, B: CubeType> RecipeAxisDeps for SumExpand<A, B>
+where
+    A::ExpandType: RecipeAxisDeps,
+    B::ExpandType: RecipeAxisDeps,
+{
+    fn addresses(&self, scope: &Scope, axis: crate::Axis) -> bool {
+        self.lhs.addresses(scope, axis) || self.rhs.addresses(scope, axis)
     }
 }


### PR DESCRIPTION
Stacked on #564.

## What changed

- Track which accumulator axes each separable recipe factor actually reads.
- Classify each factor's maximal safe reuse level as block, row, column, or cell.
- Cache each factor's complete tap walk at that level instead of recomputing it for every output cell.
- Preserve correctness for masked normalization by including source-boundary dependencies in the reuse classification.
- Extract factor lookup into a dedicated helper and add coverage for dependency and cache-level selection.

This lets interpolation reuse the vertical filter across columns and the horizontal filter across rows while retaining cell-local evaluation wherever coordinates or masked bounds require it.

## Verification

- `cargo fmt --check`
- `cargo clippy -p cubek-tile -p cubek-interpolate --all-targets -- -D warnings`
- `git diff --check origin/perf/procedural-filter-arithmetic...HEAD`

The unrelated interpolation compute-peak reporting change was split into `feat/interpolate-compute-peak` for a later stacked PR.
