### PR TITLE
perf(matmul): balance plane tiling for narrow outputs

### DIFF
--- a/crates/cubek-convolution/src/eval/cpu_reference.rs
+++ b/crates/cubek-convolution/src/eval/cpu_reference.rs
@@ -81,7 +81,6 @@ pub fn cpu_reference_result(
         &inputs.input_data,
         &inputs.weight_data,
         &problem,
-        None,
         progress,
     ))
 }
@@ -246,7 +245,7 @@ pub fn assert_result_with_bias(
     dtypes: MatmulElems,
 ) -> ValidationResult {
     let epsilon = conv_epsilon(&dtypes, 500.);
-    let expected = conv_cpu_reference(lhs, rhs, problem, bias, None);
+    let expected = conv_cpu_reference_with_bias(lhs, rhs, problem, bias, None);
     let actual = HostData::from_tensor_handle(client, out, HostDataType::F32);
 
     assert_equals_approx(&actual, &expected, epsilon)
@@ -272,6 +271,16 @@ fn conv_epsilon(elems: &MatmulElems, safety_factor: f32) -> f32 {
 ///
 /// All math is done in f32 against the host tensors carried in `HostData`.
 pub fn conv_cpu_reference(
+    lhs: &HostData,
+    rhs: &HostData,
+    problem: &ConvolutionProblem,
+    progress: Option<&Progress>,
+) -> HostData {
+    conv_cpu_reference_with_bias(lhs, rhs, problem, None, progress)
+}
+
+/// Naive CPU convolution with an optional per-output-channel bias.
+pub fn conv_cpu_reference_with_bias(
     lhs: &HostData,
     rhs: &HostData,
     problem: &ConvolutionProblem,

--- a/crates/cubek-convolution/src/eval/cpu_reference.rs
+++ b/crates/cubek-convolution/src/eval/cpu_reference.rs
@@ -81,6 +81,7 @@ pub fn cpu_reference_result(
         &inputs.input_data,
         &inputs.weight_data,
         &problem,
+        None,
         progress,
     ))
 }
@@ -230,8 +231,22 @@ pub fn assert_result(
     out: TensorHandle<TestRuntime>,
     dtypes: MatmulElems,
 ) -> ValidationResult {
+    assert_result_with_bias(lhs, rhs, None, problem, client, out, dtypes)
+}
+
+/// Validate convolution output against the CPU reference, including an optional
+/// per-output-channel bias.
+pub fn assert_result_with_bias(
+    lhs: &HostData,
+    rhs: &HostData,
+    bias: Option<&HostData>,
+    problem: &ConvolutionProblem,
+    client: &ComputeClient<TestRuntime>,
+    out: TensorHandle<TestRuntime>,
+    dtypes: MatmulElems,
+) -> ValidationResult {
     let epsilon = conv_epsilon(&dtypes, 500.);
-    let expected = conv_cpu_reference(lhs, rhs, problem, None);
+    let expected = conv_cpu_reference(lhs, rhs, problem, bias, None);
     let actual = HostData::from_tensor_handle(client, out, HostDataType::F32);
 
     assert_equals_approx(&actual, &expected, epsilon)
@@ -260,6 +275,7 @@ pub fn conv_cpu_reference(
     lhs: &HostData,
     rhs: &HostData,
     problem: &ConvolutionProblem,
+    bias: Option<&HostData>,
     progress: Option<&Progress>,
 ) -> HostData {
     let n = problem.batches;
@@ -288,7 +304,7 @@ pub fn conv_cpu_reference(
         for out_y in 0..out_h {
             for out_x in 0..out_w {
                 for out_c in 0..out_channels {
-                    let mut acc = 0.0_f32;
+                    let mut acc = bias.map(|bias| bias.get_f32(&[out_c])).unwrap_or(0.0);
                     for in_c in 0..c {
                         for ky in 0..kh {
                             for kx in 0..kw {

--- a/crates/cubek-convolution/tests/convolution/basic/mod.rs
+++ b/crates/cubek-convolution/tests/convolution/basic/mod.rs
@@ -8,6 +8,7 @@
 //! in `extended/`. The full per-axis cartesian lives in `full/`.
 
 mod common;
+mod narrow_bias;
 
 mod simple_async;
 mod simple_cyclic;

--- a/crates/cubek-convolution/tests/convolution/basic/narrow_bias.rs
+++ b/crates/cubek-convolution/tests/convolution/basic/narrow_bias.rs
@@ -1,0 +1,52 @@
+//! Regressions for accumulator loading in narrow-output convolutions.
+
+use cubek_convolution::ConvAlgorithm;
+use cubek_matmul::multi_level::components::tile::TileMatmulKind;
+use cubek_matmul::multi_level::{
+    PartitionSize, StageSize, TileSize,
+    definition::TilingScheme,
+    stage::{SwizzleMode, SwizzleModes},
+};
+
+use super::common::{default_partition_buffering, f16_dtypes};
+use crate::convolution::launcher_strategy::{ConvolutionCase, ConvolutionSize, test_algo_case};
+
+fn etive_residual_tiling() -> TilingScheme {
+    TilingScheme::builder()
+        .with_tile_size(TileSize { m: 16, n: 8, k: 16 })
+        .with_partition_size(PartitionSize { m: 1, n: 8, k: 2 })
+        .with_stage_size(StageSize { m: 4, n: 1, k: 1 })
+        .build()
+        .unwrap()
+}
+
+#[cfg(feature = "heavy")]
+#[test]
+fn simple_n64_mma_with_bias() {
+    test_algo_case(
+        ConvAlgorithm::SimpleSyncStrided,
+        f16_dtypes(),
+        TileMatmulKind::Mma,
+        etive_residual_tiling(),
+        SwizzleModes {
+            lhs: SwizzleMode::B64,
+            rhs: SwizzleMode::B64,
+            ..Default::default()
+        },
+        default_partition_buffering(),
+        ConvolutionCase {
+            size: ConvolutionSize {
+                h: 8,
+                w: 8,
+                c: 64,
+                out_c: 64,
+            },
+            batches: 1024,
+            kernel_size: [3, 3],
+            stride: [1, 1],
+            padding: [1, 1],
+            dilation: [1, 1],
+        },
+        true,
+    );
+}

--- a/crates/cubek-convolution/tests/convolution/basic/narrow_bias.rs
+++ b/crates/cubek-convolution/tests/convolution/basic/narrow_bias.rs
@@ -41,7 +41,7 @@ fn simple_n64_mma_with_bias() {
                 c: 64,
                 out_c: 64,
             },
-            batches: 1024,
+            batches: 1,
             kernel_size: [3, 3],
             stride: [1, 1],
             padding: [1, 1],

--- a/crates/cubek-convolution/tests/convolution/launcher_strategy.rs
+++ b/crates/cubek-convolution/tests/convolution/launcher_strategy.rs
@@ -31,7 +31,7 @@ use cubek_matmul::{
 use cubek_std::{InputBinding, MatrixLayout};
 use cubek_test_utils::{ExecutionOutcome, TestInput, TestOutcome, launch_and_capture_outcome};
 
-use cubek_convolution::eval::cpu_reference::assert_result;
+use cubek_convolution::eval::cpu_reference::assert_result_with_bias;
 
 /// 2D convolution input/output channel + spatial size, used by `test_algo` to
 /// build a `ConvolutionProblem`.
@@ -41,6 +41,29 @@ pub struct ConvolutionSize {
     pub w: usize,
     pub c: usize,
     pub out_c: usize,
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ConvolutionCase {
+    pub size: ConvolutionSize,
+    pub batches: usize,
+    pub kernel_size: [u32; 2],
+    pub stride: [u32; 2],
+    pub padding: [i32; 2],
+    pub dilation: [u32; 2],
+}
+
+impl ConvolutionCase {
+    fn standard(size: ConvolutionSize) -> Self {
+        Self {
+            size,
+            batches: 2,
+            kernel_size: [4, 3],
+            stride: [1, 1],
+            padding: [3, 1],
+            dilation: [3, 2],
+        }
+    }
 }
 
 /// Build a 2D forward conv problem and run it via the public `launch_ref`.
@@ -59,15 +82,38 @@ pub fn test_algo(
     partition_buffering: PartitionBuffering,
     convolution_size: ConvolutionSize,
 ) {
+    test_algo_case(
+        algorithm,
+        dtypes,
+        TileMatmulKind::Cmma,
+        tiling_scheme,
+        swizzle,
+        partition_buffering,
+        ConvolutionCase::standard(convolution_size),
+        false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn test_algo_case(
+    algorithm: ConvAlgorithm,
+    dtypes: MatmulElems,
+    tile_kind: TileMatmulKind,
+    tiling_scheme: TilingScheme,
+    swizzle: SwizzleModes,
+    partition_buffering: PartitionBuffering,
+    case: ConvolutionCase,
+    has_bias: bool,
+) {
     let client = TestRuntime::client(&Default::default());
     let plane_dim = client.properties().hardware.plane_size_max;
 
-    // Fixed for now; mirrors the parameters baked into the previous test suite.
-    let batches = 2;
-    let kernel_size = vec![4, 3];
-    let stride = vec![1, 1];
-    let padding = vec![3, 1];
-    let dilation = vec![3, 2];
+    let convolution_size = case.size;
+    let batches = case.batches;
+    let kernel_size = case.kernel_size.to_vec();
+    let stride = case.stride.to_vec();
+    let padding = case.padding.to_vec();
+    let dilation = case.dilation.to_vec();
 
     let out_h = calculate_conv_output_size(
         kernel_size[0],
@@ -127,7 +173,7 @@ pub fn test_algo(
     };
 
     let matmul_blueprint = BatchMatmulBlueprint::builder(
-        TileMatmulKind::Cmma,
+        tile_kind,
         tiling_scheme,
         plane_dim,
         &problem.as_matmul_problem(),
@@ -165,10 +211,17 @@ pub fn test_algo(
         .zeros()
         .generate_without_host_data();
 
+    let bias = has_bias.then(|| {
+        TestInput::builder(client.clone(), shape![problem.n])
+            .dtype(dtypes.acc_global)
+            .uniform(9012, -1., 1.)
+            .generate_with_f32_host_data()
+    });
+
     let blueprint = ConvBlueprint::Forward(ForwardBlueprint {
         matmul: matmul_blueprint,
         dimensionality: Dimensionality::Dim2,
-        has_bias: false,
+        has_bias,
     });
     let strategy = Strategy::Forced {
         algorithm,
@@ -178,7 +231,9 @@ pub fn test_algo(
     let inputs = ConvolutionInputs::Forward {
         input: InputBinding::new(lhs.clone().binding(), dtypes.lhs_global),
         weight: InputBinding::new(rhs.clone().binding(), dtypes.rhs_global),
-        bias: None,
+        bias: bias
+            .as_ref()
+            .map(|(bias, _)| InputBinding::new(bias.clone().binding(), dtypes.acc_global)),
         out: out.clone().binding(),
     };
 
@@ -206,9 +261,10 @@ pub fn test_algo(
         );
 
     let outcome = match outcome {
-        ExecutionOutcome::Executed => TestOutcome::Validated(assert_result(
+        ExecutionOutcome::Executed => TestOutcome::Validated(assert_result_with_bias(
             &lhs_data,
             &rhs_data,
+            bias.as_ref().map(|(_, data)| data),
             &problem_for_check,
             &client,
             out,

--- a/crates/cubek-matmul/src/multi_level/routines/selector/plane.rs
+++ b/crates/cubek-matmul/src/multi_level/routines/selector/plane.rs
@@ -127,37 +127,19 @@ pub fn infer_blueprint_plane<R: Runtime>(
         ));
     }
 
-    let mut partition_size_k = options
-        .partition_k
-        .unwrap_or_else(|| plane_dim / tile_size.k());
-
-    if options.swizzled {
-        if problem.lhs_layout == MatrixLayout::RowMajor {
-            let elem_size = dtypes.lhs_global.size() as u32;
-            while partition_size_k * tile_size.k() * elem_size > 128 {
-                partition_size_k /= 2;
-            }
-        }
-        if problem.rhs_layout == MatrixLayout::ColMajor {
-            let elem_size = dtypes.rhs_global.size() as u32;
-            while partition_size_k * tile_size.k() * elem_size > 128 {
-                partition_size_k /= 2;
-            }
-        }
-    }
-
     let max_stage_tiles_m = if options.swizzled && problem.lhs_layout == MatrixLayout::ColMajor {
         max_swizzle_tiles(tile_size.m() as usize, dtypes.lhs_stage.size())
     } else {
         usize::MAX
     };
-    let max_partition_size_n = if options.swizzled && problem.rhs_layout == MatrixLayout::RowMajor {
+    let max_partition_shape_n = if options.swizzled && problem.rhs_layout == MatrixLayout::RowMajor
+    {
         max_swizzle_tiles(tile_size.n() as usize, dtypes.rhs_stage.size())
     } else {
         usize::MAX
     };
 
-    let (rows_per_plane, stage_size_m, partition_size_n) = select_size(
+    let (rows_per_plane, stage_size_m, partition_shape_n) = select_size(
         options.multi_row_strategy,
         row_count as usize,
         tile_size.m() as usize,
@@ -167,13 +149,33 @@ pub fn infer_blueprint_plane<R: Runtime>(
         vector_sizes.lhs,
         vector_sizes.rhs,
         max_stage_tiles_m,
-        max_partition_size_n,
+        max_partition_shape_n,
     );
+
+    let mut partition_shape_k = options
+        .partition_k
+        .unwrap_or_else(|| plane_dim / tile_size.k());
+
+    if options.swizzled {
+        let max_swizzle_span = SwizzleMode::B128.span_size() as u32;
+        if problem.lhs_layout == MatrixLayout::RowMajor {
+            let elem_size = dtypes.lhs_global.size() as u32;
+            while partition_shape_k * tile_size.k() * elem_size > max_swizzle_span {
+                partition_shape_k /= 2;
+            }
+        }
+        if problem.rhs_layout == MatrixLayout::ColMajor {
+            let elem_size = dtypes.rhs_global.size() as u32;
+            while partition_shape_k * tile_size.k() * elem_size > max_swizzle_span {
+                partition_shape_k /= 2;
+            }
+        }
+    }
 
     let tiles_per_partition = PartitionSize::new(
         rows_per_plane as u32,
-        partition_size_n as u32,
-        partition_size_k,
+        partition_shape_n as u32,
+        partition_shape_k,
     );
 
     let partitions_per_stage = StageSize::new(stage_size_m as u32, 1, 1);
@@ -243,10 +245,9 @@ pub fn infer_blueprint_plane<R: Runtime>(
 
 /// All modes currently use atom size 16
 const SWIZZLE_ATOM: usize = 16;
-const MAX_SWIZZLE_SPAN: usize = 128;
 
 fn max_swizzle_tiles(instruction_size: usize, elem_size: usize) -> usize {
-    (MAX_SWIZZLE_SPAN / (instruction_size * elem_size)).max(1)
+    (SwizzleMode::B128.span_size() / (instruction_size * elem_size)).max(1)
 }
 
 pub fn select_swizzle(swizzle_dim: usize, elem: ElemType, vector_size: VectorSize) -> SwizzleMode {
@@ -276,7 +277,7 @@ fn select_size(
     lhs_vector_size: VectorSize,
     rhs_vector_size: VectorSize,
     max_stage_tiles_m: usize,
-    max_partition_size_n: usize,
+    max_partition_shape_n: usize,
 ) -> (usize, usize, usize) {
     let rows = match strategy {
         MultiRowStrategy::Never => 1,
@@ -303,11 +304,11 @@ fn select_size(
     // Otherwise preserve the existing geometry unless swizzling requires a smaller span.
     let required_n_tiles = problem_n.div_ceil(instruction_n).max(1);
     let balance_stage_loads = required_n_tiles < plane_count;
-    let partition_size_n_limit = plane_count.min(max_partition_size_n).max(1);
-    let partition_size_n = if balance_stage_loads {
-        power_of_two_at_most(required_n_tiles, partition_size_n_limit)
-    } else if partition_size_n_limit < plane_count {
-        power_of_two_at_most(plane_count, partition_size_n_limit)
+    let partition_shape_n_limit = plane_count.min(max_partition_shape_n).max(1);
+    let partition_shape_n = if balance_stage_loads {
+        power_of_two_at_most(required_n_tiles, partition_shape_n_limit)
+    } else if partition_shape_n_limit < plane_count {
+        power_of_two_at_most(plane_count, partition_shape_n_limit)
     } else {
         plane_count
     };
@@ -316,7 +317,7 @@ fn select_size(
     //
     // stage_m * instruction_m * rows / lhs_vector_size
     //     ~= instruction_n * partition_n / rhs_vector_size
-    let stage_m_numerator = instruction_n * partition_size_n * lhs_vector_size;
+    let stage_m_numerator = instruction_n * partition_shape_n * lhs_vector_size;
     let stage_m_denominator = instruction_m * rows * rhs_vector_size;
     let default_stage_size_m = plane_count / rows;
     let desired_stage_size_m = if balance_stage_loads {
@@ -330,7 +331,7 @@ fn select_size(
     let max_swizzled_stage_size_m = (max_stage_tiles_m / rows).max(1);
     let stage_size_m_limit = default_stage_size_m
         .min(max_swizzled_stage_size_m)
-        .min(partition_size_n)
+        .min(partition_shape_n)
         .max(1);
     let stage_size_m = if !balance_stage_loads && desired_stage_size_m <= stage_size_m_limit {
         desired_stage_size_m
@@ -338,7 +339,7 @@ fn select_size(
         power_of_two_at_most(desired_stage_size_m, stage_size_m_limit)
     };
 
-    (rows, stage_size_m, partition_size_n)
+    (rows, stage_size_m, partition_shape_n)
 }
 
 fn power_of_two_at_most(target: usize, limit: usize) -> usize {
@@ -499,12 +500,12 @@ mod tests {
 
     #[test]
     fn select_size_balances_stage_work_for_narrow_n() {
-        let (rows_per_plane, stage_size_m, partition_size_n) =
+        let (rows_per_plane, stage_size_m, partition_shape_n) =
             select_unswizzled(MultiRowStrategy::Never, 16, (16, 8), (65536, 64), (8, 8));
 
         assert_eq!(rows_per_plane, 1);
         assert_eq!(stage_size_m, 4);
-        assert_eq!(partition_size_n, 8);
+        assert_eq!(partition_shape_n, 8);
     }
 
     #[test]
@@ -547,10 +548,10 @@ mod tests {
 
     #[test]
     fn select_size_rounds_partition_n_to_power_of_two() {
-        let (_, _, partition_size_n) =
+        let (_, _, partition_shape_n) =
             select_unswizzled(MultiRowStrategy::Never, 16, (16, 8), (65536, 33), (8, 8));
 
-        assert_eq!(partition_size_n, 8);
+        assert_eq!(partition_shape_n, 8);
     }
 
     #[test]
@@ -572,7 +573,7 @@ mod tests {
         ];
 
         for (strategy, plane_count, instruction_m, instruction_n, problem_m, problem_n) in cases {
-            let (_, stage_size_m, partition_size_n) = select_unswizzled(
+            let (_, stage_size_m, partition_shape_n) = select_unswizzled(
                 strategy,
                 plane_count,
                 (instruction_m, instruction_n),
@@ -580,15 +581,15 @@ mod tests {
                 (8, 8),
             );
 
-            assert!(partition_size_n.is_multiple_of(stage_size_m));
+            assert!(partition_shape_n.is_multiple_of(stage_size_m));
         }
     }
 
     #[test]
     fn select_size_applies_swizzle_limits_independently() {
         let max_stage_tiles_m = max_swizzle_tiles(16, 2);
-        let max_partition_size_n = max_swizzle_tiles(8, 4);
-        let (rows_per_plane, stage_size_m, partition_size_n) = select_size(
+        let max_partition_shape_n = max_swizzle_tiles(8, 4);
+        let (rows_per_plane, stage_size_m, partition_shape_n) = select_size(
             MultiRowStrategy::Always(2),
             16,
             16,
@@ -598,13 +599,14 @@ mod tests {
             8,
             1,
             max_stage_tiles_m,
-            max_partition_size_n,
+            max_partition_shape_n,
         );
 
         assert_eq!(rows_per_plane, 2);
         assert_eq!(stage_size_m, 2);
-        assert_eq!(partition_size_n, 4);
-        assert!(rows_per_plane * stage_size_m * 16 * 2 <= MAX_SWIZZLE_SPAN);
-        assert!(partition_size_n * 8 * 4 <= MAX_SWIZZLE_SPAN);
+        assert_eq!(partition_shape_n, 4);
+        let max_swizzle_span = SwizzleMode::B128.span_size();
+        assert!(rows_per_plane * stage_size_m * 16 * 2 <= max_swizzle_span);
+        assert!(partition_shape_n * 8 * 4 <= max_swizzle_span);
     }
 }

--- a/crates/cubek-matmul/src/multi_level/routines/selector/plane.rs
+++ b/crates/cubek-matmul/src/multi_level/routines/selector/plane.rs
@@ -267,6 +267,7 @@ pub fn select_swizzle(swizzle_dim: usize, elem: ElemType, vector_size: VectorSiz
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn select_size(
     strategy: MultiRowStrategy,
     plane_count: usize,
@@ -326,8 +327,8 @@ fn select_size(
         default_stage_size_m
     };
 
-    // Keeping the power-of-two stage size no larger than the N partition makes it divide
-    // the RHS tile count without consuming the K factor needed by tilewise readers.
+    // Adjusted geometries use a power-of-two stage size no larger than the N partition,
+    // preserving the K factor needed by tilewise readers.
     let max_swizzled_stage_size_m = (max_stage_tiles_m / rows).max(1);
     let stage_size_m_limit = default_stage_size_m
         .min(max_swizzled_stage_size_m)
@@ -565,11 +566,11 @@ mod tests {
     }
 
     #[test]
-    fn select_size_m_divides_partition_n() {
+    fn select_size_balances_with_divisible_power_of_two_geometry() {
         let cases = [
             (MultiRowStrategy::Never, 16, 8, 32, 64, 64),
-            (MultiRowStrategy::Always(3), 8, 16, 16, 1024, 128),
-            (MultiRowStrategy::Never, 10, 32, 8, 1024, 1024),
+            (MultiRowStrategy::Always(3), 8, 16, 16, 1024, 64),
+            (MultiRowStrategy::Never, 10, 32, 8, 1024, 64),
         ];
 
         for (strategy, plane_count, instruction_m, instruction_n, problem_m, problem_n) in cases {

--- a/crates/cubek-matmul/src/multi_level/routines/selector/plane.rs
+++ b/crates/cubek-matmul/src/multi_level/routines/selector/plane.rs
@@ -131,7 +131,11 @@ pub fn infer_blueprint_plane<R: Runtime>(
         options.multi_row_strategy,
         row_count as usize,
         tile_size.m() as usize,
+        tile_size.n() as usize,
         problem.m,
+        problem.n,
+        vector_sizes.lhs,
+        vector_sizes.rhs,
     );
 
     if options.swizzled {
@@ -265,7 +269,11 @@ fn select_size(
     strategy: MultiRowStrategy,
     plane_count: usize,
     instruction_m: usize,
+    instruction_n: usize,
     problem_m: usize,
+    problem_n: usize,
+    lhs_vector_size: VectorSize,
+    rhs_vector_size: VectorSize,
 ) -> (usize, usize, usize) {
     let rows = match strategy {
         MultiRowStrategy::Never => 1,
@@ -288,7 +296,16 @@ fn select_size(
     // along `m` (e.g. a large `problem_m` requesting 2 rows when only 1 plane fits).
     let rows = rows.min(plane_count).max(1);
 
-    (rows, plane_count / rows, plane_count)
+    // Avoid assigning planes to columns outside the problem, then balance the LHS and RHS
+    // stage-loading work. This keeps rectangular instruction tiles from producing an
+    // unnecessarily large square stage.
+    let required_n_tiles = problem_n.div_ceil(instruction_n).max(1);
+    let partition_shape_n = required_n_tiles.next_power_of_two().min(plane_count);
+    let lhs_work = instruction_m * rows * rhs_vector_size;
+    let rhs_work = instruction_n * partition_shape_n * lhs_vector_size;
+    let stage_size_m = rhs_work.div_ceil(lhs_work).clamp(1, plane_count / rows);
+
+    (rows, stage_size_m, partition_shape_n)
 }
 
 /// The instruction shape for this problem: [`crate::multi_level::find_instruction_size`]
@@ -388,6 +405,7 @@ mod tests {
         let plane_count = 1;
         let instruction_m = 8;
         let problem_m = 1024;
+        let problem_n = 4;
 
         for strategy in [
             MultiRowStrategy::Always(2),
@@ -395,8 +413,16 @@ mod tests {
                 minimum_stage_count: 8,
             },
         ] {
-            let (rows_per_plane, stage_size_m, _partition_shape_n) =
-                select_size(strategy, plane_count, instruction_m, problem_m);
+            let (rows_per_plane, stage_size_m, _partition_shape_n) = select_size(
+                strategy,
+                plane_count,
+                instruction_m,
+                8,
+                problem_m,
+                problem_n,
+                4,
+                4,
+            );
 
             assert!(
                 stage_size_m >= 1,
@@ -406,5 +432,26 @@ mod tests {
             // With a single plane we can only fit a single row per plane.
             assert!(rows_per_plane <= plane_count);
         }
+    }
+
+    #[test]
+    fn select_size_balances_stage_work_for_narrow_n() {
+        let size = select_size(MultiRowStrategy::Never, 16, 16, 8, 65536, 64, 8, 8);
+
+        assert_eq!(size, (1, 4, 8));
+    }
+
+    #[test]
+    fn select_size_respects_plane_limit_for_wide_n() {
+        let size = select_size(MultiRowStrategy::Never, 16, 16, 8, 65536, 1024, 8, 8);
+
+        assert_eq!(size, (1, 8, 16));
+    }
+
+    #[test]
+    fn select_size_rounds_n_for_balanced_loading() {
+        let size = select_size(MultiRowStrategy::Never, 16, 16, 8, 65536, 33, 8, 8);
+
+        assert_eq!(size, (1, 4, 8));
     }
 }

--- a/crates/cubek-matmul/src/multi_level/routines/selector/plane.rs
+++ b/crates/cubek-matmul/src/multi_level/routines/selector/plane.rs
@@ -127,7 +127,37 @@ pub fn infer_blueprint_plane<R: Runtime>(
         ));
     }
 
-    let (rows_per_plane, mut stage_size_m, mut partition_shape_n) = select_size(
+    let mut partition_size_k = options
+        .partition_k
+        .unwrap_or_else(|| plane_dim / tile_size.k());
+
+    if options.swizzled {
+        if problem.lhs_layout == MatrixLayout::RowMajor {
+            let elem_size = dtypes.lhs_global.size() as u32;
+            while partition_size_k * tile_size.k() * elem_size > 128 {
+                partition_size_k /= 2;
+            }
+        }
+        if problem.rhs_layout == MatrixLayout::ColMajor {
+            let elem_size = dtypes.rhs_global.size() as u32;
+            while partition_size_k * tile_size.k() * elem_size > 128 {
+                partition_size_k /= 2;
+            }
+        }
+    }
+
+    let max_stage_tiles_m = if options.swizzled && problem.lhs_layout == MatrixLayout::ColMajor {
+        max_swizzle_tiles(tile_size.m() as usize, dtypes.lhs_stage.size())
+    } else {
+        usize::MAX
+    };
+    let max_partition_size_n = if options.swizzled && problem.rhs_layout == MatrixLayout::RowMajor {
+        max_swizzle_tiles(tile_size.n() as usize, dtypes.rhs_stage.size())
+    } else {
+        usize::MAX
+    };
+
+    let (rows_per_plane, stage_size_m, partition_size_n) = select_size(
         options.multi_row_strategy,
         row_count as usize,
         tile_size.m() as usize,
@@ -136,48 +166,14 @@ pub fn infer_blueprint_plane<R: Runtime>(
         problem.n,
         vector_sizes.lhs,
         vector_sizes.rhs,
+        max_stage_tiles_m,
+        max_partition_size_n,
     );
-
-    if options.swizzled {
-        if problem.lhs_layout == MatrixLayout::ColMajor {
-            let elem_size = dtypes.lhs_global.size();
-            while partition_shape_n * tile_size.n() as usize * elem_size > 128 {
-                partition_shape_n /= 2;
-                stage_size_m /= 2;
-            }
-        }
-        if problem.rhs_layout == MatrixLayout::RowMajor {
-            let elem_size = dtypes.rhs_global.size();
-            while partition_shape_n * tile_size.n() as usize * elem_size > 128 {
-                partition_shape_n /= 2;
-                stage_size_m /= 2;
-            }
-        }
-    }
-
-    let mut partition_shape_k = options
-        .partition_k
-        .unwrap_or_else(|| plane_dim / tile_size.k());
-
-    if options.swizzled {
-        if problem.lhs_layout == MatrixLayout::RowMajor {
-            let elem_size = dtypes.lhs_global.size() as u32;
-            while partition_shape_k * tile_size.k() * elem_size > 128 {
-                partition_shape_k /= 2;
-            }
-        }
-        if problem.rhs_layout == MatrixLayout::ColMajor {
-            let elem_size = dtypes.rhs_global.size() as u32;
-            while partition_shape_k * tile_size.k() * elem_size > 128 {
-                partition_shape_k /= 2;
-            }
-        }
-    }
 
     let tiles_per_partition = PartitionSize::new(
         rows_per_plane as u32,
-        partition_shape_n as u32,
-        partition_shape_k,
+        partition_size_n as u32,
+        partition_size_k,
     );
 
     let partitions_per_stage = StageSize::new(stage_size_m as u32, 1, 1);
@@ -247,6 +243,11 @@ pub fn infer_blueprint_plane<R: Runtime>(
 
 /// All modes currently use atom size 16
 const SWIZZLE_ATOM: usize = 16;
+const MAX_SWIZZLE_SPAN: usize = 128;
+
+fn max_swizzle_tiles(instruction_size: usize, elem_size: usize) -> usize {
+    (MAX_SWIZZLE_SPAN / (instruction_size * elem_size)).max(1)
+}
 
 pub fn select_swizzle(swizzle_dim: usize, elem: ElemType, vector_size: VectorSize) -> SwizzleMode {
     // Vector size exceeds swizzle atom
@@ -274,6 +275,8 @@ fn select_size(
     problem_n: usize,
     lhs_vector_size: VectorSize,
     rhs_vector_size: VectorSize,
+    max_stage_tiles_m: usize,
+    max_partition_size_n: usize,
 ) -> (usize, usize, usize) {
     let rows = match strategy {
         MultiRowStrategy::Never => 1,
@@ -296,16 +299,58 @@ fn select_size(
     // along `m` (e.g. a large `problem_m` requesting 2 rows when only 1 plane fits).
     let rows = rows.min(plane_count).max(1);
 
-    // Avoid assigning planes to columns outside the problem, then balance the LHS and RHS
-    // stage-loading work. This keeps rectangular instruction tiles from producing an
-    // unnecessarily large square stage.
+    // For narrow outputs, cover the useful N tiles with a bounded power-of-two partition.
+    // Otherwise preserve the existing geometry unless swizzling requires a smaller span.
     let required_n_tiles = problem_n.div_ceil(instruction_n).max(1);
-    let partition_shape_n = required_n_tiles.next_power_of_two().min(plane_count);
-    let lhs_work = instruction_m * rows * rhs_vector_size;
-    let rhs_work = instruction_n * partition_shape_n * lhs_vector_size;
-    let stage_size_m = rhs_work.div_ceil(lhs_work).clamp(1, plane_count / rows);
+    let balance_stage_loads = required_n_tiles < plane_count;
+    let partition_size_n_limit = plane_count.min(max_partition_size_n).max(1);
+    let partition_size_n = if balance_stage_loads {
+        power_of_two_at_most(required_n_tiles, partition_size_n_limit)
+    } else if partition_size_n_limit < plane_count {
+        power_of_two_at_most(plane_count, partition_size_n_limit)
+    } else {
+        plane_count
+    };
 
-    (rows, stage_size_m, partition_shape_n)
+    // Balance vector loads between the two stages. K cancels from this relationship:
+    //
+    // stage_m * instruction_m * rows / lhs_vector_size
+    //     ~= instruction_n * partition_n / rhs_vector_size
+    let stage_m_numerator = instruction_n * partition_size_n * lhs_vector_size;
+    let stage_m_denominator = instruction_m * rows * rhs_vector_size;
+    let default_stage_size_m = plane_count / rows;
+    let desired_stage_size_m = if balance_stage_loads {
+        stage_m_numerator.div_ceil(stage_m_denominator)
+    } else {
+        default_stage_size_m
+    };
+
+    // Keeping the power-of-two stage size no larger than the N partition makes it divide
+    // the RHS tile count without consuming the K factor needed by tilewise readers.
+    let max_swizzled_stage_size_m = (max_stage_tiles_m / rows).max(1);
+    let stage_size_m_limit = default_stage_size_m
+        .min(max_swizzled_stage_size_m)
+        .min(partition_size_n)
+        .max(1);
+    let stage_size_m = if !balance_stage_loads && desired_stage_size_m <= stage_size_m_limit {
+        desired_stage_size_m
+    } else {
+        power_of_two_at_most(desired_stage_size_m, stage_size_m_limit)
+    };
+
+    (rows, stage_size_m, partition_size_n)
+}
+
+fn power_of_two_at_most(target: usize, limit: usize) -> usize {
+    let limit = limit.max(1);
+    let target = target.clamp(1, limit);
+    let rounded = target.next_power_of_two();
+
+    if rounded <= limit {
+        rounded
+    } else {
+        1 << limit.ilog2()
+    }
 }
 
 /// The instruction shape for this problem: [`crate::multi_level::find_instruction_size`]
@@ -394,6 +439,27 @@ fn selection_tiny<R: Runtime>(
 mod tests {
     use super::*;
 
+    fn select_unswizzled(
+        strategy: MultiRowStrategy,
+        plane_count: usize,
+        instruction: (usize, usize),
+        problem: (usize, usize),
+        vector_sizes: (usize, usize),
+    ) -> (usize, usize, usize) {
+        select_size(
+            strategy,
+            plane_count,
+            instruction.0,
+            instruction.1,
+            problem.0,
+            problem.1,
+            vector_sizes.0,
+            vector_sizes.1,
+            usize::MAX,
+            usize::MAX,
+        )
+    }
+
     /// Regression test: when fewer planes are available than the requested
     /// rows-per-plane (e.g. a large `problem_m` asks for 2 rows but only 1 plane
     /// fits), `select_size` must not return `stage_size_m == 0`. The zero used to
@@ -413,15 +479,12 @@ mod tests {
                 minimum_stage_count: 8,
             },
         ] {
-            let (rows_per_plane, stage_size_m, _partition_shape_n) = select_size(
+            let (rows_per_plane, stage_size_m, _partition_shape_n) = select_unswizzled(
                 strategy,
                 plane_count,
-                instruction_m,
-                8,
-                problem_m,
-                problem_n,
-                4,
-                4,
+                (instruction_m, 8),
+                (problem_m, problem_n),
+                (4, 4),
             );
 
             assert!(
@@ -436,22 +499,112 @@ mod tests {
 
     #[test]
     fn select_size_balances_stage_work_for_narrow_n() {
-        let size = select_size(MultiRowStrategy::Never, 16, 16, 8, 65536, 64, 8, 8);
+        let (rows_per_plane, stage_size_m, partition_size_n) =
+            select_unswizzled(MultiRowStrategy::Never, 16, (16, 8), (65536, 64), (8, 8));
 
-        assert_eq!(size, (1, 4, 8));
+        assert_eq!(rows_per_plane, 1);
+        assert_eq!(stage_size_m, 4);
+        assert_eq!(partition_size_n, 8);
     }
 
     #[test]
-    fn select_size_respects_plane_limit_for_wide_n() {
-        let size = select_size(MultiRowStrategy::Never, 16, 16, 8, 65536, 1024, 8, 8);
+    fn select_size_covers_preferred_instruction_shapes() {
+        let cases = [
+            // Tall, wide, and square instruction preferences.
+            ((32, 8), (65536, 64), (1, 2, 8)),
+            ((8, 32), (64, 65536), (1, 16, 16)),
+            ((16, 16), (1024, 1024), (1, 16, 16)),
+        ];
 
-        assert_eq!(size, (1, 8, 16));
+        for ((instruction_m, instruction_n), (problem_m, problem_n), expected) in cases {
+            let size = select_unswizzled(
+                MultiRowStrategy::Never,
+                16,
+                (instruction_m, instruction_n),
+                (problem_m, problem_n),
+                (8, 8),
+            );
+
+            assert_eq!(size, expected);
+        }
     }
 
     #[test]
-    fn select_size_rounds_n_for_balanced_loading() {
-        let size = select_size(MultiRowStrategy::Never, 16, 16, 8, 65536, 33, 8, 8);
+    fn select_size_preserves_stage_m_when_n_uses_all_planes() {
+        let power_of_two = select_unswizzled(
+            MultiRowStrategy::Always(2),
+            16,
+            (32, 8),
+            (65536, 1024),
+            (8, 8),
+        );
+        let non_power_of_two =
+            select_unswizzled(MultiRowStrategy::Never, 10, (32, 8), (65536, 80), (8, 8));
 
-        assert_eq!(size, (1, 4, 8));
+        assert_eq!(power_of_two, (2, 8, 16));
+        assert_eq!(non_power_of_two, (1, 10, 10));
+    }
+
+    #[test]
+    fn select_size_rounds_partition_n_to_power_of_two() {
+        let (_, _, partition_size_n) =
+            select_unswizzled(MultiRowStrategy::Never, 16, (16, 8), (65536, 33), (8, 8));
+
+        assert_eq!(partition_size_n, 8);
+    }
+
+    #[test]
+    fn select_size_respects_vector_widths() {
+        let narrow_lhs =
+            select_unswizzled(MultiRowStrategy::Never, 16, (32, 8), (65536, 64), (1, 8));
+        let wide_lhs = select_unswizzled(MultiRowStrategy::Never, 16, (32, 8), (65536, 64), (8, 1));
+
+        assert_eq!(narrow_lhs, (1, 1, 8));
+        assert_eq!(wide_lhs, (1, 8, 8));
+    }
+
+    #[test]
+    fn select_size_m_divides_partition_n() {
+        let cases = [
+            (MultiRowStrategy::Never, 16, 8, 32, 64, 64),
+            (MultiRowStrategy::Always(3), 8, 16, 16, 1024, 128),
+            (MultiRowStrategy::Never, 10, 32, 8, 1024, 1024),
+        ];
+
+        for (strategy, plane_count, instruction_m, instruction_n, problem_m, problem_n) in cases {
+            let (_, stage_size_m, partition_size_n) = select_unswizzled(
+                strategy,
+                plane_count,
+                (instruction_m, instruction_n),
+                (problem_m, problem_n),
+                (8, 8),
+            );
+
+            assert!(partition_size_n.is_multiple_of(stage_size_m));
+        }
+    }
+
+    #[test]
+    fn select_size_applies_swizzle_limits_independently() {
+        let max_stage_tiles_m = max_swizzle_tiles(16, 2);
+        let max_partition_size_n = max_swizzle_tiles(8, 4);
+        let (rows_per_plane, stage_size_m, partition_size_n) = select_size(
+            MultiRowStrategy::Always(2),
+            16,
+            16,
+            8,
+            65536,
+            128,
+            8,
+            1,
+            max_stage_tiles_m,
+            max_partition_size_n,
+        );
+
+        assert_eq!(rows_per_plane, 2);
+        assert_eq!(stage_size_m, 2);
+        assert_eq!(partition_size_n, 4);
+        assert!(rows_per_plane * stage_size_m * 16 * 2 <= MAX_SWIZZLE_SPAN);
+        assert!(partition_size_n * 8 * 4 <= MAX_SWIZZLE_SPAN);
     }
 }

--- a/crates/cubek-matmul/src/multi_level/tile/variants/instruction/mma/reader.rs
+++ b/crates/cubek-matmul/src/multi_level/tile/variants/instruction/mma/reader.rs
@@ -35,16 +35,25 @@ pub fn mma_load_strided<
 
     let transposed = comptime![as_cmma_layout(layout) != vector_layout];
 
-    match config.load_method(ident) {
-        LoadMethod::Manual => {
-            if transposed {
-                load_manual_transposed(tile, fragment, def, ident, layout);
-            } else {
-                load_manual_plain(tile, fragment, def, ident, layout);
-            }
+    // ldmatrix requires distinct physical rows; a zero stride represents a broadcast.
+    if tile.unvectorized_stride() == 0 {
+        if transposed {
+            load_manual_transposed(tile, fragment, def, ident, layout);
+        } else {
+            load_manual_plain(tile, fragment, def, ident, layout);
         }
-        LoadMethod::LoadMatrix => {
-            load_ldmatrix(tile, fragment, def, transposed, ident, layout, tile_size);
+    } else {
+        match config.load_method(ident) {
+            LoadMethod::Manual => {
+                if transposed {
+                    load_manual_transposed(tile, fragment, def, ident, layout);
+                } else {
+                    load_manual_plain(tile, fragment, def, ident, layout);
+                }
+            }
+            LoadMethod::LoadMatrix => {
+                load_ldmatrix(tile, fragment, def, transposed, ident, layout, tile_size);
+            }
         }
     }
 }


### PR DESCRIPTION
## What

- use a bounded power-of-two N partition when the output is narrower than the available planes
- balance the M stage from tile dimensions and vector widths for that narrow-N case
- preserve existing geometry for non-narrow outputs
- constrain M and N swizzle spans independently so stage sizes remain valid
- load zero-stride broadcast MMA tiles manually because CUDA `ldmatrix` requires distinct physical rows
- cover the motivating biased convolution with a forced MMA regression

For the motivating FP16 implicit GEMM (`M=65536, N=64, K=576`, `16x8x16` instruction), selection changes from `stage_m=16, partition_n=16` to `stage_m=4, partition_n=8`. No workload or GPU model is hardcoded.

## Result

RTX 3070, CUDA, 100 samples:

| Selector | Median |
| --- | ---: |
| Existing inferred selector | 398.910 us |
| Narrow-N inferred selector | 191.570 us |

The isolated timing remains bias-free so it measures selector geometry directly. Bias correctness is covered separately by the new regression and Etive validation. The external cuDNN reference is approximately 139 us.

## Correctness

The selector exposed a latent accumulator initialization defect: convolution bias is represented as a zero-row-stride broadcast tile, which cannot be loaded correctly with `ldmatrix`. Zero-stride MMA sources now use the existing manual fragment loader.

Validation on an RTX 3070:

- exact biased `16x8x16` MMA regression on the current PR head and CubeCL `a30c2e3`
- serial and pipelined Etive weekend-model regressions, 16 iterations each
- full 4,096-game Etive self-play run: 28,492,548 evaluations and 4,096 unique games
- Compute Sanitizer memcheck: 0 errors

## Validation

- `git diff --check`
- `cargo test -p cubek-matmul --lib` (22 passed)
- `cargo test -p cubek-convolution --test lib` (14 passed)
- `cargo clippy -p cubek-matmul -p cubek-convolution --all-targets -- -D warnings`
- `cargo test --release -p cubek-convolution --test lib --features heavy,cubecl/cuda simple_n64_mma_with_bias`

This remains a draft pending a broader current-main GPU shape sweep.