### PR TITLE
chore(deps): follow cubecl's fallible throughput probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "darling",
  "inflections",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
+source = "git+https://github.com/tracel-ai/cubecl?rev=5a9094b8a6a2083725945365b8be8e18bdd596ba#5a9094b8a6a2083725945365b8be8e18bdd596ba"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "darling",
  "inflections",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a79e7166445969389c08e0baad92ff67a91138ca#a79e7166445969389c08e0baad92ff67a91138ca"
+source = "git+https://github.com/tracel-ai/cubecl?rev=4674dd13da8f3dedb169f5b3d117ea1b22d5b754#4674dd13da8f3dedb169f5b3d117ea1b22d5b754"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ version = "0.3.0-pre.3"
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 # cubecl-ir = { path = "../cubecl/crates/cubecl-ir", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754", default-features = false }
-cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "5a9094b8a6a2083725945365b8be8e18bdd596ba", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "5a9094b8a6a2083725945365b8be8e18bdd596ba", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "5a9094b8a6a2083725945365b8be8e18bdd596ba", default-features = false }
+cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "5a9094b8a6a2083725945365b8be8e18bdd596ba", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.3", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ version = "0.3.0-pre.3"
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 # cubecl-ir = { path = "../cubecl/crates/cubecl-ir", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
-cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "a79e7166445969389c08e0baad92ff67a91138ca", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754", default-features = false }
+cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "4674dd13da8f3dedb169f5b3d117ea1b22d5b754", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.3", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.3", default-features = false }

--- a/crates/cubek-matmul/src/definition/cost.rs
+++ b/crates/cubek-matmul/src/definition/cost.rs
@@ -31,7 +31,9 @@ pub fn compute_peak_ops_per_s<R: Runtime>(
     client: &ComputeClient<R>,
     elems: &MatmulElems,
 ) -> Option<f64> {
-    let peak = measure_peak_throughput(client, compute_key(client, elems)).ops_per_s();
+    let peak = measure_peak_throughput(client, compute_key(client, elems))
+        .ok()?
+        .ops_per_s();
 
     (peak > 0.0).then_some(peak)
 }

--- a/crates/cubek-test-utils/src/registry.rs
+++ b/crates/cubek-test-utils/src/registry.rs
@@ -63,13 +63,13 @@ fn curve_ceiling(access: MemoryAccess, bytes: usize) -> f64 {
 /// The unit comes from the key's own mode rather than from the caller, so a
 /// memo keyed on the key alone cannot serve one resource's rate to another.
 ///
-/// Zero when the device has no peak for the key, which leaves the resource
+/// NaN when the device has no peak for the key, which leaves the resource
 /// unscored rather than dividing by a ceiling that does not exist.
 fn peak_per_s(key: ThroughputKey) -> f64 {
     let mut peaks = PEAKS.lock().expect("peaks mutex is not poisoned");
     *peaks.entry(key).or_insert_with(|| {
         let Ok(value) = measure_peak_throughput(&client(), key) else {
-            return 0.0;
+            return f64::NAN;
         };
 
         match key.mode {

--- a/crates/cubek-test-utils/src/registry.rs
+++ b/crates/cubek-test-utils/src/registry.rs
@@ -62,10 +62,16 @@ fn curve_ceiling(access: MemoryAccess, bytes: usize) -> f64 {
 ///
 /// The unit comes from the key's own mode rather than from the caller, so a
 /// memo keyed on the key alone cannot serve one resource's rate to another.
+///
+/// Zero when the device has no peak for the key, which leaves the resource
+/// unscored rather than dividing by a ceiling that does not exist.
 fn peak_per_s(key: ThroughputKey) -> f64 {
     let mut peaks = PEAKS.lock().expect("peaks mutex is not poisoned");
     *peaks.entry(key).or_insert_with(|| {
-        let value = measure_peak_throughput(&client(), key);
+        let Ok(value) = measure_peak_throughput(&client(), key) else {
+            return 0.0;
+        };
+
         match key.mode {
             ThroughputMode::ComputeDirect { .. } | ThroughputMode::ComputeCmma { .. } => {
                 value.ops_per_s()


### PR DESCRIPTION
cubecl#1598 makes `measure_peak_throughput` return `Result<ThroughputValue, ThroughputError>`, so a device that implements no such operation is told apart from one whose timer reported nothing. Both degrade here the way the old zero peak did: the matmul cost model reports no peak, and the bench registry leaves the resource unscored.

Blocked on tracel-ai/cubecl#1598. The rev is pinned to its head and needs repinning once it merges.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
