### PR TITLE
feat(tile): variable-length sequences

### DIFF
--- a/crates/cubek-tile/src/physical/arg.rs
+++ b/crates/cubek-tile/src/physical/arg.rs
@@ -321,7 +321,7 @@ impl<'a, E: Numeric, V: Size> QuantTileArg<'a, E, V> {
     }
 }
 
-/// One indirect operand as a single launch argument: the values tensor, the `u32` index tensor
+/// One indirect operand as a single launch argument: the values tensor, the `u32` routing table
 /// that routes it, and the comptime half of the indirection. [`TileArg`]'s twin, for the same
 /// reason [`QuantTileArg`] is one: an operand and the table that places it are one thing, so
 /// neither can be launched against the other's spec.

--- a/crates/cubek-tile/src/physical/source.rs
+++ b/crates/cubek-tile/src/physical/source.rs
@@ -11,15 +11,17 @@ use cubecl::std::tensor::layout::linear::linear_view;
 
 use crate::{
     Axis, Boundary, ConcreteLayout, DequantAt, Geometry, IndexPolicy, IndexedTileArgLaunch,
-    IndirectionSpec, Instruction, LoadMethod, PhysicalAxis, Projection, QuantTileArgLaunch,
-    Residence, Space, StageStorage, StorageTiling, TileArgLaunch, TileSpec, validate_scheme,
+    IndirectionMode, IndirectionSpec, Instruction, LoadMethod, PhysicalAxis, Projection,
+    QuantTileArgLaunch, Residence, Space, StageStorage, StorageTiling, TileArgLaunch, TileSpec,
+    validate_scheme,
 };
 
 /// Typestate marker: a required [`StridedTileSource`] field has been set.
 pub struct Set;
 /// Typestate marker: a required [`StridedTileSource`] field is still missing.
 pub struct Unset;
-/// Typestate marker: [`indexed`](StridedTileSource::indexed) was called, so
+/// Typestate marker: a routing method such as [`indexed`](StridedTileSource::indexed) or
+/// [`variable_length`](StridedTileSource::variable_length) was called, so
 /// [`build`](StridedTileSource::build) yields an [`IndexedOperand`].
 pub struct Indexed;
 
@@ -56,12 +58,11 @@ struct TileSourceData<'a, R: Runtime> {
     units: usize,
     /// Present when the operand is quantized; [`realize`](StridedTileSource::realize) validates it.
     quant: Option<Quantization<R>>,
-    /// Present when the operand is routed through an index tensor
-    /// ([`indexed`](StridedTileSource::indexed)).
+    /// Present when the operand is routed through a table.
     indirection: Option<IndexTable<R>>,
 }
 
-/// How an operand is routed: the index tensor beside its values and the comptime
+/// How an operand is routed: the table beside its values and the comptime
 /// [`IndirectionSpec`] saying what a table entry means. The launch-side twin of the kernel's
 /// [`Indirection`](crate::Indirection), and one thing for the same reason [`Quantization`] is: a
 /// table without a spec cannot be read, and a spec without a table has nothing to read.
@@ -75,9 +76,8 @@ pub struct IndexTable<R: Runtime> {
 /// markers make [`build`](Self::build) exist only once both required setters are [`Set`];
 /// `Sub` is satisfied by [`subspace`](Self::subspace), which labels the buffer's dims, or by
 /// [`gathered`](Self::gathered), which states the affine mapping outright;
-/// the `Q` marker records whether [`quantized`](Self::quantized) was called, so `build`
-/// returns a [`StridedOperand`] (plain) or a [`QuantOperand`] (quantized) and no call
-/// site ever probes an option.
+/// the `Q` marker records whether [`quantized`](Self::quantized) or a routing method was called,
+/// so `build` returns the corresponding operand type and no call site ever probes an option.
 pub struct StridedTileSource<'a, Sp, Sub, Q, R: Runtime> {
     data: TileSourceData<'a, R>,
     _state: PhantomData<(Sp, Sub, Q)>,
@@ -358,8 +358,30 @@ impl<'a, Sp, Sub, R: Runtime> StridedTileSource<'a, Sp, Sub, Unset, R> {
         self.routed(table, spec)
     }
 
-    /// The half [`indexed`](Self::indexed) and [`paged`](Self::paged) share: only the spec they
-    /// hand over differs, and every rule below reads that spec rather than which one built it.
+    /// Address a variable-length sequence stored on a packed target axis. `cumulative_lengths`
+    /// is a dense rank-1 `u32` tensor of length `sequence_count + 1`; adjacent entries are the
+    /// physical start and exclusive end for one coordinate of `sequence_axis`.
+    ///
+    /// Unlike paging, the range lookup does not consume the logical target coordinate and may
+    /// resolve around a target tile of any size. It fires once the tiling isolates one sequence,
+    /// translates that tile's target origin, and masks reads or writes at the sequence end.
+    ///
+    /// The exclusive end *is* the mask, so the target axis always carries [`Boundary::Zero`] and
+    /// there is no policy to choose. [`build`](Self::build) refuses a
+    /// [`with_boundary`](Self::with_boundary) or [`checked`](Self::checked) that states anything
+    /// else rather than overriding it silently.
+    pub fn variable_length(
+        self,
+        cumulative_lengths: TensorBinding<R>,
+        sequence_axis: Axis,
+        target_axis: Axis,
+    ) -> StridedTileSource<'a, Sp, Sub, Indexed, R> {
+        let spec = IndirectionSpec::variable_length(sequence_axis, target_axis);
+        self.routed(cumulative_lengths, spec)
+    }
+
+    /// The half every routing constructor shares: only the spec they hand over differs, and every
+    /// rule below reads that spec rather than which method built it.
     fn routed(
         mut self,
         table: TensorBinding<R>,
@@ -527,7 +549,7 @@ impl<R: Runtime> QuantOperand<R> {
     }
 }
 
-/// A built indirect operand: the values tensor and its spec, plus the index tensor and the
+/// A built indirect operand: the values tensor and its spec, plus the routing table and the
 /// comptime [`IndirectionSpec`] that routes it. [`StridedOperand`]'s twin.
 pub struct IndexedOperand<R: Runtime> {
     pub tensor: TensorArg<R>,
@@ -613,6 +635,24 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
             None => labeled(&mut geometry, subspace, batch_axes, tiling),
         };
 
+        // A sequence range masks at its exclusive end, so `Boundary::Zero` on the target is the
+        // only mode that spells it. Refused rather than silently overridden: a caller who stated
+        // a mode is owed the news that this operand cannot honour it.
+        if let Some(spec) = indirection.as_ref().map(|table| &table.spec)
+            && spec.is_sequence_range()
+            && let Some(stated) = boundary
+            && stated != Some(Boundary::Zero)
+        {
+            let stated = match stated {
+                Some(mode) => format!("{mode:?}"),
+                None => "unchecked".to_string(),
+            };
+            panic!(
+                "StridedTileSource::variable_length: a sequence range masks at its exclusive end \
+                 and owes its target Boundary::Zero, but this operand states {stated}"
+            );
+        }
+
         // Derive boundary check: use explicit override if set, otherwise check for overhang or underflow.
         let boundary = boundary.unwrap_or_else(|| match concrete {
             Some(concrete) => {
@@ -693,9 +733,12 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
             .map(|pa| {
                 let axis = coords.physical_axis(pa).identity_axis();
                 match indirection_spec.filter(|spec| axis == Some(spec.target)) {
-                    Some(spec) => match spec.policy {
-                        IndexPolicy::Trusted => None,
-                        IndexPolicy::Checked => Some(boundary.unwrap_or(Boundary::Zero)),
+                    Some(spec) => match spec.mode {
+                        IndirectionMode::SequenceRange => Some(Boundary::Zero),
+                        IndirectionMode::Replace { policy, .. } => match policy {
+                            IndexPolicy::Trusted => None,
+                            IndexPolicy::Checked => Some(boundary.unwrap_or(Boundary::Zero)),
+                        },
                     },
                     None => boundary.filter(|_| !settled(pa)),
                 }
@@ -736,7 +779,7 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
         if let Some(indirection) = &indirection
             && let Some(concrete) = concrete.or_else(|| space.is_static().then_some(space))
         {
-            validate_index_table(indirection, concrete);
+            validate_indirection_table(indirection, concrete);
         }
         Realized {
             tensor: binding.map(|mut binding| {
@@ -755,43 +798,52 @@ impl<'a, Q, R: Runtime> StridedTileSource<'a, Set, Set, Q, R> {
     }
 }
 
-/// Validate the host-visible part of an indirection's addressing contract before the index
-/// tensor reaches device code. Its leading dimensions enumerate fire-level tiles of the index
-/// axes. When the target has multiple entries, a final dimension enumerates them; singleton
-/// targets omit that dimension entirely. The whole table is dense row-major so its shape also
-/// proves that the largest computed offset is backed by storage.
-fn validate_index_table<R: Runtime>(table: &IndexTable<R>, space: &Space) {
+/// Validate the host-visible table shape before it reaches device code. Replacement tables use
+/// leading fire-level index dimensions and an optional trailing target-entry dimension. Sequence
+/// ranges use one cumulative-length vector with a final exclusive-end entry. Both forms are dense
+/// row-major so their shape also proves that the largest computed table offset is backed.
+fn validate_indirection_table<R: Runtime>(table: &IndexTable<R>, space: &Space) {
     let spec = &table.spec;
     if !spec
         .index_axes
         .iter()
         .all(|&a| space.contains(a) && !space.is_dynamic(a))
-        || !space.contains(spec.target)
-        || space.is_dynamic(spec.target)
+        || (!spec.is_sequence_range()
+            && (!space.contains(spec.target) || space.is_dynamic(spec.target)))
     {
         return;
     }
-    let mut fire = space.partitioner();
-    while fire.edge(spec.target) > spec.granularity {
-        fire = fire.next();
-    }
+    let expected_shape = match spec.mode {
+        IndirectionMode::SequenceRange => vec![space.extent(spec.index_axes[0]) + 1],
+        IndirectionMode::Replace { granularity, .. } => {
+            let fire = spec.fire_partitioner(space);
+            let mut shape = spec
+                .index_axes
+                .iter()
+                .map(|&axis| space.extent(axis).div_ceil(fire.edge(axis)))
+                .collect::<Vec<_>>();
+            let target_entries = space.extent(spec.target).div_ceil(granularity);
+            if target_entries > 1 {
+                shape.push(target_entries);
+            }
+            shape
+        }
+    };
 
-    let mut expected_shape = spec
-        .index_axes
-        .iter()
-        .map(|&axis| space.extent(axis).div_ceil(fire.edge(axis)))
-        .collect::<Vec<_>>();
-    let target_entries = space.extent(spec.target).div_ceil(spec.granularity);
-    if target_entries > 1 {
-        expected_shape.push(target_entries);
-    }
-
+    let shape_contract = match spec.mode {
+        IndirectionMode::Replace { .. } => {
+            "index table shape must have one leading dimension per index axis (one entry per \
+             fire-level tile), plus a trailing target-entry dimension when the target has more \
+             than one entry"
+        }
+        IndirectionMode::SequenceRange => {
+            "cumulative sequence lengths have shape [sequence_count + 1]"
+        }
+    };
     assert_eq!(
         table.table.shape(),
         expected_shape,
-        "StridedTileSource::indexed: index table shape must have one leading dimension per \
-         index axis (one entry per fire-level tile), plus a trailing target-entry dimension \
-         when the target has more than one entry"
+        "StridedTileSource: {shape_contract}"
     );
     let mut expected_strides = vec![0; expected_shape.len()];
     let mut stride = 1;
@@ -799,11 +851,20 @@ fn validate_index_table<R: Runtime>(table: &IndexTable<R>, space: &Space) {
         expected_strides[axis] = stride;
         stride *= expected_shape[axis];
     }
+    let stride_contract = match spec.mode {
+        IndirectionMode::Replace { .. } => {
+            "index table must be dense row-major; its target entries are addressed at unit stride \
+             and its shape must bound every computed table offset"
+        }
+        IndirectionMode::SequenceRange => {
+            "cumulative sequence lengths must be dense row-major so adjacent entries delimit one \
+             sequence"
+        }
+    };
     assert_eq!(
         table.table.strides(),
         expected_strides,
-        "StridedTileSource::indexed: the index table must be dense row-major; its target entries \
-         are addressed at unit stride and its shape must bound every computed table offset"
+        "StridedTileSource: {stride_contract}"
     );
 }
 
@@ -971,7 +1032,7 @@ impl<'a, R: Runtime> StridedTileSource<'a, Set, Set, Set, R> {
 }
 
 impl<'a, R: Runtime> StridedTileSource<'a, Set, Set, Indexed, R> {
-    /// Build the indirect operand: the plain derivation plus the index tensor that routes it.
+    /// Build the indirect operand: the plain derivation plus the table that routes it.
     pub fn build(self) -> IndexedOperand<R> {
         let Realized {
             tensor,
@@ -982,7 +1043,7 @@ impl<'a, R: Runtime> StridedTileSource<'a, Set, Set, Indexed, R> {
         } = self.realize();
         IndexedOperand {
             tensor: tensor.expect(
-                "StridedTileSource::build: an indexed operand is always bound; only a fused \
+                "StridedTileSource::build: an indirect operand is always bound; only a fused \
                  store is built over geometry alone",
             ),
             vector_size,

--- a/crates/cubek-tile/src/staging/fill.rs
+++ b/crates/cubek-tile/src/staging/fill.rs
@@ -19,7 +19,7 @@ pub(crate) struct SlotOperand<'a> {
     residence: Residence,
     source: StageSource,
     space: &'a Space,
-    /// The axes addressing this operand's index tensor, empty for a plain one. Carried because a
+    /// The axes addressing this operand's routing table, empty for a plain one. Carried because a
     /// walk over one of them moves an indirect operand's window even though its own space says
     /// nothing about that axis (see [`Space::walk_invariant`]).
     index_axes: SmallVec<[Axis; MAX_AXES]>,
@@ -637,8 +637,10 @@ mod tests {
         let spec = IndirectionSpec {
             index_axes: index_axes.clone(),
             target: EXPERT,
-            granularity: 1,
-            policy: IndexPolicy::Trusted,
+            mode: IndirectionMode::Replace {
+                granularity: 1,
+                policy: IndexPolicy::Trusted,
+            },
         };
         SlotPlan::new(
             &[SlotOperand::new(
@@ -646,6 +648,33 @@ mod tests {
                 StageSource::Transport(Delivery::Copy),
                 &weights,
                 index_axes,
+                Some(spec),
+            )],
+            &space,
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "an indirect operand cannot be staged above the level where its lookup resolves"
+    )]
+    fn a_variable_length_operand_cannot_be_staged_before_one_sequence_is_isolated() {
+        let space = Tiling::new()
+            .extents(&[(M, 4), (N, 4), (K, 4)])
+            .level(WalkOrder::RowMajor, Buffering::SINGLE, |l| {
+                l.axis(M, Cut::sequential(2))
+                    .axis(N, Cut::sequential(4))
+                    .axis(K, Cut::sequential(2))
+            })
+            .build();
+        let values = space.project(&[K, N]);
+        let spec = IndirectionSpec::variable_length(M, K);
+        SlotPlan::new(
+            &[SlotOperand::new(
+                Residence::Smem,
+                StageSource::Transport(Delivery::Copy),
+                &values,
+                spec.index_axes.clone(),
                 Some(spec),
             )],
             &space,

--- a/crates/cubek-tile/src/tile/mem.rs
+++ b/crates/cubek-tile/src/tile/mem.rs
@@ -382,55 +382,63 @@ impl<T: Numeric> Tile<T> {
         )
     }
 
-    /// [`of`](Tile::of) with one axis's window origin resolved through an index tensor: `ids`
-    /// holds one `u32` entry per fire-level tile of `indirection.index_axes`, and the descent
-    /// places the operand's `indirection.target` window at the entry it reads ([`Indirection`]).
-    /// MoE expert routing is exactly this: `values` is `[num_experts, K, N]` with `EXPERT` held at
-    /// [`Static(1)`](crate::Extent::Static) in the kernel space, `ids` is `[m_tiles]`, and the
-    /// weights operand does not span `M` at all.
+    /// [`of`](Tile::of) with one axis's window resolved through a routing table. Replacement
+    /// routing places the origin at an indexed slice or page; a variable-length sequence reads
+    /// adjacent cumulative lengths and translates and bounds the target window as one operation.
     ///
     /// The operand stays direct and untiled, so every dense, cmma and straight-fill path still
     /// describes it. Caller contracts:
     ///
     /// - The tile does not [`witness`](Tile::witnesses) the target axis. Its bound is the index
     ///   tensor's range, not the operation's extent, so the kernel space states that axis itself.
-    /// - Under [`IndexPolicy::Trusted`] nothing checks an entry. Under
-    ///   [`IndexPolicy::Checked`] the spec must carry a [`Boundary`] on the target axis, which is
-    ///   what masks an entry past its bound. [`StridedTileSource::indexed`](crate::StridedTileSource::indexed)
-    ///   derives it from the policy; hand-built specs state it themselves.
+    /// - A checked replacement must carry a target [`Boundary`]. A variable-length sequence must
+    ///   carry [`Boundary::Zero`], which masks at its exclusive end. The launch-side builder
+    ///   derives both; hand-built specs state them themselves.
     /// - The lookup resolves during [`Tile::at`], not at construction. An indexed tile that is
     ///   read without descending through a region still addresses its entry-0 window.
     pub fn of_indexed<E: CubePrimitive<Scalar = T>>(
         values: &Tensor<E>,
-        ids: &Tensor<u32>,
+        table: &Tensor<u32>,
         #[comptime] indirection: IndirectionSpec,
         #[comptime] space: Space,
         #[comptime] spec: TileSpec,
     ) -> Tile<T> {
         let projected = comptime!(space.project(spec.axes()));
-        // The engine's own backstop, like `validate_dequant_at`: `StridedTileSource::indexed`
-        // runs this on the caller's thread, but a hand-built `IndexedTileArgLaunch` reaches here
-        // without passing through it.
+        // The engine's own backstop, like `validate_dequant_at`: every routing constructor on
+        // `StridedTileSource` runs this on the caller's thread, but a hand-built
+        // `IndexedTileArgLaunch` reaches here without passing through one.
         comptime!(indirection.validate(&space, &projected, &spec.projection));
-        comptime!(assert!(
-            indirection.policy == IndexPolicy::Trusted
-                || spec
-                    .boundaries
-                    .get(projected.position(indirection.target))
-                    .copied()
-                    .flatten()
-                    .is_some(),
-            "Tile::of_indexed: IndexPolicy::Checked masks an out-of-range entry against the \
-             target axis's bound, but the operand states no boundary on {:?}",
-            indirection.target
-        ));
+        let target_boundary = comptime!(
+            spec.boundaries
+                .get(projected.position(indirection.target))
+                .copied()
+                .flatten()
+        );
+        // One refusal per rule: the two modes fail for different reasons and a caller is owed the
+        // one that applies to it.
+        if comptime!(indirection.is_sequence_range()) {
+            comptime!(assert!(
+                target_boundary == Some(Boundary::Zero),
+                "Tile::of_indexed: a variable-length sequence masks at its exclusive end, so \
+                 {:?} owes Boundary::Zero, not {target_boundary:?}",
+                indirection.target
+            ));
+        } else {
+            comptime!(assert!(
+                indirection.replacement_policy() == Some(IndexPolicy::Trusted)
+                    || target_boundary.is_some(),
+                "Tile::of_indexed: IndexPolicy::Checked masks an out-of-range entry against the \
+                 target axis's bound, but the operand states no boundary on {:?}",
+                indirection.target
+            ));
+        }
         let mut table_strides = Coords::<u32>::new();
         #[unroll]
         for a in 0..comptime!(indirection.index_axes.len()) {
-            table_strides.push(ids.stride(a) as u32);
+            table_strides.push(table.stride(a) as u32);
         }
         let carrier = Indirection {
-            table: unsafe { ids.as_slice().as_boxed_unchecked() },
+            table: unsafe { table.as_slice().as_boxed_unchecked() },
             table_base: 0u32,
             table_strides,
             spec: comptime!(indirection),
@@ -1540,7 +1548,7 @@ impl<T: Numeric> MemData<T> {
     /// Unchecked only, and unreachable any other way: a checked operand cannot vectorize
     /// ([`realize`](crate::StridedTileSource) refuses it), and a word-serving operand is
     /// `num_quants` wide, so a checked source never gets here; the assert below is a backstop for
-    /// hand-built args. The ragged-tail obligation this leaves is the engine's ordinary unchecked
+    /// hand-built args. The variable-tail obligation this leaves is the engine's ordinary unchecked
     /// contract, stated at the operand: a cut that overhangs the buffer *panics at launch* unless
     /// the caller declared `checked(false)`, and that declaration is the caller's claim that every
     /// staged block lies inside the allocation (e.g. an S block pinned to a divisor of the cache's
@@ -1628,7 +1636,7 @@ impl<T: Numeric> MemData<T> {
         dequant_at
     }
 
-    /// Which axes' region coordinates address this operand's index tensor, empty for an operand
+    /// Which axes' region coordinates address this operand's routing table, empty for an operand
     /// with no indirection. Read by the staging plan: an operand routed by an axis it does not
     /// span is *not* invariant across a walk that steps that axis, however its own space reads.
     pub(crate) fn index_axes(&self) -> comptime_type!(SmallVec<[Axis; MAX_AXES]>) {
@@ -2235,32 +2243,42 @@ impl<T: Numeric> MemData<T> {
         let last = comptime!(rank - 1);
         let w = comptime!(self.store.vector_size);
 
-        // A pending indirection resolves once at the fire level (where target edge <= granularity).
-        // At resolution, the displacement applies on both address routes and the child drops the
-        // carrier; above it, only the table base advances.
-        let (displacement, indirection, displaced_at) = #[comptime]
-        match &self.indirection {
-            ComptimeOption::Some(ind) => {
-                if comptime!(ind.spec.fires_at(&space)) {
-                    (
-                        ind.displacement(region, &self.window.origin, comptime!(space.clone())),
-                        ComptimeOption::new_None(),
-                        comptime!(Some(space.position(ind.spec.target))),
-                    )
-                } else {
-                    (
-                        0i32.runtime(),
-                        ComptimeOption::new_Some(ind.advance(region, comptime!(space.clone()))),
-                        comptime!(None::<usize>),
-                    )
+        // A pending indirection resolves once at its mode's fire level. At resolution, the
+        // displacement applies on both address routes, a sequence range also narrows the target
+        // bound, and the child drops the carrier; above it, only the table base advances.
+        let (displacement, sequence_end, indirection, displaced_at, bounded_at) =
+            #[comptime]
+            match &self.indirection {
+                ComptimeOption::Some(ind) => {
+                    if comptime!(ind.spec.fires_at(&space)) {
+                        let (displacement, sequence_end) =
+                            ind.resolve(region, &self.window.origin, comptime!(space.clone()));
+                        let target = comptime!(space.position(ind.spec.target));
+                        (
+                            displacement,
+                            sequence_end,
+                            ComptimeOption::new_None(),
+                            comptime!(Some(target)),
+                            comptime!(ind.spec.is_sequence_range().then_some(target)),
+                        )
+                    } else {
+                        (
+                            0i32.runtime(),
+                            0u32.runtime(),
+                            ComptimeOption::new_Some(ind.advance(region, comptime!(space.clone()))),
+                            comptime!(None::<usize>),
+                            comptime!(None::<usize>),
+                        )
+                    }
                 }
-            }
-            ComptimeOption::None => (
-                0i32.runtime(),
-                ComptimeOption::new_None(),
-                comptime!(None::<usize>),
-            ),
-        };
+                ComptimeOption::None => (
+                    0i32.runtime(),
+                    0u32.runtime(),
+                    ComptimeOption::new_None(),
+                    comptime!(None::<usize>),
+                    comptime!(None::<usize>),
+                ),
+            };
 
         let map = if comptime!(proj.is_direct()) {
             // One logical axis per physical axis at coefficient 1. Kept as its own loop because
@@ -2364,6 +2382,23 @@ impl<T: Numeric> MemData<T> {
             .window_start
             .fadd(advances.fsum(comptime!((0..rank).collect::<Vec<_>>())));
 
+        // A sequence range narrows exactly one physical bound when it resolves; every other axis
+        // keeps the bound it inherited. Re-pushing those is free: `Coords` holds expression
+        // handles, so the rebuilt list carries the same ones a clone would have, and only the
+        // narrowed axis costs an instruction.
+        let mut bound = Coords::<u32>::new();
+        #[unroll]
+        for p in 0..rank {
+            let inherited = self.window.bound.at(p);
+            if comptime!(bounded_at == Some(p)) {
+                // Never past the buffer itself: the sequence end is data, and a bad one may name
+                // a position the values tensor does not back.
+                bound.push(min(sequence_end, inherited));
+            } else {
+                bound.push(inherited);
+            }
+        }
+
         // Re-window the scales alongside the values.
         let mut origin_u32 = Coords::<u32>::new();
         #[unroll]
@@ -2406,7 +2441,7 @@ impl<T: Numeric> MemData<T> {
             window: Window::new(
                 origin,
                 extent,
-                self.window.bound.clone(),
+                bound,
                 comptime!(self.window.signed),
                 comptime!(self.window.boundaries.clone()),
             ),

--- a/crates/cubek-tile/src/tile/mod.rs
+++ b/crates/cubek-tile/src/tile/mod.rs
@@ -416,29 +416,56 @@ pub enum IndexPolicy {
     Checked,
 }
 
+/// How an [`Indirection`] interprets its table entries.
+///
+/// Replacement routing selects independently placed slices or pages. A sequence range instead
+/// translates one logical token axis into the packed interval delimited by two adjacent cumulative
+/// lengths. Keeping the policy inside `Replace` makes a sequence range intrinsically checked: its
+/// end entry is the logical boundary, not an optional safety policy.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum IndirectionMode {
+    /// `table[..., t / granularity]` names the physical entry holding logical target coordinate
+    /// `t`, and the lookup replaces the window's origin with it.
+    Replace {
+        /// Elements of `target` per table entry: a page size for a paged cache, `1` for a slice
+        /// index. Comptime so the divide folds and the divisibility rules are checkable on the
+        /// host.
+        granularity: usize,
+        /// What an entry past the target axis's bound means. Only replacement routing has the
+        /// choice; see [`IndexPolicy`].
+        policy: IndexPolicy,
+    },
+    /// Adjacent entries `table[b]` and `table[b + 1]` are the physical start and exclusive end of
+    /// the sequence at coordinate `b` of the single index axis. The lookup translates the target
+    /// window to that start and narrows its bound to that end.
+    SequenceRange,
+}
+
 /// The comptime half of an [`Indirection`]: everything that decides *where* to look, with no
-/// buffer. Part of a kernel's identity, so two granularities never share a compiled kernel.
+/// buffer. Part of a kernel's identity, so different routing semantics never share a compiled
+/// kernel.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct IndirectionSpec {
     /// The operand axis whose window origin the lookup displaces.
     pub target: Axis,
-    /// Elements of `target` per table entry: a page size for a paged cache, `1` for a slice index.
-    /// Comptime so the divide folds and the divisibility rules are checkable on the host.
-    pub granularity: usize,
-    /// Which axes' region coordinates address the table, outer to inner.
+    /// Which axes' region coordinates address the table, outer to inner. A sequence range takes
+    /// exactly one, the axis its cumulative lengths are indexed by.
     pub index_axes: SmallVec<[Axis; MAX_AXES]>,
-    pub policy: IndexPolicy,
+    /// What a table entry means, and so what the lookup does when it fires.
+    pub mode: IndirectionMode,
 }
 
 impl IndirectionSpec {
     /// A per-tile slice index: one entry per `index_axis` tile, displacing `target`'s origin to
-    /// the entry outright (`granularity = 1`). MoE expert routing and `cu_seqlens` are both this.
+    /// the entry outright (`granularity = 1`). MoE expert routing is exactly this.
     pub fn indexed(index_axis: Axis, target: Axis, policy: IndexPolicy) -> Self {
         IndirectionSpec {
             target,
-            granularity: 1,
             index_axes: SmallVec::from_slice(&[index_axis]),
-            policy,
+            mode: IndirectionMode::Replace {
+                granularity: 1,
+                policy,
+            },
         }
     }
 
@@ -458,10 +485,38 @@ impl IndirectionSpec {
         );
         IndirectionSpec {
             target,
-            granularity: page_size,
             index_axes: SmallVec::from_slice(&[index_axis]),
-            policy,
+            mode: IndirectionMode::Replace {
+                granularity: page_size,
+                policy,
+            },
         }
+    }
+
+    /// A variable-length packed sequence. Adjacent entries in `cumulative_lengths` delimit the
+    /// physical target-axis range for one coordinate of `sequence_axis`: entry `b` is its start
+    /// and entry `b + 1` its exclusive end. The range translates the target origin and always
+    /// masks at its end.
+    pub fn variable_length(sequence_axis: Axis, target: Axis) -> Self {
+        IndirectionSpec {
+            target,
+            index_axes: SmallVec::from_slice(&[sequence_axis]),
+            mode: IndirectionMode::SequenceRange,
+        }
+    }
+
+    /// The policy attached to replacement routing. A sequence range has no policy: its exclusive
+    /// end is necessarily a checked boundary.
+    pub(crate) fn replacement_policy(&self) -> Option<IndexPolicy> {
+        match self.mode {
+            IndirectionMode::Replace { policy, .. } => Some(policy),
+            IndirectionMode::SequenceRange => None,
+        }
+    }
+
+    /// Whether this lookup translates a sequence range rather than replacing a slice or page.
+    pub(crate) fn is_sequence_range(&self) -> bool {
+        matches!(self.mode, IndirectionMode::SequenceRange)
     }
 
     /// Refuse a plan whose lookup could not fire correctly. `kernel` is the whole launched space,
@@ -473,12 +528,11 @@ impl IndirectionSpec {
     /// worker thread, where it reads as zeroed output rather than as a rejection, so this is the
     /// one gate. The rules: the operand carries the target axis and does not carry it innermost
     /// (that window is addressed in lines, not elements); the mapping is direct and untiled, so
-    /// one dim carries the target alone; some level's cut of `target` fits inside one table entry
-    /// (else the lookup never fires); that level's cut divides the entry (else a child window
-    /// starts mid-entry); every level above steps whole entries (else a window below the fire
-    /// level straddles two); and every index axis is distributed across cubes or planes rather
-    /// than lanes (a per-lane origin would hand `dense_lines` and `window_offset` a divergent
-    /// base pointer).
+    /// one dim carries the target alone; replacement routing reaches a target cut wholly inside
+    /// one table entry, with whole entries above and dividing cuts below; sequence-range routing
+    /// reaches a level that isolates one sequence; and every index axis is distributed across
+    /// cubes or planes rather than lanes (a per-lane origin would hand `dense_lines` and
+    /// `window_offset` a divergent base pointer).
     ///
     /// One rule has no host-side site and is asserted in [`Indirection::advanced_base`]: that the
     /// *operation*'s region actually spans each index axis. Which operands meet at a level is not
@@ -511,6 +565,13 @@ impl IndirectionSpec {
             !self.index_axes.is_empty(),
             "Indirection: an indirection with no index axis reads one entry for every tile"
         );
+        if self.is_sequence_range() {
+            assert_eq!(
+                self.index_axes.len(),
+                1,
+                "Indirection: a variable-length sequence has exactly one sequence axis"
+            );
+        }
         assert!(
             !self.index_axes.contains(&self.target),
             "Indirection: {:?} both addresses the table and is displaced by it",
@@ -530,27 +591,32 @@ impl IndirectionSpec {
             // This level still reads the table when the lookup fires here. Its child does not,
             // so distribution below it cannot make the resolved pointer lane-divergent.
             let lookup_pending = !fires;
-            let edge = partitioner.edge(self.target);
             if !fires {
-                if edge <= self.granularity {
-                    assert!(
-                        self.granularity.is_multiple_of(edge),
-                        "Indirection: a level cuts {:?} into {edge}-element windows, which do \
-                         not divide the {}-element table entry, so a child window would start \
-                         mid-entry",
-                        self.target,
-                        self.granularity
-                    );
-                    fires = true;
-                } else {
-                    assert!(
-                        edge.is_multiple_of(self.granularity),
-                        "Indirection: a level above the lookup cuts {:?} into {edge}-element \
-                         windows, which are not whole {}-element table entries, so a window below \
-                         would straddle two",
-                        self.target,
-                        self.granularity
-                    );
+                // The one definition of the fire level, so what validation accepts and what the
+                // descent actually resolves cannot drift apart.
+                fires = self.fires_with(partitioner);
+                // Only replacement routing constrains how the target is cut: its entries are
+                // whole slices of that axis. A sequence range translates a target tile of any
+                // size once one sequence is isolated, so it has nothing to say here.
+                if let IndirectionMode::Replace { granularity, .. } = self.mode {
+                    let edge = partitioner.edge(self.target);
+                    if fires {
+                        assert!(
+                            granularity.is_multiple_of(edge),
+                            "Indirection: a level cuts {:?} into {edge}-element windows, which do \
+                             not divide the {granularity}-element table entry, so a child window \
+                             would start mid-entry",
+                            self.target,
+                        );
+                    } else {
+                        assert!(
+                            edge.is_multiple_of(granularity),
+                            "Indirection: a level above the lookup cuts {:?} into {edge}-element \
+                             windows, which are not whole {granularity}-element table entries, so \
+                             a window below would straddle two",
+                            self.target,
+                        );
+                    }
                 }
             }
             if lookup_pending {
@@ -566,17 +632,25 @@ impl IndirectionSpec {
             }
             partitioner = partitioner.next();
         }
-        assert!(
-            fires,
-            "Indirection: no level cuts {:?} down to a {}-element table entry, so the \
-             lookup never resolves",
-            self.target, self.granularity
-        );
+        match self.mode {
+            IndirectionMode::Replace { granularity, .. } => assert!(
+                fires,
+                "Indirection: no level cuts {:?} down to a {granularity}-element table entry, so \
+                 the lookup never resolves",
+                self.target,
+            ),
+            IndirectionMode::SequenceRange => assert!(
+                fires,
+                "Indirection: no level isolates the variable-length sequence axis {:?} to one \
+                 sequence, so the lookup never resolves",
+                self.index_axes[0],
+            ),
+        }
     }
 }
 
 /// A data-dependent displacement of one axis's window origin, resolved exactly once during the
-/// descent. Rides beside [`QuantInfo`] on [`MemData`] and follows its shape: the index tensor is a
+/// descent. Rides beside [`QuantInfo`] on [`MemData`] and follows its shape: the routing table is a
 /// lifetime-erased `Box<[u32]>`, and everything deciding *where* to look is comptime
 /// ([`IndirectionSpec`]).
 ///
@@ -587,7 +661,7 @@ impl IndirectionSpec {
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct Indirection {
-    /// The index tensor, lifetime-erased like every other tile buffer.
+    /// The routing table, lifetime-erased like every other tile buffer.
     pub(crate) table: Box<[u32]>,
     /// The offset into `table` this descent has accumulated, advanced at each
     /// [`at`](MemData::at) by the index axes' region coordinates. Accumulated rather than read
@@ -601,12 +675,33 @@ pub struct Indirection {
 }
 
 impl IndirectionSpec {
-    /// Whether the level `space` describes is the one that resolves the lookup: its cut of the
-    /// target axis fits inside a single table entry, so the child window it is about to build
-    /// lies wholly in one slice. [`validate`](Self::validate) has already proven such a level
-    /// exists and that no window straddles an entry.
+    /// Whether the level `space` describes resolves the lookup. Replacement routing fires once
+    /// the target fits in one table entry; a sequence range fires once its sequence axis has been
+    /// isolated to one sequence.
     pub(crate) fn fires_at(&self, space: &Space) -> bool {
-        space.partitioner().edge(self.target) <= self.granularity
+        self.fires_with(space.partitioner())
+    }
+
+    /// The fire predicate itself, over one level. Every other fire-level question in the crate
+    /// routes through this, so there is one place the rule is stated per mode.
+    fn fires_with(&self, partitioner: &Partitioner) -> bool {
+        match self.mode {
+            IndirectionMode::Replace { granularity, .. } => {
+                partitioner.edge(self.target) <= granularity
+            }
+            IndirectionMode::SequenceRange => partitioner.edge(self.index_axes[0]) == 1,
+        }
+    }
+
+    /// The first partitioner whose child can carry a resolved window. Validation proves the walk
+    /// reaches one before this helper is used by launch-side table derivation or descent math;
+    /// without that proof the walk runs off the final level, which carries no edges to read.
+    pub(crate) fn fire_partitioner<'a>(&self, space: &'a Space) -> &'a Partitioner {
+        let mut partitioner = space.partitioner();
+        while !self.fires_with(partitioner) {
+            partitioner = partitioner.next();
+        }
+        partitioner
     }
 
     /// Number of table entries represented by one coordinate step at `space` for `axis`.
@@ -615,10 +710,7 @@ impl IndirectionSpec {
     /// scaled by the number of fire-level table entries per step below it.
     fn table_entries_per_step(&self, space: &Space, axis: Axis) -> usize {
         let current_edge = space.partitioner().edge(axis);
-        let mut partitioner = space.partitioner();
-        while partitioner.edge(self.target) > self.granularity {
-            partitioner = partitioner.next();
-        }
+        let partitioner = self.fire_partitioner(space);
         let fire_edge = partitioner.edge(axis);
         comptime!(assert!(
             current_edge.is_multiple_of(fire_edge),
@@ -674,37 +766,60 @@ impl Indirection {
         ))
     }
 
-    /// How far this level moves the target axis's window origin, in elements of that axis; `0`
-    /// above the level that resolves the lookup.
+    /// What this level's lookup resolves to, as `(displacement, sequence_end)`. `displacement` is
+    /// how far the target axis's window origin moves, in elements of that axis. `sequence_end` is
+    /// the exclusive physical end the child window is bounded at, and is meaningful only under
+    /// [`IndirectionMode::SequenceRange`]; replacement routing returns `0` for it and the caller
+    /// leaves the inherited bound alone. Both are `0` above the level that resolves the lookup.
     ///
-    /// The entry is addressed by the *absolute* logical coordinate `origin[target] + index·edge`,
-    /// never by the region coordinate alone: below the top level a region coordinate is a
-    /// within-parent tile index, and addressing a table with one reads garbage.
-    pub(crate) fn displacement(
+    /// A replacement entry is addressed by the *absolute* logical coordinate
+    /// `origin[target] + index·edge`, never by the region coordinate alone: below the top level a
+    /// region coordinate is a within-parent tile index, and addressing a table with one reads
+    /// garbage. A sequence range reads no target coordinate at all; its pair of entries is
+    /// addressed by the accumulated index-axis base alone.
+    pub(crate) fn resolve(
         &self,
         region: &Region,
         origin: &Coords<i32>,
         #[comptime] space: Space,
-    ) -> i32 {
+    ) -> (i32, u32) {
         if comptime!(self.spec.fires_at(&space)) {
-            let target = comptime!(self.spec.target);
-            let edge = comptime!(space.partitioner().edge(target) as i32);
-            let granularity = comptime!(self.spec.granularity as i32).runtime();
-            let t = origin.at(comptime!(space.position(target))).fadd(
-                region
-                    .coord(target)
-                    .fcast::<i32>()
-                    .fmul(comptime!(edge).runtime()),
-            );
-            let entry = t.fdiv(granularity);
-            let base = self.advanced_base(region, space);
-            let found = self.table[base.fadd(entry.fcast::<u32>()).fcast::<usize>()];
-            found
-                .fcast::<i32>()
-                .fmul(granularity)
-                .fsub(entry.fmul(granularity))
+            match comptime!(self.spec.mode) {
+                IndirectionMode::Replace { granularity, .. } => {
+                    let target = comptime!(self.spec.target);
+                    let edge = comptime!(space.partitioner().edge(target) as i32);
+                    let granularity = comptime!(granularity as i32).runtime();
+                    let t = origin.at(comptime!(space.position(target))).fadd(
+                        region
+                            .coord(target)
+                            .fcast::<i32>()
+                            .fmul(comptime!(edge).runtime()),
+                    );
+                    let entry = t.fdiv(granularity);
+                    let base = self.advanced_base(region, space);
+                    let found = self.table[base.fadd(entry.fcast::<u32>()).fcast::<usize>()];
+                    (
+                        found
+                            .fcast::<i32>()
+                            .fmul(granularity)
+                            .fsub(entry.fmul(granularity)),
+                        0u32.runtime(),
+                    )
+                }
+                IndirectionMode::SequenceRange => {
+                    let base = self.advanced_base(region, space);
+                    // The end is the next entry, one *stride* along, which is what
+                    // `advanced_base` already scaled this base by. A literal `1` would agree
+                    // only for the dense table the host validates, and the host defers that
+                    // check when the sequence axis is dynamic.
+                    let stride = self.table_strides.at(0);
+                    let start = self.table[base.fcast::<usize>()];
+                    let end = self.table[base.fadd(stride).fcast::<usize>()];
+                    (start.fcast::<i32>(), end)
+                }
+            }
         } else {
-            0i32.runtime()
+            (0i32.runtime(), 0u32.runtime())
         }
     }
 }
@@ -1129,7 +1244,7 @@ impl<T: Numeric> Tile<T> {
         )
     }
 
-    /// Which axes' region coordinates address this operand's index tensor; empty for an operand
+    /// Which axes' region coordinates address this operand's routing table; empty for an operand
     /// with no indirection. Comptime, and read by the staging plan
     /// ([`Space::walk_invariant`](crate::Space::walk_invariant)).
     pub(crate) fn index_axes(&self) -> comptime_type!(SmallVec<[Axis; MAX_AXES]>) {

--- a/crates/cubek-tile/tests/tile/mod.rs
+++ b/crates/cubek-tile/tests/tile/mod.rs
@@ -19,3 +19,4 @@ mod scaled;
 mod separable;
 mod softmax;
 mod space;
+mod variable_length;

--- a/crates/cubek-tile/tests/tile/variable_length.rs
+++ b/crates/cubek-tile/tests/tile/variable_length.rs
@@ -1,0 +1,406 @@
+//! Variable-length sequences stored contiguously on one packed token axis.
+//!
+//! Each sequence is presented to the kernel as a rectangular `max_tokens` window. Adjacent
+//! cumulative lengths translate that logical window to its packed physical start and bound it at
+//! its exclusive end, so a short sequence cannot read into the next one.
+
+use cubecl::std::tensor::layout::CoordsDyn;
+use cubecl::{Runtime, TestRuntime, prelude::*, zspace::shape};
+use cubek_test_utils::{HostData, HostDataType, TestInput};
+use cubek_tile::*;
+
+const BATCH: Axis = Axis(0);
+const TOKEN: Axis = Axis(1);
+const DIM: Axis = Axis(2);
+
+#[cube(launch)]
+fn unpack_sequences<E: Numeric>(
+    packed: &IndexedTileArg<'_, E, Const<1>>,
+    padded: &TileArg<'_, E, Const<1>>,
+    #[comptime] space: Space,
+) {
+    let packed = packed.tile(comptime!(space.clone()));
+    let padded = padded.tile(comptime!(space.clone()));
+    for outer_region in Walk::over(padded.runtime_space()) {
+        let outer_packed = packed.at(&outer_region);
+        let outer_padded = padded.at(&outer_region);
+        for inner_region in Walk::over(outer_padded.runtime_space()) {
+            let inner_packed = outer_packed.at(&inner_region);
+            let mut inner_padded = outer_padded.at(&inner_region);
+            let source = inner_packed.nd::<E, Const<1>, Const<1>>(comptime!(Guard::Checked));
+            let mut destination = inner_padded.view_mut::<Const<1>>();
+            let shape = source.shape();
+            for token in 0..shape[0] {
+                for dim in 0..shape[1] {
+                    let mut source_pos = CoordsDyn::new();
+                    source_pos.push(token);
+                    source_pos.push(dim);
+                    let mut destination_pos = CoordsDyn::new();
+                    destination_pos.push(0u32);
+                    destination_pos.push(token);
+                    destination_pos.push(dim);
+                    destination.write(destination_pos, source.read(source_pos));
+                }
+            }
+        }
+    }
+}
+
+#[cube(launch)]
+fn pack_sequences<E: Numeric>(
+    rectangular: &TileArg<'_, E, Const<1>>,
+    packed: &IndexedTileArg<'_, E, Const<1>>,
+    #[comptime] space: Space,
+) {
+    let rectangular = rectangular.tile(comptime!(space.clone()));
+    let packed = packed.tile(comptime!(space.clone()));
+    for outer_region in Walk::over(rectangular.runtime_space()) {
+        let outer_rectangular = rectangular.at(&outer_region);
+        let outer_packed = packed.at(&outer_region);
+        for inner_region in Walk::over(outer_rectangular.runtime_space()) {
+            let inner_rectangular = outer_rectangular.at(&inner_region);
+            let mut inner_packed = outer_packed.at(&inner_region);
+            let source = inner_rectangular.matrix::<Const<1>>(0usize);
+            let mut destination = inner_packed.matrix_mut::<Const<1>>(0usize);
+            let shape = source.shape();
+            for token in 0..shape.0 {
+                for dim in 0..shape.1 {
+                    let pos = (token, dim);
+                    destination.write(pos, source.read(pos));
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StageAt {
+    Never,
+    Outer,
+    Inner,
+}
+
+fn check_unpack(outer_batch: usize, stage_at: StageAt) {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::elem_type_native();
+    let lengths = [2usize, 0, 5, 3];
+    let cumulative = [0u32, 2, 2, 7, 10];
+    let batch = lengths.len();
+    let max_tokens = 6;
+    let dim = 3;
+
+    // Every physical row is distinct. In particular, the first row of the next sequence cannot
+    // pass for a zero at the preceding sequence's tail.
+    let packed_values = (0..10 * dim).map(|i| i as f32 + 1.0).collect::<Vec<_>>();
+    let (packed_t, _) = TestInput::builder(client.clone(), shape![10, dim])
+        .dtype(dtype)
+        .custom(packed_values.clone())
+        .generate_with_f32_host_data();
+    let lengths_t = TestInput::builder(client.clone(), shape![batch + 1])
+        .dtype(u32::elem_type_native())
+        .custom(cumulative.iter().map(|&x| x as f32).collect())
+        .generate_without_host_data();
+    let padded_t = TestInput::builder(client.clone(), shape![batch, max_tokens, dim])
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+
+    let mut operands = (
+        Operand::new(&[TOKEN, DIM], dtype),
+        Operand::new(&[BATCH, TOKEN, DIM], dtype),
+    );
+    let space = Tiling::over(
+        &mut operands,
+        &[(BATCH, batch), (TOKEN, max_tokens), (DIM, dim)],
+    )
+    .level(WalkOrder::RowMajor, Buffering::SINGLE, |l, ops| {
+        l.axis(BATCH, Cut::sequential(outer_batch))
+            .axis(TOKEN, Cut::sequential(3))
+            .axis(DIM, Cut::sequential(dim));
+        if matches!(stage_at, StageAt::Outer) {
+            ops.0.stage(Residence::Smem);
+        }
+    })
+    .level(WalkOrder::RowMajor, Buffering::SINGLE, |l, ops| {
+        l.axis(BATCH, Cut::sequential(1))
+            .axis(TOKEN, Cut::sequential(1))
+            .axis(DIM, Cut::sequential(dim));
+        if matches!(stage_at, StageAt::Inner) {
+            ops.0.stage(Residence::Smem);
+        }
+    })
+    .build();
+
+    let launcher = space.launcher(&client);
+    let packed = launcher
+        .bind(&operands.0, packed_t.binding())
+        .variable_length(lengths_t.binding(), BATCH, TOKEN)
+        .build();
+    let padded = launcher
+        .bind(&operands.1, padded_t.clone().binding())
+        .build();
+
+    unpack_sequences::launch::<f32, TestRuntime>(
+        &client,
+        launcher.cube_count(),
+        launcher.cube_dim(),
+        packed.arg(),
+        padded.arg(),
+        launcher.space().clone(),
+    );
+
+    let got = HostData::from_tensor_handle(&client, padded_t, HostDataType::F32);
+    for b in 0..batch {
+        for token in 0..max_tokens {
+            for d in 0..dim {
+                let expected = if token < lengths[b] {
+                    packed_values[(cumulative[b] as usize + token) * dim + d]
+                } else {
+                    0.0
+                };
+                assert_eq!(
+                    got.get_f32(&[b, token, d]),
+                    expected,
+                    "wrong value at sequence {b}, token {token}, dim {d}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn cumulative_lengths_translate_and_bound_each_sequence() {
+    check_unpack(1, StageAt::Never);
+}
+
+#[test]
+fn the_lookup_may_resolve_after_an_outer_sequence_tile() {
+    check_unpack(2, StageAt::Inner);
+}
+
+#[test]
+fn a_resolved_sequence_may_be_staged() {
+    check_unpack(1, StageAt::Outer);
+}
+
+#[test]
+fn writes_past_each_sequence_end_are_skipped() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::elem_type_native();
+    let lengths = [2usize, 0, 5, 3];
+    let cumulative = [0u32, 2, 2, 7, 10];
+    let (batch, max_tokens, dim) = (lengths.len(), 6, 3);
+    // Two rows past the last sequence's end that no sequence owns. Sequences are walked in
+    // ascending order, so every earlier overflow is overwritten by the next sequence's correct
+    // writes; only a tail that runs off the *last* sequence has nothing behind it to repair it,
+    // and only if the buffer is long enough to accept the write.
+    let packed_rows = *cumulative.last().unwrap() as usize + 2;
+    let rectangular_values = (0..batch * max_tokens * dim)
+        .map(|i| i as f32 + 1.0)
+        .collect::<Vec<_>>();
+    let rectangular_t = TestInput::builder(client.clone(), shape![batch, max_tokens, dim])
+        .dtype(dtype)
+        .custom(rectangular_values.clone())
+        .generate_without_host_data();
+    let cumulative_t = TestInput::builder(client.clone(), shape![batch + 1])
+        .dtype(u32::elem_type_native())
+        .custom(cumulative.iter().map(|&x| x as f32).collect())
+        .generate_without_host_data();
+    let packed_t = TestInput::builder(client.clone(), shape![packed_rows, dim])
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+
+    let mut operands = (
+        Operand::new(&[BATCH, TOKEN, DIM], dtype),
+        Operand::new(&[TOKEN, DIM], dtype),
+    );
+    let space = Tiling::over(
+        &mut operands,
+        &[(BATCH, batch), (TOKEN, max_tokens), (DIM, dim)],
+    )
+    .level(WalkOrder::RowMajor, Buffering::SINGLE, |l, _| {
+        l.axis(BATCH, Cut::sequential(1))
+            .axis(TOKEN, Cut::sequential(3))
+            .axis(DIM, Cut::sequential(dim));
+    })
+    .level(WalkOrder::RowMajor, Buffering::SINGLE, |l, _| {
+        l.axis(BATCH, Cut::sequential(1))
+            .axis(TOKEN, Cut::sequential(1))
+            .axis(DIM, Cut::sequential(dim));
+    })
+    .build();
+    let launcher = space.launcher(&client);
+    let rectangular = launcher.bind(&operands.0, rectangular_t.binding()).build();
+    let packed = launcher
+        .bind(&operands.1, packed_t.clone().binding())
+        .variable_length(cumulative_t.binding(), BATCH, TOKEN)
+        .build();
+    pack_sequences::launch::<f32, TestRuntime>(
+        &client,
+        launcher.cube_count(),
+        launcher.cube_dim(),
+        rectangular.arg(),
+        packed.arg(),
+        launcher.space().clone(),
+    );
+
+    // One expected value per physical row, so the rows past the last sequence are asserted to be
+    // untouched rather than merely left out of the walk.
+    let mut expected = vec![0.0f32; packed_rows * dim];
+    for b in 0..batch {
+        for token in 0..lengths[b] {
+            for d in 0..dim {
+                expected[(cumulative[b] as usize + token) * dim + d] =
+                    rectangular_values[(b * max_tokens + token) * dim + d];
+            }
+        }
+    }
+    let got = HostData::from_tensor_handle(&client, packed_t, HostDataType::F32);
+    for row in 0..packed_rows {
+        for d in 0..dim {
+            assert_eq!(
+                got.get_f32(&[row, d]),
+                expected[row * dim + d],
+                "wrong packed value at row {row}, dim {d}"
+            );
+        }
+    }
+}
+
+fn build_with_lengths_layout(shape: &[usize], strides: Option<&[usize]>) {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::elem_type_native();
+    let packed = TestInput::builder(client.clone(), shape![10, 3])
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+    let cumulative = TestInput::builder(client.clone(), shape.to_vec())
+        .dtype(u32::elem_type_native())
+        .zeros()
+        .generate_without_host_data();
+    let mut cumulative = cumulative.binding();
+    if let Some(strides) = strides {
+        cumulative.strides = strides.to_vec().into();
+    }
+    let mut operands = (Operand::new(&[TOKEN, DIM], dtype),);
+    let space = Tiling::over(&mut operands, &[(BATCH, 4), (TOKEN, 5), (DIM, 3)])
+        .level(WalkOrder::RowMajor, Buffering::SINGLE, |l, _| {
+            l.axis(BATCH, Cut::sequential(1))
+                .axis(TOKEN, Cut::sequential(2))
+                .axis(DIM, Cut::sequential(3));
+        })
+        .build();
+    let launcher = space.launcher(&client);
+    let _ = launcher
+        .bind(&operands.0, packed.binding())
+        .variable_length(cumulative, BATCH, TOKEN)
+        .build();
+}
+
+#[test]
+#[should_panic(expected = "cumulative sequence lengths have shape [sequence_count + 1]")]
+fn cumulative_lengths_owe_one_more_entry_than_sequences() {
+    build_with_lengths_layout(&[4], None);
+}
+
+#[test]
+#[should_panic(expected = "cumulative sequence lengths have shape [sequence_count + 1]")]
+fn cumulative_lengths_are_rank_one() {
+    build_with_lengths_layout(&[1, 5], None);
+}
+
+#[test]
+#[should_panic(expected = "cumulative sequence lengths must be dense row-major")]
+fn cumulative_lengths_are_dense() {
+    build_with_lengths_layout(&[5], Some(&[2]));
+}
+
+/// Build a variable-length operand over a well-formed table, optionally stating a boundary mode
+/// the sequence range has to answer for.
+fn build_with_boundary(boundary: Option<Option<Boundary>>) -> IndexedOperand<TestRuntime> {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::elem_type_native();
+    let packed = TestInput::builder(client.clone(), shape![10, 3])
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+    let cumulative = TestInput::builder(client.clone(), shape![5])
+        .dtype(u32::elem_type_native())
+        .zeros()
+        .generate_without_host_data();
+    let mut operands = (Operand::new(&[TOKEN, DIM], dtype),);
+    let space = Tiling::over(&mut operands, &[(BATCH, 4), (TOKEN, 5), (DIM, 3)])
+        .level(WalkOrder::RowMajor, Buffering::SINGLE, |l, _| {
+            l.axis(BATCH, Cut::sequential(1))
+                .axis(TOKEN, Cut::sequential(2))
+                .axis(DIM, Cut::sequential(3));
+        })
+        .build();
+    let launcher = space.launcher(&client);
+    let source = launcher.bind(&operands.0, packed.binding());
+    let source = match boundary {
+        Some(boundary) => source.with_boundary(boundary),
+        None => source,
+    };
+    source
+        .variable_length(cumulative.binding(), BATCH, TOKEN)
+        .build()
+}
+
+#[test]
+fn a_variable_length_target_derives_a_zero_boundary() {
+    assert_eq!(
+        build_with_boundary(None).spec.boundaries[0],
+        Some(Boundary::Zero)
+    );
+}
+
+/// The exclusive end is the mask, so clamping onto the sequence's last token would read a live
+/// value where the tail owes a zero. Refused rather than silently corrected.
+#[test]
+#[should_panic(expected = "owes its target Boundary::Zero, but this operand states Clamp")]
+fn a_variable_length_target_refuses_a_stated_clamp() {
+    build_with_boundary(Some(Some(Boundary::Clamp)));
+}
+
+/// Likewise for an operand declared unchecked: without the mask a short sequence reads straight
+/// into the next one.
+#[test]
+#[should_panic(expected = "owes its target Boundary::Zero, but this operand states unchecked")]
+fn a_variable_length_target_refuses_an_unchecked_declaration() {
+    build_with_boundary(Some(None));
+}
+
+#[test]
+#[should_panic(expected = "no level isolates the variable-length sequence axis")]
+fn a_sequence_axis_that_is_never_isolated_is_refused() {
+    let client = <TestRuntime as Runtime>::client(&Default::default());
+    let dtype = f32::elem_type_native();
+    let packed = TestInput::builder(client.clone(), shape![10, 3])
+        .dtype(dtype)
+        .zeros()
+        .generate_without_host_data();
+    let cumulative = TestInput::builder(client.clone(), shape![5])
+        .dtype(u32::elem_type_native())
+        .zeros()
+        .generate_without_host_data();
+    let mut operands = (Operand::new(&[TOKEN, DIM], dtype),);
+    let space = Tiling::over(&mut operands, &[(BATCH, 4), (TOKEN, 6), (DIM, 3)])
+        .level(WalkOrder::RowMajor, Buffering::SINGLE, |l, _| {
+            l.axis(BATCH, Cut::sequential(2))
+                .axis(TOKEN, Cut::sequential(3))
+                .axis(DIM, Cut::sequential(3));
+        })
+        .level(WalkOrder::RowMajor, Buffering::SINGLE, |l, _| {
+            l.axis(BATCH, Cut::sequential(2))
+                .axis(TOKEN, Cut::sequential(1))
+                .axis(DIM, Cut::sequential(3));
+        })
+        .build();
+    let launcher = space.launcher(&client);
+    let _ = launcher
+        .bind(&operands.0, packed.binding())
+        .variable_length(cumulative.binding(), BATCH, TOKEN)
+        .build();
+}


### PR DESCRIPTION
Stacked on #578. Adds variable-length packed sequences as a third mode of the existing `Indirection` side channel.

## What it does

Sequences of different lengths, packed end to end on one axis, presented to the kernel as a rectangular `[batch, max_tokens, ...]` space. For sequence `b`, adjacent cumulative lengths give its physical range:

```
start = table[b]
end   = table[b + 1]
```

When the lookup fires it adds `start` to the target window's origin and narrows that axis's `Window::bound` to `min(end, buffer_bound)`. `Boundary::Zero` then masks the tail, so a short sequence reads zero instead of reading into the next one. Both halves resolve at one level, and the child drops the carrier and is an ordinary dense sub-tile, same as indexed and paged.

```rust
let packed = launcher
    .bind(&packed_operand, packed_values.binding())
    .variable_length(cumulative_lengths.binding(), BATCH, TOKEN)
    .build();
```

The table is the conventional cumulative-length vector: dense rank-1 `u32`, `sequence_count + 1` entries. The last entry is not sliced off, it is what masks the final tail.

## Two design notes

**It fires on sequence isolation, not target granularity.** A replacement lookup fires once the target is cut down to one table entry. A range lookup never consumes the target coordinate, so that rule does not apply: it fires once the tiling isolates one sequence, and can then translate a target tile of any size. Reusing `granularity = 1` would demand one token per tile, which is unusable. `granularity` and `policy` therefore move into a new `IndirectionMode::Replace`, which also makes range-plus-trusted unrepresentable instead of rejected later.

**`Window::bound` was already the right mechanism.** It is the absolute logical extent and `axis_in_bounds` already computes `origin + pos < bound`, so validity is exactly `start + t < end` with nothing new added. Zero-length sequences fall out for free, and arming `Boundary::Zero` forecloses the unmasked fast paths on its own.

Nothing else moves: no data-dependent `Extent`, `Walk` stays comptime, and the operand stays direct and untiled. `IndexedTileArg` and friends keep their names, with docs corrected to say routing table.

## Tests

`tests/tile/variable_length.rs`, over lengths 2, 0, 5, 3 with every physical row distinct so a read past one sequence cannot pass for a zero: packed-to-padded copy, a zero-length sequence, firing at two different levels, `InPlace` and `Smem` staging, rectangular-to-packed writes, and the construction-time refusals (table shape and density, a sequence axis never isolated, a contradicting boundary, staging above the fire level).

Each correctness test was checked to fail when the bound narrowing is disabled, so they verify the mechanism rather than just exercising it. MoE and paged coverage is unchanged and still passes.
