### PR TITLE
Fix matmul autotune keys for pitched strides

### DIFF
--- a/crates/cubek-matmul/src/tune_key.rs
+++ b/crates/cubek-matmul/src/tune_key.rs
@@ -311,45 +311,19 @@ mod tests {
     }
 
     #[test]
-    fn async_copy_legality_must_distinguish_padded_row_stride() {
+    fn pitched_operand_strides_change_autotune_key() {
         let lhs_shape = Shape::new([65_536, 128]);
         let rhs_shape = Shape::new([128, 2]);
-        let rhs_strides = Strides::new(&[1, 128]);
-        let aligned_strides = Strides::new(&[128, 1]);
-        let padded_strides = Strides::new(&[130, 1]);
+        let aligned_lhs = Strides::new(&[128, 1]);
+        let padded_lhs = Strides::new(&[130, 1]);
+        let aligned_rhs = Strides::new(&[1, 128]);
+        let padded_rhs = Strides::new(&[1, 130]);
 
-        let key = |lhs_strides: &Strides| {
+        let key = |lhs_strides: &Strides, rhs_strides: &Strides| {
             MatmulAutotuneKey::from_parts(
                 &lhs_shape,
                 &rhs_shape,
                 lhs_strides,
-                &rhs_strides,
-                F32,
-                F32,
-                F32,
-                None,
-                None,
-            )
-        };
-
-        assert!(stride_align_bits(&aligned_strides, &MatrixLayout::RowMajor, &F32) >= 4);
-        assert!(stride_align_bits(&padded_strides, &MatrixLayout::RowMajor, &F32) < 4);
-        assert_ne!(key(&aligned_strides), key(&padded_strides));
-    }
-
-    #[test]
-    fn rhs_async_copy_legality_distinguishes_padded_row_stride() {
-        let lhs_shape = Shape::new([2, 128]);
-        let rhs_shape = Shape::new([128, 128]);
-        let lhs_strides = Strides::new(&[128, 1]);
-        let aligned_strides = Strides::new(&[128, 1]);
-        let padded_strides = Strides::new(&[130, 1]);
-
-        let key = |rhs_strides: &Strides| {
-            MatmulAutotuneKey::from_parts(
-                &lhs_shape,
-                &rhs_shape,
-                &lhs_strides,
                 rhs_strides,
                 F32,
                 F32,
@@ -359,40 +333,18 @@ mod tests {
             )
         };
 
-        assert!(stride_align_bits(&aligned_strides, &MatrixLayout::RowMajor, &F32) >= 4);
-        assert!(stride_align_bits(&padded_strides, &MatrixLayout::RowMajor, &F32) < 4);
-        assert_ne!(key(&aligned_strides), key(&padded_strides));
+        assert!(stride_align_bits(&aligned_lhs, &MatrixLayout::RowMajor, &F32) >= 4);
+        assert!(stride_align_bits(&padded_lhs, &MatrixLayout::RowMajor, &F32) < 4);
+        assert!(stride_align_bits(&aligned_rhs, &MatrixLayout::ColMajor, &F32) >= 4);
+        assert!(stride_align_bits(&padded_rhs, &MatrixLayout::ColMajor, &F32) < 4);
+
+        let aligned = key(&aligned_lhs, &aligned_rhs);
+        assert_ne!(aligned, key(&padded_lhs, &aligned_rhs));
+        assert_ne!(aligned, key(&aligned_lhs, &padded_rhs));
     }
 
     #[test]
-    fn transposed_rhs_async_copy_legality_distinguishes_padded_column_stride() {
-        let lhs_shape = Shape::new([2, 128]);
-        let rhs_shape = Shape::new([128, 128]);
-        let lhs_strides = Strides::new(&[128, 1]);
-        let aligned_strides = Strides::new(&[1, 128]);
-        let padded_strides = Strides::new(&[1, 130]);
-
-        let key = |rhs_strides: &Strides| {
-            MatmulAutotuneKey::from_parts(
-                &lhs_shape,
-                &rhs_shape,
-                &lhs_strides,
-                rhs_strides,
-                F32,
-                F32,
-                F32,
-                None,
-                None,
-            )
-        };
-
-        assert!(stride_align_bits(&aligned_strides, &MatrixLayout::ColMajor, &F32) >= 4);
-        assert!(stride_align_bits(&padded_strides, &MatrixLayout::ColMajor, &F32) < 4);
-        assert_ne!(key(&aligned_strides), key(&padded_strides));
-    }
-
-    #[test]
-    fn batch_stride_contributes_to_async_copy_legality() {
+    fn batch_stride_alignment_changes_autotune_key() {
         let lhs_shape = Shape::new([2, 128, 128]);
         let rhs_shape = Shape::new([2, 128, 2]);
         let rhs_strides = Strides::new(&[256, 2, 1]);

--- a/crates/cubek-matmul/src/tune_key.rs
+++ b/crates/cubek-matmul/src/tune_key.rs
@@ -137,7 +137,7 @@ impl MatmulAutotuneKey {
             k: k as u32,
         });
 
-        // The alignment factors below are computed from the *anchored* dims,
+        // The vectorization factors below are computed from the *anchored* dims,
         // the same bucketing the `m`/`n`/`k` fields get, never from the raw
         // values. A dimension carrying a runtime-dependent length (a KV-cache
         // width, a dynamic batch) would otherwise re-split every anchored
@@ -168,28 +168,8 @@ impl MatmulAutotuneKey {
             MatrixBatchLayout::HighlyPermuted => 0,
         };
 
-        // The canonical tightest non-contiguous stride of each layout: the
-        // row stride: `cols` for a contiguous `[.., rows, cols]`, `rows` for
-        // its transposed view. Batch strides are products of these, so their
-        // alignment can only be higher.
-        let lhs_stride_factor = match matrix_layout_lhs {
-            MatrixBatchLayout::Contiguous => stride_factor(k_anchored, elem_lhs),
-            // TMA can't handle discontiguous batches because they're all combined into one dim
-            MatrixBatchLayout::MildlyPermuted {
-                transposed: true,
-                batch_swap: false,
-            } => stride_factor(m_anchored, elem_lhs),
-            _ => 0,
-        };
-        let rhs_stride_factor = match matrix_layout_rhs {
-            MatrixBatchLayout::Contiguous => stride_factor(n_anchored, elem_rhs),
-            // TMA can't handle discontiguous batches because they're all combined into one dim
-            MatrixBatchLayout::MildlyPermuted {
-                transposed: true,
-                batch_swap: false,
-            } => stride_factor(k_anchored, elem_rhs),
-            _ => 0,
-        };
+        let lhs_stride_factor = stride_factor(lhs_strides, &matrix_layout_lhs, elem_lhs);
+        let rhs_stride_factor = stride_factor(rhs_strides, &matrix_layout_rhs, elem_rhs);
 
         let definition = MatmulProblemDefinition::new(
             m,
@@ -219,11 +199,26 @@ impl MatmulAutotuneKey {
     }
 }
 
-/// Stride alignment (in powers of two of bytes) of the canonical row stride
-/// `cols`: the tightest non-contiguous stride of the layout.
-fn stride_factor(cols: usize, elem: ElemType) -> u8 {
-    let bytes = (cols * elem.size_bits()) / 8;
-    bytes.trailing_zeros().min(MAX_STRIDE_FACTOR) as u8
+/// Minimum non-contiguous stride alignment in powers of two of bytes.
+fn stride_factor(strides: &Strides, layout: &MatrixBatchLayout, elem: ElemType) -> u8 {
+    let exclude_dim = match layout {
+        MatrixBatchLayout::Contiguous => strides.len() - 1,
+        MatrixBatchLayout::MildlyPermuted {
+            transposed: true,
+            batch_swap: false,
+        } => strides.len() - 2,
+        _ => return 0,
+    };
+
+    strides
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != exclude_dim)
+        .map(|(_, stride)| (stride * elem.size_bits()) / 8)
+        .map(|bytes| bytes.trailing_zeros())
+        .min()
+        .unwrap_or(MAX_STRIDE_FACTOR)
+        .min(MAX_STRIDE_FACTOR) as u8
 }
 
 /// Defines the potential vectorization.
@@ -235,6 +230,7 @@ fn pow2_factor(axis: usize) -> u8 {
 mod tests {
     use super::*;
     use cubecl::ir::{ElemType, FloatKind};
+    use cubek_std::{MatrixLayout, launch::tma::stride_align_bits};
 
     const F32: ElemType = ElemType::Float(FloatKind::F32);
 
@@ -258,31 +254,27 @@ mod tests {
         )
     }
 
-    /// Every raw length inside one anchored bucket must produce the same key:
-    /// a runtime-dependent dimension (a KV-cache width) may take any integer
-    /// value, and re-splitting the bucket by the raw value's alignment retunes
-    /// endlessly for problems the anchor treats as equal.
+    /// Shapes in one anchored bucket still need distinct keys when their actual stride alignment
+    /// changes, because that determines whether async-copy kernels are legal.
     #[test]
-    fn raw_lengths_within_a_bucket_share_one_key() {
-        // 65..=128 all anchor to the 128 bucket, at every alignment class:
-        // odd, 2-, 4-, 8-, 16-aligned, and the exact power of two.
-        let reference = key(64, 69, 64);
-        for kv in [70, 76, 88, 96, 112, 128] {
-            assert_eq!(reference, key(64, kv, 64), "kv {kv} split the bucket");
-        }
+    fn stride_alignment_splits_an_anchor_bucket() {
+        assert_eq!(key(64, 69, 64), key(64, 71, 64));
+        assert_ne!(key(64, 69, 64), key(64, 70, 64));
+        assert_ne!(key(64, 70, 64), key(64, 76, 64));
     }
 
-    /// The bucket maximum shares its bucket's key. The scale thresholds sit
-    /// exactly on the pow2 bucket ceilings (512, 2048), so deriving the scale
-    /// from the raw dims used to split the (256, 512] bucket into
-    /// 257..511 = `Small` and 512 = `Medium`, and a KV cache landing on
-    /// exactly 512 positions re-tuned mid-conversation.
+    /// The bucket maximum shares its anchored dimensions and scale. Stride alignment may still
+    /// split the full key because it changes kernel legality.
     #[test]
-    fn bucket_maxima_share_the_bucket_key() {
+    fn bucket_maxima_share_anchored_dimensions_and_scale() {
         let reference = key(64, 460, 64);
-        assert_eq!(reference, key(64, 512, 64), "512 split its bucket");
+        let maximum = key(64, 512, 64);
+        assert_eq!(reference.definition.k, maximum.definition.k);
+        assert_eq!(reference.analysis, maximum.analysis);
         let reference = key(64, 1500, 64);
-        assert_eq!(reference, key(64, 2048, 64), "2048 split its bucket");
+        let maximum = key(64, 2048, 64);
+        assert_eq!(reference.definition.k, maximum.definition.k);
+        assert_eq!(reference.analysis, maximum.analysis);
     }
 
     /// Distinct anchored buckets still get distinct keys.
@@ -293,12 +285,10 @@ mod tests {
         assert_ne!(key(64, 128, 64), key(1, 128, 64));
     }
 
-    /// The transposed (`MildlyPermuted`) arm: a column-major LHS takes its alignment
-    /// factors from `m` (the row count) rather than `k`, so raw `m` lengths inside one
-    /// anchored bucket must share a key just as the contiguous `kv` case does. The
+    /// The transposed (`MildlyPermuted`) arm must likewise use the actual column stride. The
     /// [`key`] helper above is all-contiguous, so it never reaches this branch.
     #[test]
-    fn transposed_lhs_shares_bucket_key() {
+    fn transposed_lhs_stride_alignment_splits_an_anchor_bucket() {
         // Column-major lhs `[b, m, k]`: `m` has stride 1, `k` has stride `m`, so
         // `row_stride < col_stride` and the layout is `MildlyPermuted { transposed }`.
         let key_t = |m: usize| {
@@ -315,10 +305,122 @@ mod tests {
                 None,
             )
         };
-        // 65..=128 all anchor to the 128 bucket, at every alignment class.
-        let reference = key_t(69);
-        for m in [70, 76, 88, 96, 112, 128] {
-            assert_eq!(reference, key_t(m), "m {m} split the transposed bucket");
-        }
+        assert_eq!(key_t(69), key_t(71));
+        assert_ne!(key_t(69), key_t(70));
+        assert_ne!(key_t(70), key_t(76));
+    }
+
+    #[test]
+    fn async_copy_legality_must_distinguish_padded_row_stride() {
+        let lhs_shape = Shape::new([65_536, 128]);
+        let rhs_shape = Shape::new([128, 2]);
+        let rhs_strides = Strides::new(&[1, 128]);
+        let aligned_strides = Strides::new(&[128, 1]);
+        let padded_strides = Strides::new(&[130, 1]);
+
+        let key = |lhs_strides: &Strides| {
+            MatmulAutotuneKey::from_parts(
+                &lhs_shape,
+                &rhs_shape,
+                lhs_strides,
+                &rhs_strides,
+                F32,
+                F32,
+                F32,
+                None,
+                None,
+            )
+        };
+
+        assert!(stride_align_bits(&aligned_strides, &MatrixLayout::RowMajor, &F32) >= 4);
+        assert!(stride_align_bits(&padded_strides, &MatrixLayout::RowMajor, &F32) < 4);
+        assert_ne!(key(&aligned_strides), key(&padded_strides));
+    }
+
+    #[test]
+    fn rhs_async_copy_legality_distinguishes_padded_row_stride() {
+        let lhs_shape = Shape::new([2, 128]);
+        let rhs_shape = Shape::new([128, 128]);
+        let lhs_strides = Strides::new(&[128, 1]);
+        let aligned_strides = Strides::new(&[128, 1]);
+        let padded_strides = Strides::new(&[130, 1]);
+
+        let key = |rhs_strides: &Strides| {
+            MatmulAutotuneKey::from_parts(
+                &lhs_shape,
+                &rhs_shape,
+                &lhs_strides,
+                rhs_strides,
+                F32,
+                F32,
+                F32,
+                None,
+                None,
+            )
+        };
+
+        assert!(stride_align_bits(&aligned_strides, &MatrixLayout::RowMajor, &F32) >= 4);
+        assert!(stride_align_bits(&padded_strides, &MatrixLayout::RowMajor, &F32) < 4);
+        assert_ne!(key(&aligned_strides), key(&padded_strides));
+    }
+
+    #[test]
+    fn transposed_rhs_async_copy_legality_distinguishes_padded_column_stride() {
+        let lhs_shape = Shape::new([2, 128]);
+        let rhs_shape = Shape::new([128, 128]);
+        let lhs_strides = Strides::new(&[128, 1]);
+        let aligned_strides = Strides::new(&[1, 128]);
+        let padded_strides = Strides::new(&[1, 130]);
+
+        let key = |rhs_strides: &Strides| {
+            MatmulAutotuneKey::from_parts(
+                &lhs_shape,
+                &rhs_shape,
+                &lhs_strides,
+                rhs_strides,
+                F32,
+                F32,
+                F32,
+                None,
+                None,
+            )
+        };
+
+        assert!(stride_align_bits(&aligned_strides, &MatrixLayout::ColMajor, &F32) >= 4);
+        assert!(stride_align_bits(&padded_strides, &MatrixLayout::ColMajor, &F32) < 4);
+        assert_ne!(key(&aligned_strides), key(&padded_strides));
+    }
+
+    #[test]
+    fn batch_stride_contributes_to_async_copy_legality() {
+        let lhs_shape = Shape::new([2, 128, 128]);
+        let rhs_shape = Shape::new([2, 128, 2]);
+        let rhs_strides = Strides::new(&[256, 2, 1]);
+        let aligned_strides = Strides::new(&[16_384, 128, 1]);
+        let padded_strides = Strides::new(&[16_386, 128, 1]);
+
+        let key = |lhs_strides: &Strides| {
+            MatmulAutotuneKey::from_parts(
+                &lhs_shape,
+                &rhs_shape,
+                lhs_strides,
+                &rhs_strides,
+                F32,
+                F32,
+                F32,
+                None,
+                None,
+            )
+        };
+
+        let aligned = key(&aligned_strides);
+        let padded = key(&padded_strides);
+        assert_eq!(aligned.definition.lhs_stride_factor, 9);
+        assert_eq!(padded.definition.lhs_stride_factor, 3);
+        assert_eq!(
+            padded.definition.lhs_stride_factor as u32,
+            stride_align_bits(&padded_strides, &MatrixLayout::RowMajor, &F32)
+        );
+        assert_ne!(aligned, padded);
     }
 }

--- a/crates/cubek-matmul/src/tune_key.rs
+++ b/crates/cubek-matmul/src/tune_key.rs
@@ -6,7 +6,7 @@ use cubecl::{
     tune::anchor,
     zspace::{Shape, Strides},
 };
-use cubek_std::MatmulProblemSize;
+use cubek_std::{MatmulProblemSize, MatrixLayout, launch::tma::stride_align_bits};
 use serde::{Deserialize, Serialize};
 
 use cubecl::std::tensor::{MatrixBatchLayout, matrix_batch_layout};
@@ -201,24 +201,16 @@ impl MatmulAutotuneKey {
 
 /// Minimum non-contiguous stride alignment in powers of two of bytes.
 fn stride_factor(strides: &Strides, layout: &MatrixBatchLayout, elem: ElemType) -> u8 {
-    let exclude_dim = match layout {
-        MatrixBatchLayout::Contiguous => strides.len() - 1,
+    let matrix_layout = match layout {
+        MatrixBatchLayout::Contiguous => MatrixLayout::RowMajor,
         MatrixBatchLayout::MildlyPermuted {
             transposed: true,
             batch_swap: false,
-        } => strides.len() - 2,
+        } => MatrixLayout::ColMajor,
         _ => return 0,
     };
 
-    strides
-        .iter()
-        .enumerate()
-        .filter(|(i, _)| *i != exclude_dim)
-        .map(|(_, stride)| (stride * elem.size_bits()) / 8)
-        .map(|bytes| bytes.trailing_zeros())
-        .min()
-        .unwrap_or(MAX_STRIDE_FACTOR)
-        .min(MAX_STRIDE_FACTOR) as u8
+    stride_align_bits(strides, &matrix_layout, &elem).min(MAX_STRIDE_FACTOR) as u8
 }
 
 /// Defines the potential vectorization.
@@ -230,7 +222,6 @@ fn pow2_factor(axis: usize) -> u8 {
 mod tests {
     use super::*;
     use cubecl::ir::{ElemType, FloatKind};
-    use cubek_std::{MatrixLayout, launch::tma::stride_align_bits};
 
     const F32: ElemType = ElemType::Float(FloatKind::F32);
 


### PR DESCRIPTION
## What happened

Burn autotuned an F32 matmul using an aligned tensor, then later ran the same logical matmul with a pitched tensor produced during training.

Both inputs had shape `[65_536, 128]`, but their metadata strides differed:

| LHS strides | Row pitch | Valid for 16-byte async copies |
| --- | ---: | --- |
| `[128, 1]` | 512 bytes | yes |
| `[130, 1]` | 520 bytes | no |

Shape and storage layout are independent. A logical `[65_536, 128]` tensor can be a view into wider storage where each physical row contains 130 elements. Preserving that view avoids an otherwise unnecessary contiguous copy. Burn produced such a legal pitched layout during training; CubeK's general matmul paths can handle it, even though some specialized candidates cannot.

Autotuning the first input selected `matmul_specialized_cyclic_mma`. The second input received the same `MatmulAutotuneKey`, so CubeCL reused that cached operation instead of tuning for the new layout. The selected operation then rejected the pitched input:

```text
Should run when selected by autotune.: matmul_specialized_cyclic_mma
Async copy requires strides to be aligned to 16 bytes
```

The pitched tensor is a valid matmul input. It is only incompatible with the cached specialized kernel.

## Why the keys collided

The key already contains `lhs_stride_factor` and `rhs_stride_factor`, but those fields were calculated from anchored matrix dimensions. That describes the alignment a tightly packed tensor would have, not necessarily the alignment of its actual metadata strides.

`MatrixBatchLayout::Contiguous` also covers tensors whose dimensions remain monotonically ordered but whose rows are pitched. As a result, `[128, 1]` and `[130, 1]` were both keyed as though their row pitch came from the anchored `k = 128` dimension.

This violates the autotune cache contract: inputs sharing a key must be valid for the operation selected under that key.

## Fix

Derive the stride factors from the operand's actual metadata strides. The implementation reuses `stride_align_bits`, the same helper used when async-copy and TMA kernels validate their inputs.

The existing shape bucketing remains unchanged:

- `m`, `n`, and `k` stay anchored
- vectorization factors still come from the anchored dimensions
- tensors only receive different keys when their actual stride-alignment class differs
- unsupported or highly permuted layouts retain stride factor `0`

The aligned and pitched tensors now receive different keys, so the pitched input is tuned independently and incompatible candidates can be rejected normally.

## Verification

- `cargo fmt -p cubek-matmul --check`
- `cargo test -p cubek-matmul --lib` (17 passed)
- `git diff --check`
- Burn/CUDA reproducer on an RTX 3070: in one process, tune `[65_536, 128] @ [128, 2]` with LHS strides `[128, 1]`, then execute the same logical shape with explicit `[130, 1]` metadata; both outputs were finite and the test passed
