### PR TITLE
Budget the unrolled top-k selection networks by emitted size

### DIFF
--- a/crates/cubek-reduce/src/components/instructions/base.rs
+++ b/crates/cubek-reduce/src/components/instructions/base.rs
@@ -149,6 +149,25 @@ impl<X: CubePrimitive> Value<X> {
     }
 }
 
+/// How much fully-unrolled top-k selection work is worth emitting, counted in
+/// copies of a loop body.
+///
+/// The selection networks below are `k`-by-`k`: every candidate walks all `k`
+/// accumulator slots. Unrolling both levels keeps the accumulator in registers
+/// with constant slot indices, which is worth a lot — rolled, the slots move to
+/// scratch memory and every step becomes a load/store. Measured on a
+/// `32x512x4095` `ArgTopK` (device timing, RTX 5090 / Vulkan), unrolling is
+/// worth 5.8x at `k = 32` and 2.2x at `k = 64`.
+///
+/// But the emitted kernel grows with the product, so a flat cap on `k` prices
+/// the three nest shapes wrong: `topk_finalize_*` is `k * k * vector_size`, not
+/// `k * k`, and is the first to become unaffordable. Budgeting the product
+/// instead lets the square nests unroll further than the cubic one, and stops
+/// all of them before the backend compiler does: past this budget the same
+/// selection runs as a plain runtime loop whose kernel size does not depend on
+/// `k` at all.
+pub(crate) const TOPK_UNROLL_BUDGET: usize = 1024;
+
 /// Plane-cooperative top-k insertion; the candidate's coordinate decides which
 /// algorithm runs, since winners are identified by their coordinate when one
 /// rides along and by lane id otherwise.
@@ -184,7 +203,7 @@ fn plane_topk_insert_with_coords<N: Numeric, S: Size>(
     let mut local_best_val = item;
     let mut local_best_coord = coord;
 
-    #[unroll]
+    #[unroll(k * k <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
     for _i in 0..k {
         let winning_val = plane_max(local_best_val);
         let winning_coord =
@@ -193,7 +212,7 @@ fn plane_topk_insert_with_coords<N: Numeric, S: Size>(
         let mut insert_val = winning_val;
         let mut insert_coord = winning_coord;
 
-        #[unroll]
+        #[unroll(k * k <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
         for j in 0..k {
             let to_keep = select_many(
                 elements[j].equal(&insert_val),
@@ -228,7 +247,7 @@ fn plane_topk_insert_values<N: Numeric, S: Size>(
     let mut local_best_val = item;
     let lane_id = Vector::new(UNIT_POS_X);
 
-    #[unroll]
+    #[unroll(k * k <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
     for _i in 0..k {
         let winning_val = plane_max(local_best_val);
         let is_match = local_best_val.equal(&winning_val);
@@ -236,7 +255,7 @@ fn plane_topk_insert_values<N: Numeric, S: Size>(
 
         let mut insert_val = winning_val;
 
-        #[unroll]
+        #[unroll(k * k <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
         for j in 0..k {
             let to_keep = elements[j].greater_than(&insert_val);
             let next_val = select_many(to_keep, insert_val, elements[j]);
@@ -276,12 +295,12 @@ fn plane_topk_merge_with_coords<N: Numeric, S: Size>(
     let mut cursor = Vector::new(0u32);
     let lane_id = Vector::new(UNIT_POS_X);
 
-    #[unroll]
+    #[unroll(k * k <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
     for i in 0..k {
         let mut local_val = Vector::new(N::min_value());
         let mut local_coord = Vector::new(u32::MAX);
 
-        #[unroll]
+        #[unroll(k * k <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
         for j in 0..k {
             let is_pointed = cursor.equal(&Vector::new(j as u32));
             local_val = select_many(is_pointed, elements[j], local_val);
@@ -317,11 +336,11 @@ fn plane_topk_merge_values<N: Numeric, S: Size>(
     let mut cursor = Vector::new(0u32);
     let lane_id = Vector::new(UNIT_POS_X);
 
-    #[unroll]
+    #[unroll(k * k <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
     for i in 0..k {
         let mut local_val = Vector::new(N::min_value());
 
-        #[unroll]
+        #[unroll(k * k <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
         for j in 0..k {
             let is_pointed = cursor.equal(&Vector::new(j as u32));
             local_val = select_many(is_pointed, elements[j], local_val);

--- a/crates/cubek-reduce/src/components/instructions/topk.rs
+++ b/crates/cubek-reduce/src/components/instructions/topk.rs
@@ -4,6 +4,7 @@ use cubecl::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::components::instructions::AccumulatorFormat;
+
 use crate::components::instructions::plane_topk_insert;
 use crate::components::instructions::plane_topk_merge;
 use crate::components::instructions::{Accumulator, Item, Value, ValueExpand};
@@ -362,13 +363,13 @@ fn topk_finalize_values<P: ReducePrecision, Out: Numeric>(
         topk[slot] = Out::min_value();
     }
 
-    #[unroll]
+    #[unroll(k * k * vector_size <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
     for i in 0..k {
         #[unroll]
         for j in 0..vector_size {
             let mut element = Out::cast_from(vals[i].extract(j));
 
-            #[unroll]
+            #[unroll(k * k * vector_size <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
             for slot in 0..k {
                 let current = topk[slot];
                 let keep = current > element;
@@ -405,14 +406,14 @@ fn topk_finalize_with_coords<P: ReducePrecision>(
         topk_coords[slot] = u32::MAX;
     }
 
-    #[unroll]
+    #[unroll(k * k * vector_size <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
     for i in 0..k {
         #[unroll]
         for j in 0..vector_size {
             let mut value = vals[i].extract(j);
             let mut coordinate = coords[i].extract(j);
 
-            #[unroll]
+            #[unroll(k * k * vector_size <= crate::components::instructions::TOPK_UNROLL_BUDGET)]
             for slot in 0..k {
                 let current_value = topk_vals[slot];
                 let current_coordinate = topk_coords[slot];

--- a/crates/cubek-reduce/src/eval/benchmarks/problem.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/problem.rs
@@ -108,6 +108,25 @@ pub fn problems() -> Vec<CatalogEntry<ReduceProblem>> {
         ));
     }
 
+    // Large `k`, where the selection network's `O(reduce_len * k)` shape shows.
+    // The catalogue stopped at `k = 5`, which is why the cost of large `k` went
+    // unnoticed: on a 5090 these run 0.18 ms at `k = 8` and 370 ms at `k = 256`.
+    // `k = 32` is the interesting point — it is the largest that still fits the
+    // unroll budget, and it is 5.8x faster for it. Fused only: what is being
+    // measured is the accumulator, not the launch pattern.
+    for k in [16, 32, 64, 128, 256] {
+        entries.push(CatalogEntry::new(
+            format!("topk{k}_fused_axis2_32x512x4095"),
+            format!("TopK({k}) values+indices, 1 fused launch, axis=2 (32x512x4095)"),
+            ReduceProblem {
+                shape: shape(),
+                axis: 2,
+                config: ReduceOperationConfig::TopK(k),
+                kind: ReduceBenchKind::Fused,
+            },
+        ));
+    }
+
     // The same comparison for min and max, which reach `reduce_with_indices`
     // through their own collapsed instructions rather than the top-k one.
     for (name, label, config) in [

--- a/crates/cubek-reduce/src/launch/base.rs
+++ b/crates/cubek-reduce/src/launch/base.rs
@@ -95,6 +95,27 @@ fn prepare_reduce_launch<Run: Runtime>(
         vectorization_mode,
         &strategy.vectorization,
     );
+    // The rolled top-k selection network (`k * k > TOPK_UNROLL_BUDGET`) keeps
+    // per-lane accumulator and finalize arrays whose dynamic indexing places
+    // them in per-thread local memory, and their footprint scales with
+    // `k * vector_size` (about 48 bytes per slot at width 8). Past roughly
+    // 4 KiB per thread the NVIDIA Vulkan driver corrupts memory around the
+    // local-memory window (observed on 610.62 with an RTX 5090, with both the
+    // SPIR-V and the WGSL compiler: k = 64 at width 8 is clean, k = 96 faults):
+    // the kernel still returns correct results, but a later dispatch dies with
+    // `VK_ERROR_DEVICE_LOST`. Keep the rolled path scalar - its cost is
+    // dominated by the k-slot selection network, not the input read - so the
+    // slots shrink about six-fold, which holds k = 300, the object-detection
+    // case that exposed this, comfortably below the fault threshold.
+    let (vector_size_input, vector_size_output) = match &problem.instruction {
+        ReduceOperationConfig::TopK(k) | ReduceOperationConfig::ArgTopK(k)
+            if *k * *k > crate::components::instructions::TOPK_UNROLL_BUDGET =>
+        {
+            (1, 1)
+        }
+        _ => (vector_size_input, vector_size_output),
+    };
+
     // Both fused outputs share this width, so it must be legal for the index dtype too.
     // Cap to the largest width the index dtype supports that does not exceed the values
     // width (widths are powers of two, so the cap still divides the layout constraints the

--- a/crates/cubek-reduce/tests/reduce/it/argtopk_shared_memory.rs
+++ b/crates/cubek-reduce/tests/reduce/it/argtopk_shared_memory.rs
@@ -3,8 +3,8 @@
 //! Before the clamp, the inferred Cube blueprint sized its shared allocation from
 //! plane geometry alone, so `ArgTopK(k)` requested `8 * k * cube_width` bytes and the
 //! launch was rejected once `k` passed ~12 on a 99 KiB device, even though a narrower
-//! cube fit. Gated behind `heavy` like the other cube tests (the kernels are slow to
-//! compile, the top-k insert/merge are unrolled over `k`).
+//! cube fit. Gated behind `heavy` like the other cube tests, whose kernels are
+//! slow to compile.
 
 #![cfg(feature = "heavy")]
 
@@ -45,8 +45,8 @@ fn run_wide_argtopk(k: usize) {
 #[test]
 fn argtopk_k13_inferred_cube_launches() {
     // The smallest k that failed to launch before the fix (8 * 13 * 1024 = 106496
-    // bytes vs the 101376-byte Ada limit). Larger k is launchable too, but the
-    // top-k codegen is unrolled over k and compiles slowly (a separate issue), so
-    // a single representative k keeps this suite fast.
+    // bytes vs the 101376-byte Ada limit). Larger k is launchable too, but a cube
+    // kernel is slow to compile whatever k it is built for, so a single
+    // representative k keeps this suite fast.
     run_wide_argtopk(13);
 }

--- a/crates/cubek-reduce/tests/reduce/it/mod.rs
+++ b/crates/cubek-reduce/tests/reduce/it/mod.rs
@@ -16,6 +16,7 @@ mod argtopk_shared_memory;
 mod logical;
 mod nan_extrema;
 mod plane_reduction;
+mod topk_unroll_limit;
 mod topk_with_indices_cube;
 mod with_indices_validation;
 

--- a/crates/cubek-reduce/tests/reduce/it/topk_unroll_limit.rs
+++ b/crates/cubek-reduce/tests/reduce/it/topk_unroll_limit.rs
@@ -1,0 +1,129 @@
+//! Top-k past `TOPK_UNROLL_BUDGET`.
+//!
+//! `plane_topk_insert`, `plane_topk_merge` and `topk_finalize_*` each walk all
+//! `k` accumulator slots for each of their `k` candidates. Both levels used to
+//! be unrolled unconditionally, so the emitted kernel grew with `k²`: the
+//! `topk(300)` an object-detection head asks for expanded to ~90k copies of the
+//! insertion body and no backend compiler returned from it. Past the limit those
+//! loops stay rolled up, and the cases below cover the rolled form of every one
+//! of them.
+//!
+//! `k` is only just past the limit so the *unrolled* comparison stays cheap; the
+//! point is which code path runs, not how large `k` gets.
+
+use cubecl::{
+    config::autotune::AutotuneLevel,
+    prelude::CubeDim,
+    zspace::{Shape, Strides},
+};
+use cubek_reduce::{
+    BoundChecks, IdleMode, ReduceStrategy,
+    launch::{RoutineStrategy, VectorizationStrategy},
+    routines::{BlueprintStrategy, PlaneMergeStrategy, PlaneReduceBlueprint, unit::UnitStrategy},
+};
+
+use crate::reduce::it::test_case::TestCase;
+
+/// Past the budget for the `k`-by-`k` nests, which roll once `k * k` exceeds
+/// `TOPK_UNROLL_BUDGET`. The `k * k * vector_size` nests roll well before this.
+const K: usize = 40;
+
+fn case(routine: RoutineStrategy, parallel_output_vectorization: bool) -> TestCase {
+    TestCase::new::<f32>(
+        Shape::new([4, 256]),
+        Strides::new(&[256, 1]),
+        Some(1),
+        ReduceStrategy {
+            autotune_level: AutotuneLevel::Full,
+            vectorization: VectorizationStrategy {
+                parallel_output_vectorization,
+            },
+            routine,
+        },
+    )
+}
+
+/// `Eager` folds every candidate into the plane-wide accumulator as it arrives,
+/// which is `plane_topk_insert`; `Lazy` accumulates per lane and merges the
+/// lanes once at the end, which is `plane_topk_merge`. Both are forced, since an
+/// inferred blueprint picks one of them and would leave the other uncovered.
+fn plane(plane_merge_strategy: PlaneMergeStrategy) -> RoutineStrategy {
+    RoutineStrategy::Plane(BlueprintStrategy::Forced(
+        PlaneReduceBlueprint {
+            plane_idle: IdleMode::Terminate,
+            bound_checks: BoundChecks::Mask,
+            plane_merge_strategy,
+            plane_dim_ceil: true,
+        },
+        CubeDim::new_2d(32, 2),
+    ))
+}
+
+fn unit() -> RoutineStrategy {
+    RoutineStrategy::Unit(BlueprintStrategy::Inferred(UnitStrategy))
+}
+
+/// The case from the bug report, and the only one here that actually fails
+/// without the limit: `k = 300` is what an object-detection head asks for, and
+/// unrolled it expands to ~90k copies of the insertion body. The failure mode is
+/// a hang, not an assertion — expanding the kernel alone went from 15 ms to
+/// minutes between `k = 64` and `k = 128`, and never returned at 300 — so
+/// without the fix this test does not finish rather than reporting red.
+///
+/// The `K` cases below are the correctness half: they cover the rolled form of
+/// every selection network, but they pass either way, since that `k` unrolled
+/// still compiles.
+#[test]
+fn topk_300_terminates_and_matches_reference() {
+    TestCase::new::<f32>(
+        Shape::new([1, 1024]),
+        Strides::new(&[1024, 1]),
+        Some(1),
+        ReduceStrategy {
+            autotune_level: AutotuneLevel::Full,
+            vectorization: VectorizationStrategy {
+                parallel_output_vectorization: true,
+            },
+            routine: unit(),
+        },
+    )
+    .test_topk_with_indices(300);
+}
+
+#[test]
+fn plane_eager_topk_with_indices_past_unroll_limit() {
+    case(plane(PlaneMergeStrategy::Eager), false).test_topk_with_indices(K);
+}
+
+#[test]
+fn plane_eager_topk_past_unroll_limit() {
+    case(plane(PlaneMergeStrategy::Eager), false).test_topk(K);
+}
+
+#[test]
+fn plane_lazy_topk_with_indices_past_unroll_limit() {
+    case(plane(PlaneMergeStrategy::Lazy), false).test_topk_with_indices(K);
+}
+
+#[test]
+fn plane_lazy_topk_past_unroll_limit() {
+    case(plane(PlaneMergeStrategy::Lazy), false).test_topk(K);
+}
+
+// Output vectorization is what routes the accumulator out through
+// `topk_finalize_with_coords` / `topk_finalize_values`, whose `k`-by-`k` nest
+// runs once more per lane of the vector.
+#[test]
+fn vectorized_topk_with_indices_past_unroll_limit() {
+    case(unit(), true).test_topk_with_indices(K);
+}
+
+#[test]
+fn vectorized_topk_past_unroll_limit() {
+    case(unit(), true).test_topk(K);
+}
+
+#[test]
+fn vectorized_argtopk_past_unroll_limit() {
+    case(unit(), true).test_argtopk(K);
+}


### PR DESCRIPTION
`topk_with_indices(300, ..)` — an ordinary object-detection head — never returns on the wgpu/Vulkan backend. One thread spins at 100% CPU with ~13.8 GB resident, forever; nothing is ever dispatched, because the process never gets out of kernel compilation. Reproduces in debug and release.

Six loop nests unroll `k` inside `k`, so the emitted kernel is `O(k²)`:

| function | file |
| --- | --- |
| `plane_topk_insert_with_coords`, `plane_topk_insert_values` | `components/instructions/base.rs` |
| `plane_topk_merge_with_coords`, `plane_topk_merge_values` | `components/instructions/base.rs` |
| `topk_finalize_values`, `topk_finalize_with_coords` (`O(k² · vector_size)`) | `components/instructions/topk.rs` |

Time to *expand* the kernel — `KernelTask::define`, before any compiler pass — for `ArgTopK(k)` over `[1, 1024]` f16, plane routine, `vec_in = 8`:

| k | 8 | 16 | 32 | 64 | 128 | 300 |
| --- | --- | --- | --- | --- | --- | --- |
| before | 13.6 ms | 45.3 ms | 199 ms | 693 ms | >240 s | never |
| after | 12.3 ms | 2.4 ms | 3.8 ms | 4.7 ms | 12.2 ms | 15.4 ms |

~3.5-4x per doubling before, which is the `k²`; flat after. At `k = 300` the IR was large enough that the SPIR-V pipeline never returned either (it does not get past `verify_operation`).

Budget the emitted size rather than capping `k`. The three nests do not cost the same — two are `k * k`, the third is `k * k * vector_size` — so a single cap on `k` prices them together and, to keep the cubic one affordable, has to stop the square ones long before they need to. Each nest instead asks whether its own unrolled size fits `TOPK_UNROLL_BUDGET`.

That matters because unrolling is worth a lot where it fits: rolled, the accumulator's slots move from registers to scratch memory and every step of the selection becomes a load/store. `ArgTopK` over `32x512x4095`, axis 2, fused, device timing (RTX 5090 / Vulkan):

| k | 1 | 8 | 16 | 32 | 64 | 128 | 256 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| unrolled to a flat `k <= 8` | 0.171 | 0.183 | 0.378 | 5.214 | 10.70 | 35.8 | 333 |
| budgeted | 0.171 | 0.183 | 0.333 | 0.892 | 10.70 | 35.8 | 333 |

`k = 32` is 5.8x faster for being unrolled, `k = 16` 1.14x.

The budget is 1024 because that is where compiling stops being worth it, not because of the kernel's shape. One `k` through the bench harness (autotune plus warmup plus 10 samples) takes 9 s rolled; unrolled, 37 s at `k = 32` and 377 s at `k = 64`. So `k = 32` buys 4.3 ms per call for ~28 s of one-time compilation, while `k = 64` would buy 6.2 ms for ~367 s — payback only after ~59k calls. 1024 takes the first step and declines the second.

Below the budget nothing changes: constant slot indices, same code, same numbers. Above it the same selection runs as a runtime loop over the accumulator `Array` — the shape `topk_insert`, the non-plane insertion, has always had — and the kernel size stops depending on `k` at all.

The rolled path also gets its vectorization clamped to 1, in `prepare_reduce_launch`. Rolled, the per-lane accumulator and finalize arrays live in per-thread local memory, and their footprint scales with `k * vector_size` — about 48 bytes per slot at width 8, so `k = 300` puts ~16 KiB of dynamically indexed local memory on every thread. Past roughly 4 KiB per thread the NVIDIA Vulkan driver corrupts memory around the local-memory window (observed on 610.62 with an RTX 5090, with both the SPIR-V and the WGSL compiler: `k = 64` at width 8 is clean, `k = 96` faults): the top-k itself still returns bit-exact results, but a later, unrelated dispatch dies with `VK_ERROR_DEVICE_LOST` — an `nvlddmkm` 153 engine fault, which `VK_EXT_device_fault` attributes to a wild `WRITE_INVALID` at an address that varies run to run. Scalar slots are ~6x smaller, which holds `k = 300` — the object-detection head that exposed all of this — comfortably below the threshold, and costs nothing that matters: the rolled path's time is the `O(reduce_len * k)` selection network, not the input read.

There is no in-repo regression test for that device loss: it needs the affected driver, and the corruption is only ever observed by later dispatches — cubek-reduce's own suite runs the arming shape hundreds of times without tripping it. `topk_300_terminates_and_matches_reference` exercises the clamped path for correctness.

Tests, in `tests/reduce/it/topk_unroll_limit.rs`, against the existing CPU references:

- `topk_300_terminates_and_matches_reference` is the regression guard, and the only case that fails without the fix. Its failure mode is a hang rather than a red assertion — that is the bug — so it surfaces as a job timeout; the test's doc comment says so, to save someone diagnosing it as flakiness.
- Seven `k = 40` cases cover the rolled form of each of the six nests: plane-eager reaches `plane_topk_insert`, plane-lazy `plane_topk_merge`, and output vectorization `topk_finalize_*`. These pass either way — they check the rolled path is correct, not that the bug is gone.

The benchmark catalogue stopped at `k = 5`, which is why none of this was visible; it now carries `k` of 16 through 256.

Two comments in `tests/reduce/it/argtopk_shared_memory.rs` said `k = 13` compiles slowly *because* the top-k codegen is unrolled over `k`, and called it "a separate issue" — this is that issue, so those sentences are updated.

Not in scope: this moves the point at which the constant factor stops being paid in scratch memory; it does not touch the `O(reduce_len * k)` shape of the algorithm. A top-k that is actually good at large `k` — a radix select, rather than an insertion network held in registers — is a separate change, and the numbers above are the case for it: `k = 256` is ~2000x the memory-bound floor.

### Verification

`cargo test -p cubek-reduce`: 902 passed, 0 failed (wgpu/Vulkan, RTX 5090). `cargo fmt --all --check` is clean.

`cargo clippy -p cubek-reduce --tests --features extended -- -D warnings` reports one error, in `cubek-tile` (`instruction/registers/contract/base.rs:169`, a simplifiable boolean) — it is on `main` already and untouched by this PR; nothing in `cubek-reduce` fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
