### PR TITLE
fix(matmul): read each extent off the rank of the shape it belongs to

### DIFF
--- a/crates/cubek-matmul/src/definition/base.rs
+++ b/crates/cubek-matmul/src/definition/base.rs
@@ -91,7 +91,6 @@ impl MatmulProblem {
         lhs_scheme: Option<&QuantScheme>,
         rhs_scheme: Option<&QuantScheme>,
     ) -> Result<Self, MatmulSetupError> {
-        let rank = out_shape.len();
         let lhs_layout =
             MatrixLayout::from_shape_and_strides(&lhs_shape, &lhs_strides, lhs_scheme)?;
         let rhs_layout =
@@ -99,9 +98,16 @@ impl MatmulProblem {
         let out_layout = MatrixLayout::from_shape_and_strides(&out_shape, &out_strides, None)?;
 
         Ok(Self {
-            m: lhs_shape[rank - 2],
-            n: rhs_shape[rank - 1],
-            k: lhs_shape[rank - 1],
+            // Each extent read off the rank of the shape it belongs to, which
+            // is what the batch lines below already do. Taking one rank from
+            // the *output* and indexing the operands with it is the same
+            // number only while every rank agrees, and out of bounds when they
+            // do not: a folded projection contracts a rank-2 `[rows, k]` and
+            // reshapes the product to `[batch, seq, n]`, so `lhs_shape[2]` of a
+            // length-2 shape is the panic rather than the wrong answer.
+            m: lhs_shape[lhs_shape.len() - 2],
+            n: rhs_shape[rhs_shape.len() - 1],
+            k: lhs_shape[lhs_shape.len() - 1],
             lhs_batches: lhs_shape[..lhs_shape.len() - 2].into(),
             rhs_batches: rhs_shape[..rhs_shape.len() - 2].into(),
             out_batches: out_shape[..out_shape.len() - 2].into(),


### PR DESCRIPTION
`MatmulProblem::from_shapes_and_strides` took one `rank` from the *output's* shape and indexed the operands with it, while the three lines below it read each shape's own length for the batches. The two agree only while every rank agrees.

Where they do not, it is an out-of-bounds index rather than a wrong answer. A folded projection is the ordinary case: the contraction takes a rank-2 `[rows, k]` and the product is reshaped to `[batch, seq, n]`, so `rank` is 3 and `lhs_shape[rank - 1]` reads past the end of a length-2 shape.

Reached through burn's fused matmul, that panic is caught by the write scope, which claims the segment's outputs — so every later operation reading one is skipped, and a decode pass reports a time for work that never ran.
