### PR TITLE
feat(tile): write a Projection one dim at a time, and ask it about a …

### DIFF
--- a/crates/cubek-tile/src/physical/projection/build.rs
+++ b/crates/cubek-tile/src/physical/projection/build.rs
@@ -1,0 +1,333 @@
+//! Writing a [`Projection`] one buffer dim at a time.
+//!
+//! [`Projection::new`] takes two parallel lists — the logical axes and one map per physical
+//! dim — and nothing at the call site says how they relate. This states the same value the
+//! way a reader thinks of it: **one line per buffer dim, in buffer order, each saying what
+//! that dim's index is computed from**. The logical axis list falls out of the dims.
+//!
+//! ```text
+//! Projection::dims()
+//!     .dim(B)                                        // dim 0 = b
+//!     .dim(window(&[(OH, stride), (RH, dilation)]).pad(pad))   // dim 1 = oh·stride + rh·dilation − pad
+//!     .dim(window(&[(OW, stride), (RW, dilation)]).pad(pad))   // dim 2
+//!     .dim(C)                                        // dim 3 = c
+//!     .build()
+//! ```
+//!
+//! Three kinds of dim, and the argument says which:
+//!
+//! * an [`Axis`] — the dim *is* that coordinate;
+//! * [`split`] — several axes cut one dim into blocks, `kb·block + ki`, and cannot land on the
+//!   same cell. Stated in **extents**, coarsest first, so no coefficient is computed by hand;
+//! * [`window`] — several axes slide over one dim, `oh·stride + rh·dilation`, and may land on
+//!   the same cell. Stated in coefficients, because a stride and a dilation *are* the
+//!   coefficients, with [`pad`](WindowDim::pad) for the constant term.
+//!
+//! A storage-tiled axis is the plain axis repeated, coarsest fragment first; the radix each
+//! fragment steps by is read off the buffer at use time, not stated here.
+
+use cubecl::zspace::SmallVec;
+
+use crate::{Axis, Composition, MAX_AXES, PhysicalAxisMap, Projection};
+
+impl Projection {
+    /// Start writing a projection one buffer dim at a time. See the [module doc](self).
+    pub fn dims() -> DimsBuilder {
+        DimsBuilder {
+            physical: SmallVec::new(),
+            spanning: SmallVec::new(),
+        }
+    }
+}
+
+/// A [`Projection`] under construction: the dims stated so far, and any axis the operand is
+/// defined over but addresses with no dim.
+#[derive(Clone, Debug)]
+pub struct DimsBuilder {
+    physical: SmallVec<[PhysicalAxisMap; MAX_AXES]>,
+    spanning: SmallVec<[Axis; MAX_AXES]>,
+}
+
+impl DimsBuilder {
+    /// The next buffer dim, coarsest first: an [`Axis`], a [`split`], or a [`window`].
+    pub fn dim(mut self, dim: impl Into<PhysicalAxisMap>) -> Self {
+        self.physical.push(dim.into());
+        self
+    }
+
+    /// An axis this operand is defined over and constant along — addressed by no dim. One scale
+    /// covering a block of the contraction is this, and so is a grouped-query cache, which spans
+    /// the query group without distinguishing its members.
+    pub fn spanning(mut self, axis: Axis) -> Self {
+        self.spanning.push(axis);
+        self
+    }
+
+    /// The projection, with its logical axes derived from the dims.
+    ///
+    /// The order is the one [`Projection::validate`] requires and nothing else: the innermost
+    /// dim's axes come **last**, because that dim is addressed in vector lines and the line runs
+    /// along the operand's last logical axis. Every other axis follows first mention, and a
+    /// [`spanning`](Self::spanning) axis sits after the addressed ones but before the innermost
+    /// dim's, so it never takes the line position.
+    ///
+    /// # Panics
+    ///
+    /// On no dims at all, or on an axis that is both [`spanning`](Self::spanning) and addressed
+    /// by a dim — the two are contradictory claims about the same coordinate.
+    pub fn build(self) -> Projection {
+        assert!(
+            !self.physical.is_empty(),
+            "Projection::dims: an operand has at least one dim"
+        );
+        let (innermost, outer) = self.physical.split_last().expect("checked non-empty");
+        let mut axes: SmallVec<[Axis; MAX_AXES]> = SmallVec::new();
+        let mention = |axis: Axis, axes: &mut SmallVec<[Axis; MAX_AXES]>| {
+            if !axes.contains(&axis) {
+                axes.push(axis);
+            }
+        };
+        for map in outer {
+            for term in map.terms() {
+                mention(term.axis, &mut axes);
+            }
+        }
+        for &axis in &self.spanning {
+            assert!(
+                !self.physical.iter().any(|map| map.addresses(axis)),
+                "Projection::dims: {axis:?} is stated as spanning (addressed by no dim) but a dim \
+                 addresses it"
+            );
+            mention(axis, &mut axes);
+        }
+        // Last, so the line runs along it. A term already mentioned by an outer dim is a
+        // storage-tiled axis whose finest fragment this is; it keeps its earlier position, and
+        // `validate` accepts that because such a projection is invertible.
+        for term in innermost.terms() {
+            mention(term.axis, &mut axes);
+        }
+        Projection::new(&axes, &self.physical)
+    }
+}
+
+/// A dim that *is* one coordinate: `.dim(K)`.
+impl From<Axis> for PhysicalAxisMap {
+    fn from(axis: Axis) -> Self {
+        PhysicalAxisMap::of(axis)
+    }
+}
+
+/// One dim cut into blocks by several axes, stated in **extents**, coarsest first:
+/// `split(&[(KB, blocks), (KI, block)])` is `kb·block + ki`.
+///
+/// The coefficients are derived — each axis steps by the product of the extents finer than it
+/// — so the caller states the sizes it already knows and never a stride-within-a-dim. And
+/// because they are derived that way, no two positions can share a cell: this is
+/// [`Composition::Disjoint`] by construction, which is what keeps every window dense and every
+/// read on the direct path.
+///
+/// # Panics
+///
+/// On no terms, or on an extent of zero.
+pub fn split(extents: &[(Axis, usize)]) -> PhysicalAxisMap {
+    assert!(
+        !extents.is_empty(),
+        "split: a dim is cut by at least one axis"
+    );
+    let mut terms: SmallVec<[(Axis, usize); MAX_AXES]> = SmallVec::new();
+    let mut coefficient = 1;
+    for &(axis, extent) in extents.iter().rev() {
+        assert!(extent > 0, "split: {axis:?} has extent 0");
+        terms.push((axis, coefficient));
+        coefficient *= extent;
+    }
+    terms.reverse();
+    PhysicalAxisMap::disjoint(&terms)
+}
+
+/// One dim several axes slide over, stated in **coefficients**:
+/// `window(&[(OH, stride), (RH, dilation)])` is `oh·stride + rh·dilation`, and
+/// [`.pad(p)`](WindowDim::pad) subtracts the padding.
+///
+/// Consecutive windows may overlap — that is what a receptive field is — so this is
+/// [`Composition::Overlapping`], and the aliasing checks leave it alone.
+pub fn window(coefficients: &[(Axis, usize)]) -> WindowDim {
+    WindowDim {
+        coefficients: SmallVec::from_slice(coefficients),
+        pad: 0,
+    }
+}
+
+/// A [`window`] before its padding is stated. Converts into the dim's map directly, at zero
+/// padding, or after [`pad`](Self::pad).
+#[derive(Clone, Debug)]
+pub struct WindowDim {
+    coefficients: SmallVec<[(Axis, usize); MAX_AXES]>,
+    pad: usize,
+}
+
+impl WindowDim {
+    /// How many cells before the buffer's first this window's origin sits: the padding, which
+    /// a boundary guard reads as zero.
+    pub fn pad(mut self, pad: usize) -> Self {
+        self.pad = pad;
+        self
+    }
+}
+
+impl From<WindowDim> for PhysicalAxisMap {
+    fn from(window: WindowDim) -> Self {
+        let map = PhysicalAxisMap::affine_with_offset(&window.coefficients, -(window.pad as isize));
+        debug_assert!(
+            window.coefficients.len() == 1 || map.composition() == Composition::Overlapping,
+            "a window over several axes takes the overlapping reading"
+        );
+        map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Offset;
+
+    const B: Axis = Axis(0);
+    const H: Axis = Axis(1);
+    const G: Axis = Axis(2);
+    const T: Axis = Axis(3);
+    const D: Axis = Axis(4);
+    const K: Axis = Axis(5);
+    const N: Axis = Axis(6);
+    const KB: Axis = Axis(7);
+    const KI: Axis = Axis(8);
+    const OH: Axis = Axis(9);
+    const RH: Axis = Axis(10);
+    const C: Axis = Axis(11);
+    const M: Axis = Axis(12);
+
+    /// One dim's index for a coordinate: `Σ axis·coefficient + offset` — the projection,
+    /// evaluated, so each case below checks arithmetic rather than describing it.
+    fn index(p: &Projection, dim: usize, coordinate: &[(Axis, usize)]) -> isize {
+        let sum: usize = coordinate
+            .iter()
+            .map(|&(axis, at)| at * p.scale(dim, axis))
+            .sum();
+        let offset = match p.offset(dim) {
+            Offset::Static(o) => o,
+            Offset::Dynamic => unreachable!("nothing here builds a dynamic offset"),
+        };
+        sum as isize + offset
+    }
+
+    #[test]
+    fn one_axis_per_dim_is_direct() {
+        let p = Projection::dims().dim(K).dim(N).build();
+        assert_eq!(p, Projection::direct(&[K, N]));
+    }
+
+    /// `kb·32 + ki`, stated as extents: 4 blocks of 32. The coefficients are derived, and
+    /// `k = 100` lands at block 3, position 4.
+    #[test]
+    fn split_derives_the_coefficients_from_extents() {
+        let p = Projection::dims()
+            .dim(N)
+            .dim(split(&[(KB, 4), (KI, 32)]))
+            .build();
+
+        assert_eq!(p.scale(1, KB), 32);
+        assert_eq!(p.scale(1, KI), 1);
+        assert_eq!(index(&p, 1, &[(KB, 3), (KI, 4)]), 100);
+        assert_eq!(p.composition(), Composition::Disjoint);
+        // The innermost dim's axes are last, its finest term last of all.
+        assert_eq!(p.logical_axes(), &[N, KB, KI]);
+    }
+
+    /// A three-way split multiplies through: `(a, b, c)` over extents `(2, 3, 5)` steps by
+    /// `15, 5, 1`.
+    #[test]
+    fn split_composes_more_than_two_axes() {
+        let p = Projection::dims()
+            .dim(split(&[(B, 2), (H, 3), (D, 5)]))
+            .build();
+        assert_eq!(p.scale(0, B), 15);
+        assert_eq!(p.scale(0, H), 5);
+        assert_eq!(p.scale(0, D), 1);
+        assert_eq!(index(&p, 0, &[(B, 1), (H, 2), (D, 4)]), 29);
+    }
+
+    /// Split-merge partials, group-major: `g·splits + t`, so a group member's slices are
+    /// adjacent. The other choice is a one-line change and a different kernel.
+    #[test]
+    fn a_partition_in_the_middle_keeps_the_innermost_last() {
+        let (group, splits) = (4, 8);
+        let p = Projection::dims()
+            .dim(B)
+            .dim(H)
+            .dim(split(&[(G, group), (T, splits)]))
+            .dim(D)
+            .build();
+
+        assert_eq!(index(&p, 2, &[(G, 2), (T, 5)]), 21);
+        assert_eq!(index(&p, 2, &[(G, 2), (T, 6)]), 22);
+        assert_eq!(p.logical_axes(), &[B, H, G, T, D]);
+    }
+
+    /// `oh·2 + rh·1 − 1`: adjacent output steps overlap, and `oh = 0` reaches into the pad.
+    #[test]
+    fn window_is_an_overlapping_affine_map_with_padding() {
+        let p = Projection::dims()
+            .dim(B)
+            .dim(window(&[(OH, 2), (RH, 1)]).pad(1))
+            .dim(C)
+            .build();
+
+        assert_eq!(index(&p, 1, &[(OH, 3), (RH, 2)]), 7);
+        assert_eq!(index(&p, 1, &[(OH, 4), (RH, 0)]), 7);
+        assert_eq!(index(&p, 1, &[(OH, 0), (RH, 0)]), -1);
+        assert_eq!(p.composition(), Composition::Overlapping);
+        assert_eq!(p.logical_axes(), &[B, OH, RH, C]);
+    }
+
+    /// A grouped-query cache: `g` is in the coordinate and in no dim, and it must not take the
+    /// line position — the innermost dim's axis stays last.
+    #[test]
+    fn a_spanning_axis_sits_before_the_innermost() {
+        let p = Projection::dims()
+            .dim(B)
+            .dim(H)
+            .dim(T)
+            .dim(D)
+            .spanning(G)
+            .build();
+
+        assert!(!p.addresses(G));
+        assert_eq!(p.logical_axes(), &[B, H, T, G, D]);
+        // The rule `validate` enforces, checked here so a builder cannot produce a projection
+        // the bind refuses.
+        p.validate(4);
+    }
+
+    /// Storage tiling is the plain axis repeated, coarsest fragment first. The logical list
+    /// keeps each axis once, at its first mention.
+    #[test]
+    fn a_repeated_axis_is_storage_tiled() {
+        let p = Projection::dims()
+            .dim(B)
+            .dim(M)
+            .dim(K)
+            .dim(M)
+            .dim(K)
+            .dim(C)
+            .build();
+
+        assert_eq!(p.logical_axes(), &[B, M, K, C]);
+        assert_eq!(p.tiling().fragments(1), 2);
+        assert_eq!(p.tiling().fragments(3), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "stated as spanning")]
+    fn spanning_an_addressed_axis_is_refused() {
+        let _ = Projection::dims().dim(B).dim(D).spanning(D).build();
+    }
+}

--- a/crates/cubek-tile/src/physical/projection/mod.rs
+++ b/crates/cubek-tile/src/physical/projection/mod.rs
@@ -18,18 +18,28 @@
 //! So a physical axis is an affine combination of logical axes, and consecutive windows along `Oh`
 //! overlap by the receptive field. [`Projection`] is that combination;
 //! [`direct`](Projection::direct) is the degenerate one every current operand uses.
+//!
+//! A projection is written one buffer dim at a time ([`Projection::dims`], in [`build`]) and,
+//! once the buffer's real extents and strides are in hand, asked which axis is contiguous, how
+//! far an axis steps, and whether the dims alias or run out of order ([`query`]). It holds no
+//! extents and no strides of its own: which dim carries `k` is a fact about the operand, and
+//! how far `k` steps is a fact about the allocation, and they arrive from different places.
 
 mod base;
+mod build;
 mod carrier;
 mod compact;
 mod fold;
 mod map;
+mod query;
 mod tiling;
 
 pub use base::*;
+pub use build::*;
 pub use compact::*;
 pub use fold::*;
 pub use map::*;
+pub use query::*;
 pub use tiling::*;
 
 /// Shared by the two places a set of coefficients has a common factor worth taking out:

--- a/crates/cubek-tile/src/physical/projection/query.rs
+++ b/crates/cubek-tile/src/physical/projection/query.rs
@@ -1,0 +1,448 @@
+//! The questions a launch asks of a [`Projection`] once it has the buffer's real extents and
+//! strides in hand — its [`Geometry`].
+//!
+//! A projection holds neither: which dim carries `k` is a fact about the operand, how far `k`
+//! steps is a fact about the allocation, and they arrive from different places. So every
+//! question here takes both. The ones that exist are the ones the launches actually ask:
+//!
+//! * [`contiguous`](Projection::contiguous) — which axis the unit-strided dim carries. This is
+//!   all that "row-major" and "col-major" ever meant for a rank-2 operand, and it is a question
+//!   about the layout *and* the buffer, never about the layout alone.
+//! * [`stride_of`](Projection::stride_of) — how far an axis steps, off the allocation rather
+//!   than the shape, because a pitched allocator pads a row past its extent.
+//! * [`is_addressable`](Projection::is_addressable) — whether two positions can land on one
+//!   cell. The question a launch asks before deciding to copy an operand.
+//! * [`is_ordered`](Projection::is_ordered) — whether the dims run in the order they are named.
+//!   A permuted buffer is a bijection, so it passes the last test and fails this one; a kernel
+//!   that walks strides positionally needs this, not that.
+//! * [`in_buffer_order`](Projection::in_buffer_order) — the same buffer with its dims named in
+//!   the order they actually step, which is what re-expressing a transposed view is.
+//! * [`verify`](Projection::verify) — all of the above that must hold, plus that every axis
+//!   multiplies back to its extent, as one check with one error.
+
+use core::fmt::{self, Display, Formatter};
+
+use cubecl::zspace::SmallVec;
+
+use crate::{Axis, Composition, Geometry, MAX_AXES, PhysicalAxisMap, Projection};
+
+/// Why a [`Projection`] does not describe the buffer it was checked against. Carries the value
+/// that decided it, so a message names the number a reader would otherwise go looking for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectionMisfit {
+    /// The buffer has a different number of dims than the projection addresses.
+    Rank { expected: usize, actual: usize },
+    /// A disjoint projection whose dims alias: some dim's stride is shorter than the span of
+    /// everything finer than it, so two coordinates address one cell. Padding — a stride
+    /// *longer* than that span — is fine and expected.
+    Aliases {
+        dim: usize,
+        stride: usize,
+        span: usize,
+    },
+    /// An axis whose dims do not multiply back to its extent — a storage-tiled axis whose
+    /// fragments were mis-stated, or a shape that is not this problem's.
+    Extent {
+        axis: Axis,
+        expected: usize,
+        actual: usize,
+    },
+}
+
+impl Display for ProjectionMisfit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Rank { expected, actual } => write!(
+                f,
+                "the projection addresses {expected} dims, the buffer has {actual}"
+            ),
+            Self::Aliases { dim, stride, span } => write!(
+                f,
+                "dim {dim} strides by {stride}, shorter than the {span} its finer dims span, so \
+                 two positions would address one cell"
+            ),
+            Self::Extent {
+                axis,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "{axis:?} has extent {expected}, but its dims multiply to {actual}"
+            ),
+        }
+    }
+}
+
+impl Projection {
+    /// The axes carried by the buffer's unit-strided dim, or none where no dim strides by one.
+    ///
+    /// Several come back from a windowed dim, which is the honest answer: a convolution's
+    /// innermost spatial dim is addressed by an output step and a tap together.
+    pub fn contiguous(&self, geometry: &Geometry) -> SmallVec<[Axis; MAX_AXES]> {
+        match self.unit_dim(geometry) {
+            None => SmallVec::new(),
+            Some(dim) => self
+                .logical_axes()
+                .iter()
+                .copied()
+                .filter(|&axis| self.physical_axis(dim).addresses(axis))
+                .collect(),
+        }
+    }
+
+    /// The stride `axis` steps by: its coarsest dim's, in scalars, off the allocation.
+    ///
+    /// # Panics
+    ///
+    /// If this operand does not address `axis` — a spanning axis has no stride, and asking for
+    /// one is a staging bug rather than a layout to serve.
+    pub fn stride_of(&self, axis: Axis, geometry: &Geometry) -> usize {
+        let dim = (0..self.physical_rank())
+            .find(|&dim| self.physical_axis(dim).addresses(axis))
+            .unwrap_or_else(|| panic!("Projection::stride_of: {axis:?} addresses no dim"));
+        geometry.strides()[dim]
+    }
+
+    /// Whether the buffer's dims can be addressed without two positions landing on one cell.
+    ///
+    /// Ordered by stride, each dim must step by at least the span of everything finer than it.
+    /// Equality is a dense buffer and a larger stride is padding; only a *shorter* one aliases.
+    /// An [`Overlapping`](Composition::Overlapping) projection is exempt, because landing twice
+    /// on a cell is what it is for.
+    pub fn is_addressable(&self, geometry: &Geometry) -> bool {
+        self.alias_check(geometry).is_ok()
+    }
+
+    /// Whether the buffer's dims run in the order the projection names them — strides
+    /// non-increasing from the first dim to the last.
+    ///
+    /// A **separate** question from [`is_addressable`](Self::is_addressable): a permutation is
+    /// a bijection, so nothing aliases, but a kernel that walks `strides[0..rank]` positionally
+    /// reads the wrong axis. Being unordered is not a fault — a `[k, n]` view over an `[n, k]`
+    /// buffer is deliberately unordered, and [`in_buffer_order`](Self::in_buffer_order) is how
+    /// it is read as its physical self.
+    pub fn is_ordered(&self, geometry: &Geometry) -> bool {
+        let dims = addressing_dims(geometry);
+        dims.windows(2).all(|pair| {
+            let (_, (_, stride)) = pair[0];
+            let (_, (_, finer)) = pair[1];
+            stride >= finer
+        })
+    }
+
+    /// This projection and buffer with the dims named in the order they actually step,
+    /// coarsest stride first. The same bytes and never a copy.
+    ///
+    /// The logical axes are untouched, because a view changes where the bytes are read, not
+    /// what the operand spans. Both halves move together and come back as a pair, so the map
+    /// and the strides cannot be permuted by hand and drift apart.
+    pub fn in_buffer_order(&self, geometry: &Geometry) -> (Projection, Geometry) {
+        let mut order: SmallVec<[usize; MAX_AXES]> = (0..self.physical_rank()).collect();
+        order.sort_by_key(|&dim| core::cmp::Reverse(geometry.strides()[dim]));
+        let maps: SmallVec<[PhysicalAxisMap; MAX_AXES]> = order
+            .iter()
+            .map(|&dim| self.physical_axis(dim).clone())
+            .collect();
+        let dims: SmallVec<[(usize, usize); MAX_AXES]> = order
+            .iter()
+            .map(|&dim| (geometry.shape()[dim], geometry.strides()[dim]))
+            .collect();
+        (
+            Projection::new(self.logical_axes(), &maps),
+            Geometry::of_dims(&dims),
+        )
+    }
+
+    /// Check this projection against a real buffer and the operand's extents.
+    ///
+    /// Three things: the ranks agree, a disjoint projection does not alias, and every axis whose
+    /// dims carry it alone multiplies back to its extent — which is what catches a storage-tiled
+    /// axis whose fragments were mis-stated. A shared dim is exempt from the last, since a
+    /// window's spatial extent is not the product of its output and tap extents.
+    pub fn verify(
+        &self,
+        geometry: &Geometry,
+        extent_of: impl Fn(Axis) -> usize,
+    ) -> Result<(), ProjectionMisfit> {
+        if geometry.rank() != self.physical_rank() {
+            return Err(ProjectionMisfit::Rank {
+                expected: self.physical_rank(),
+                actual: geometry.rank(),
+            });
+        }
+        self.alias_check(geometry)?;
+        for &axis in self.logical_axes() {
+            let carriers: SmallVec<[usize; MAX_AXES]> = (0..self.physical_rank())
+                .filter(|&dim| self.physical_axis(dim).addresses(axis))
+                .collect();
+            // Only where every carrier carries this axis alone: a shared dim's extent belongs
+            // to the split or the window, not to one axis.
+            let exclusive = carriers
+                .iter()
+                .all(|&dim| self.physical_axis(dim).terms().len() == 1);
+            if carriers.is_empty() || !exclusive {
+                continue;
+            }
+            let actual: usize = carriers.iter().map(|&dim| geometry.shape()[dim]).product();
+            let expected = extent_of(axis);
+            if actual != expected {
+                return Err(ProjectionMisfit::Extent {
+                    axis,
+                    expected,
+                    actual,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// The buffer's contiguous dim — the innermost unit-strided one.
+    fn unit_dim(&self, geometry: &Geometry) -> Option<usize> {
+        by_stride(geometry)
+            .into_iter()
+            .filter(|&(_, (_, stride))| stride == 1)
+            .map(|(dim, _)| dim)
+            .next_back()
+    }
+
+    /// The aliasing check both predicates rest on, keeping the dim index so the error can
+    /// name it.
+    fn alias_check(&self, geometry: &Geometry) -> Result<(), ProjectionMisfit> {
+        if self.composition() == Composition::Overlapping {
+            return Ok(());
+        }
+        for pair in by_stride(geometry).windows(2) {
+            let (dim, (_, stride)) = pair[0];
+            let (_, (finer_extent, finer_stride)) = pair[1];
+            let span = finer_extent * finer_stride;
+            if stride < span {
+                return Err(ProjectionMisfit::Aliases { dim, stride, span });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The dims that actually address something, as `(index, (extent, stride))`, in the buffer's
+/// own order.
+///
+/// A dim of extent one reaches exactly one cell whatever its stride, and a stride-zero dim is a
+/// broadcast that aliases on purpose; neither takes part in the orderings the checks rest on.
+fn addressing_dims(geometry: &Geometry) -> SmallVec<[(usize, (usize, usize)); MAX_AXES]> {
+    geometry
+        .dims()
+        .enumerate()
+        .filter(|&(_, (extent, stride))| extent > 1 && stride > 0)
+        .collect()
+}
+
+/// The addressing dims coarsest stride first. Ordering by stride rather than by position is
+/// what makes a transposed view and its physical self answer the same.
+fn by_stride(geometry: &Geometry) -> SmallVec<[(usize, (usize, usize)); MAX_AXES]> {
+    let mut dims = addressing_dims(geometry);
+    dims.sort_by_key(|&(_, (_, stride))| core::cmp::Reverse(stride));
+    dims
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::split;
+
+    const K: Axis = Axis(0);
+    const N: Axis = Axis(1);
+    const B: Axis = Axis(2);
+    const H: Axis = Axis(3);
+    const S: Axis = Axis(4);
+    const D: Axis = Axis(5);
+    const M: Axis = Axis(6);
+    const C: Axis = Axis(7);
+    const G: Axis = Axis(8);
+    const T: Axis = Axis(9);
+
+    fn geometry(dims: &[(usize, usize)]) -> Geometry {
+        Geometry::of_dims(dims)
+    }
+
+    /// A `[k, n]` view over an `[n, k]` buffer: `k` strides by one, `n` by the row. The whole
+    /// of what a `Col` variant used to say, read off the strides instead.
+    #[test]
+    fn a_col_weight_is_k_contiguous() {
+        let p = Projection::direct(&[K, N]);
+        let g = geometry(&[(4096, 1), (11008, 4096)]);
+
+        assert_eq!(p.contiguous(&g).as_slice(), &[K]);
+        assert_eq!(p.stride_of(N, &g), 4096);
+        assert_eq!(p.stride_of(K, &g), 1);
+        // Declared `[k, n]` over an `[n, k]` buffer: a view, not a fault.
+        assert!(!p.is_ordered(&g));
+    }
+
+    #[test]
+    fn a_row_weight_is_n_contiguous() {
+        let p = Projection::direct(&[K, N]);
+        let g = geometry(&[(4096, 11008), (11008, 1)]);
+
+        assert_eq!(p.contiguous(&g).as_slice(), &[N]);
+        assert_eq!(p.stride_of(K, &g), 11008);
+        assert!(p.is_ordered(&g));
+    }
+
+    /// A pitched allocator makes a row longer than its extent: addressable, and every kernel
+    /// walks by the stride rather than the shape to serve it.
+    #[test]
+    fn padding_is_addressable() {
+        let p = Projection::direct(&[K, N]);
+        let padded = geometry(&[(4096, 11136), (11008, 1)]);
+
+        assert!(p.is_addressable(&padded));
+        assert!(
+            p.verify(&padded, |a| if a == K { 4096 } else { 11008 })
+                .is_ok()
+        );
+    }
+
+    /// A stride *shorter* than the row is a narrowed or permuted view, not padding.
+    #[test]
+    fn a_narrowed_row_aliases() {
+        let p = Projection::direct(&[K, N]);
+        let narrowed = geometry(&[(4096, 4096), (11008, 1)]);
+
+        assert!(!p.is_addressable(&narrowed));
+        assert_eq!(
+            p.verify(&narrowed, |a| if a == K { 4096 } else { 11008 }),
+            Err(ProjectionMisfit::Aliases {
+                dim: 0,
+                stride: 4096,
+                span: 11008,
+            })
+        );
+    }
+
+    /// Seven dims over five axes, `m` and `k` each split across two: the tiled axes multiply
+    /// back through their fragments.
+    #[test]
+    fn a_tiled_operand_multiplies_back_to_its_extents() {
+        let p = Projection::dims()
+            .dim(B)
+            .dim(H)
+            .dim(M)
+            .dim(K)
+            .dim(M)
+            .dim(K)
+            .dim(C)
+            .build();
+        let g = geometry(&[
+            (2, 8 * 4 * 64 * 32 * 128 * 16),
+            (8, 4 * 64 * 32 * 128 * 16),
+            (4, 64 * 32 * 128 * 16),
+            (64, 32 * 128 * 16),
+            (32, 128 * 16),
+            (128, 16),
+            (16, 1),
+        ]);
+        let extents = |axis: Axis| match axis {
+            a if a == B => 2,
+            a if a == H => 8,
+            a if a == M => 4 * 32,
+            a if a == K => 64 * 128,
+            a if a == C => 16,
+            _ => unreachable!(),
+        };
+
+        assert_eq!(p.contiguous(&g).as_slice(), &[C]);
+        assert!(p.verify(&g, extents).is_ok());
+
+        // Claim m is 4×32 on a buffer whose fragments are 4×16, and it does not describe it.
+        let mis_stated = geometry(&[
+            (2, 8 * 4 * 64 * 16 * 128 * 16),
+            (8, 4 * 64 * 16 * 128 * 16),
+            (4, 64 * 16 * 128 * 16),
+            (64, 16 * 128 * 16),
+            (16, 128 * 16),
+            (128, 16),
+            (16, 1),
+        ]);
+        assert_eq!(
+            p.verify(&mis_stated, extents),
+            Err(ProjectionMisfit::Extent {
+                axis: M,
+                expected: 128,
+                actual: 64,
+            })
+        );
+    }
+
+    /// A split-merge partials buffer: `g` and `t` share a dim, so neither is checked against
+    /// its own extent — the dim's extent belongs to the split.
+    #[test]
+    fn a_shared_dim_is_exempt_from_the_extent_check() {
+        let p = Projection::dims()
+            .dim(B)
+            .dim(split(&[(G, 4), (T, 8)]))
+            .dim(D)
+            .build();
+        let g = geometry(&[(2, 32 * 128), (32, 128), (128, 1)]);
+        let extents = |axis: Axis| match axis {
+            a if a == B => 2,
+            a if a == G => 4,
+            a if a == T => 8,
+            a if a == D => 128,
+            _ => unreachable!(),
+        };
+        assert!(p.verify(&g, extents).is_ok());
+    }
+
+    /// A capacity-shaped cache, padded by the allocator and written in place. Padding is
+    /// allowed and a permutation is not — and the two are different predicates, because a
+    /// permutation is a bijection and aliases nothing.
+    #[test]
+    fn an_in_place_cache_distinguishes_padding_from_permutation() {
+        let p = Projection::direct(&[B, H, S, D]);
+
+        let padded = geometry(&[(2, 8 * 4096 * 136), (8, 4096 * 136), (4096, 136), (128, 1)]);
+        assert!(p.is_addressable(&padded));
+        assert!(p.is_ordered(&padded));
+
+        let permuted = geometry(&[(2, 8 * 4096 * 128), (8, 128), (4096, 8 * 128), (128, 1)]);
+        assert!(p.is_addressable(&permuted));
+        assert!(!p.is_ordered(&permuted));
+    }
+
+    /// The swapped binding: the buffer read as its physical self, both halves moving together,
+    /// and the same answers because it is the same buffer.
+    #[test]
+    fn in_buffer_order_moves_the_map_and_the_strides_together() {
+        let p = Projection::direct(&[K, N]);
+        let g = geometry(&[(4096, 1), (11008, 4096)]);
+
+        let (physical, moved) = p.in_buffer_order(&g);
+
+        assert_eq!(moved.shape(), &[11008, 4096]);
+        assert_eq!(moved.strides(), &[4096, 1]);
+        assert_eq!(physical.contiguous(&moved).as_slice(), &[K]);
+        assert_eq!(physical.stride_of(N, &moved), 4096);
+        assert_eq!(physical.logical_axes(), p.logical_axes());
+        assert!(physical.is_ordered(&moved));
+
+        // Already in buffer order: nothing moves.
+        let dense = geometry(&[(4096, 11008), (11008, 1)]);
+        assert_eq!(p.in_buffer_order(&dense).1, dense);
+    }
+
+    /// A windowed dim is addressed by two axes, and it is not an aliasing fault that
+    /// consecutive windows overlap — that is what a receptive field is.
+    #[test]
+    fn a_window_is_exempt_from_the_aliasing_check() {
+        let p = Projection::dims()
+            .dim(B)
+            .dim(crate::window(&[(M, 2), (K, 1)]).pad(1))
+            .dim(C)
+            .build();
+        let g = geometry(&[(8, 64 * 32), (64, 32), (32, 1)]);
+
+        assert_eq!(p.composition(), Composition::Overlapping);
+        assert!(p.is_addressable(&g));
+        assert_eq!(p.contiguous(&g).as_slice(), &[C]);
+    }
+}


### PR DESCRIPTION
…buffer

Projection::new takes two parallel lists — the logical axes and one map per physical dim — and nothing at the call site says how they relate. Projection::dims() states the same value the way a reader thinks of it: one line per buffer dim, in buffer order, each saying what that dim's index is computed from. The logical list falls out of the dims, in the one order validate() requires: the innermost dim's axes last, because that dim is addressed in vector lines.

Three kinds of dim, and the argument says which. An Axis is the dim. split(&[(KB, blocks), (KI, block)]) cuts a dim into blocks, stated in extents so no coefficient is computed by hand, and is Disjoint by construction. window(&[(OH, stride), (RH, dilation)]).pad(p) slides several axes over a dim and may overlap. A storage-tiled axis is the plain axis repeated.

The queries are the ones a launch asks once it holds the buffer's real extents and strides, and they take the Geometry rather than storing it: contiguous (which axis the unit-strided dim carries — all row-major and col-major ever meant), stride_of, is_addressable (no two positions on one cell), is_ordered (dims run in the order named — a permutation is a bijection, so it passes the former and fails this), in_buffer_order (a transposed view as its physical self, map and strides moved together), and verify, which folds the checks and the per-axis extent product into one Result.

Proven on cubek's own depthwise-conv projection and on the shapes a consumer has in production: a col weight, a q4 block, split-merge partials, a grouped-query cache, a seven-dim tiled operand.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
