### PR TITLE
fix(mma): derive the ldmatrix fragment origin from the definition

### DIFF
--- a/crates/cubek-matmul/src/multi_level/tile/variants/instruction/mma/base.rs
+++ b/crates/cubek-matmul/src/multi_level/tile/variants/instruction/mma/base.rs
@@ -339,7 +339,6 @@ pub fn mma_load_lhs_from_shared<E: Numeric, ES: Size, L: Numeric, R: Numeric, A:
         &def,
         MatrixIdent::A,
         matrix_layout,
-        tile_size,
         mma_io_config,
     );
 }
@@ -360,7 +359,6 @@ pub fn mma_load_rhs_from_shared<E: Numeric, ES: Size, R: Numeric, L: Numeric, A:
         &def,
         MatrixIdent::B,
         matrix_layout,
-        tile_size,
         mma_io_config,
     );
 }
@@ -381,7 +379,6 @@ pub fn mma_load_acc_from_shared<E: Numeric, ES: Size, A: Numeric, L: Numeric, R:
         &def,
         MatrixIdent::Accumulator,
         matrix_layout,
-        tile_size,
         mma_io_config,
     );
 }

--- a/crates/cubek-matmul/src/multi_level/tile/variants/instruction/mma/reader.rs
+++ b/crates/cubek-matmul/src/multi_level/tile/variants/instruction/mma/reader.rs
@@ -3,14 +3,11 @@ use cubecl::{
     prelude::*,
 };
 
-use crate::multi_level::{
-    TileSize,
-    tile::{
-        StridedTile,
-        variants::{LoadMethod, MmaIOConfig},
-    },
+use crate::multi_level::tile::{
+    StridedTile,
+    variants::{LoadMethod, MmaIOConfig},
 };
-use cubek_std::{MatrixLayout, as_cmma_layout, from_cmma_layout};
+use cubek_std::{MatrixLayout, as_cmma_layout};
 
 /// Load an MMA fragment from a strided tile.
 #[cube]
@@ -28,7 +25,6 @@ pub fn mma_load_strided<
     def: &MmaDefinition<A, B, CD>,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
-    #[comptime] tile_size: TileSize,
     #[comptime] config: MmaIOConfig,
 ) {
     let vector_layout = def.vector_layout(ident);
@@ -44,7 +40,7 @@ pub fn mma_load_strided<
             }
         }
         LoadMethod::LoadMatrix => {
-            load_ldmatrix(tile, fragment, def, transposed, ident, layout, tile_size);
+            load_ldmatrix(tile, fragment, def, transposed, ident, layout);
         }
     }
 }
@@ -147,7 +143,6 @@ fn load_ldmatrix<E: Numeric, N: Size, V: Numeric, NV: Size, A: Numeric, B: Numer
     #[comptime] transposed: bool,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
-    #[comptime] tile_size: TileSize,
 ) {
     let stage_vector_size = tile.container.vector_size().comptime();
     let stride = tile.unvectorized_stride();
@@ -156,8 +151,7 @@ fn load_ldmatrix<E: Numeric, N: Size, V: Numeric, NV: Size, A: Numeric, B: Numer
     let num_regs = def.vectors_per_lane(ident);
     let width = (16 / elem_size / stage_vector_size) as u32;
 
-    let start =
-        ldmatrix_offset::<V, A, B, CD>(stride, def, stage_vector_size, ident, layout, tile_size);
+    let start = ldmatrix_offset::<V, A, B, CD>(stride, def, stage_vector_size, ident, layout);
     let start = tile.stage_offset(start);
 
     let row_slice = &tile.container[start as usize..(start + width) as usize];
@@ -169,8 +163,7 @@ fn load_ldmatrix<E: Numeric, N: Size, V: Numeric, NV: Size, A: Numeric, B: Numer
     }
 }
 
-/// This logic is horrible and hard to reason about, and very hardcoded. But can't figure out a
-/// better way to do it.
+/// Where in the stage lane `UNIT_POS_PLANE` starts its `ldmatrix` row.
 #[cube]
 pub(crate) fn ldmatrix_offset<E: Numeric, A: Numeric, B: Numeric, CD: Numeric>(
     stride: u32,
@@ -178,41 +171,23 @@ pub(crate) fn ldmatrix_offset<E: Numeric, A: Numeric, B: Numeric, CD: Numeric>(
     #[comptime] stage_vector_size: VectorSize,
     #[comptime] ident: MatrixIdent,
     #[comptime] layout: MatrixLayout,
-    #[comptime] tile_size: TileSize,
 ) -> u32 {
-    let expected_layout = from_cmma_layout(def.vector_layout(ident)).comptime();
     let (stride_row, stride_col) = match layout {
         MatrixLayout::RowMajor => (stride, 1),
         MatrixLayout::ColMajor => (1, stride),
     };
 
-    let elem_size = E::size().comptime();
     let num_regs = def.vectors_per_lane(ident).comptime() as u32;
-    let width = 16 / elem_size as u32;
-    // Height is always 8, and lanes are divided into blocks of 8.
+    let vector_size = def.vector_size(ident).comptime() as u32;
+    // Lanes are divided into blocks of 8, one per row of the sub-matrix.
     let height = 8;
-
-    let (total_rows, total_cols) = match ident {
-        MatrixIdent::A => (tile_size.m(), tile_size.k()),
-        MatrixIdent::B => (tile_size.k(), tile_size.n()),
-        MatrixIdent::Accumulator => (tile_size.m(), tile_size.n()),
-    };
-    // tile is treated as row-major, if col-major the tile shape is just inverted
-    let total_cols = match expected_layout {
-        MatrixLayout::RowMajor => total_cols,
-        MatrixLayout::ColMajor => total_rows,
-    };
 
     //  Indices are wrapped for < 4 registers.
     let lane = UNIT_POS_PLANE;
     let sub_lane = lane % height;
     let nth_matrix = lane / height % num_regs;
 
-    let tiles_col = total_cols / height;
-
-    // Tiles are arranged in column-major fashion
-    let row_offs = (nth_matrix % tiles_col) * 8;
-    let col_offs = (nth_matrix / tiles_col) * width;
+    let (row_offs, col_offs) = def.position_of_nth(0, nth_matrix * vector_size, ident);
 
     let (row, col) = match layout {
         MatrixLayout::RowMajor => (row_offs + sub_lane, col_offs),


### PR DESCRIPTION
## Issue

`ldmatrix_offset` recomputes, from raw tile extents, the origin of the 8-row sub-matrix that a lane's `ldmatrix` register belongs to. `MmaDefinition` already owns that mapping, and re-deriving it introduces a free parameter — **which extent to divide** — that is currently resolved wrongly for the A fragment.

The divisor must be the number of sub-matrices **down a column**, since the sub-matrices tile the fragment column-major (as the comment directly above the code says). The current expression divides the *column* extent, selected via the fragment's `vector_layout`:

```rust
let total_cols = match expected_layout {           // fragment layout, not stage layout
    MatrixLayout::RowMajor => total_cols,
    MatrixLayout::ColMajor => total_rows,
};
let tiles_col = total_cols / height;               // <-- the free parameter
let row_offs = (nth_matrix % tiles_col) * 8;
let col_offs = (nth_matrix / tiles_col) * width;
```

`vector_layout` is a per-ident constant (`RowMajor` for A and the accumulator, `ColMajor` for B on CUDA) with no relation to how the stage is stored, so the swap normalises nothing — it silently picks a different axis per ident: `k` for A, `k` for B, `n` for the accumulator. Only B's is right.

**Effect on A:** at `m16n8k8` the divisor becomes `8/8 = 1`, so `row_offs` is pinned to 0 — rows 8-15 of each tile are never addressed — while `col_offs` reaches 8, off the end of an 8-wide tile and into its neighbour.

The error only surfaces when a fragment is **non-square in units of the 8-row sub-matrix**, and which fragment is non-square depends on the instruction shape, hence on the architecture:

| fragment | `m16n8k8` (sm_75) | `m16n8k16` (sm_80+) |
|---|---|---|
| A | 16×8, 2 regs — **wrong** | 16×16, square — every derivation agrees |
| B | 8×8, 1 reg — index vacuous | 16×8, 2 regs — correct today |

`m16n8k8` is the only f16 `mma.sync` shape on sm_75 and `m16n8k16` is sm_80+, so the failing case exists only on Turing.

## The fix

```rust
let (row_offs, col_offs) = def.position_of_nth(0, nth_matrix * vector_size, ident);
let (row, col) = match layout {
    MatrixLayout::RowMajor => (row_offs + sub_lane, col_offs),
    MatrixLayout::ColMajor => (row_offs, col_offs + sub_lane),
};
```

`tile_size` becomes unused and is dropped from `ldmatrix_offset` and the three `mma_load_*_from_shared` call sites, so the extents are gone from the function rather than merely used correctly.

## Why `position_of_nth` is the origin

**What the instruction needs.** `ldmatrix` requires lane `L` to supply the shared-memory address of row `L % 8` of sub-matrix `L / 8`. `sub_lane` already contributes the `L % 8` term, so the only open quantity is the origin of sub-matrix `nth_matrix`.

**Registers and sub-matrices are the same partition.** `ldmatrix` is usable to fill an MMA fragment precisely because the 8×8 blocks it loads are the blocks the fragment's registers hold — one register per sub-matrix for a 16-bit type. So the origin of sub-matrix `n` is the position of the first element of register `n`, which is element index `n * vector_size`.

**Lane 0 selects that origin exactly.** `position_of_nth` is defined by `row_index` / `col_index` in `cubecl-cpp/src/cuda/mma/manual.rs`, where every lane term is `lane_id / 4`, `lane_id % 4` or `lane_id >> 2`. All three vanish at `lane_id = 0`, leaving a pure function of the element index. `ldmatrix`'s own lane-to-row contract *requires* lane 0 to address the origin, so a mapping in which it did not would break the instruction, not just this offset.

Substituting `lane_id = 0` and `i = n * vector_size` gives, for 16-bit types:

| ident | origin of sub-matrix `n` | grid at `m16n8k16` |
|---|---|---|
| A | `(8·(n&1), 8·((n>>1)&1))` | 2 × 2, 4 regs |
| B | `(8·n, 0)` | 2 × 1, 2 regs |
| Accumulator | `(8·(n&1), 0)` | 2 × 1 |

which is what the PTX documentation specifies.

## Verification

Measured with a forced-blueprint reproducer — one tile per partition per stage, so the tile is the fragment — at both stage layouts, on the two architectures that exercise the two non-square cases:

| case | card | before | after |
|---|---|---|---|
| A, `m16n8k8`, row/row | T4, sm_75 | **3309 / 8192 elements wrong** | ok |
| A, `m16n8k8`, row/col | T4, sm_75 | **3338 / 8192 elements wrong** | ok |
| B, `m16n8k16`, row/row | L40S, sm_89 | ok | ok |
| B, `m16n8k16`, row/col | L40S, sm_89 | ok | ok |

Reproducing the sm_75 half additionally requires the `ldmatrix` `.x1` operand fix in https://github.com/tracel-ai/cubecl/pull/1596. Without it, every `m16n8k8` kernel fails in ptxas before this code is reached.

