### PR TITLE
fix(tile): decode e2m1 in software, as every other read of it does

### DIFF
--- a/crates/cubek-tile/src/tile/view/packed.rs
+++ b/crates/cubek-tile/src/tile/view/packed.rs
@@ -10,7 +10,7 @@ use std::marker::PhantomData;
 use cubecl::ir::VectorSize;
 use cubecl::prelude::barrier::Barrier;
 use cubecl::quant::scheme::QuantValue;
-use cubecl_common::e2m1x2;
+use cubecl::std::quant::fp4::e2m1_packed_bits_to_float;
 
 use crate::{FieldDecode, field_decode};
 use cubecl::unexpanded;
@@ -71,11 +71,15 @@ fn unpack_int_line<F: Numeric, NQ: Size, NF: Size>(
     out
 }
 
-/// The `e2m1` fields, reinterpreted a pair at a time.
+/// The `e2m1` fields, decoded a pair at a time.
 ///
-/// The pair is the unit rather than the value: two `e2m1` codes share a byte, and `e2m1x2` is what
-/// the hardware decodes and what the shared software decoder names, so a byte answers two values
-/// in one cast either way. That is [`QuantValue::native_packing`], read here as the loop's step.
+/// The pair is the unit rather than the value: two `e2m1` codes share a byte, which is
+/// [`QuantValue::native_packing`], read here as the loop's step.
+///
+/// Decoded in software, as `cubek-quant`'s field read and cubecl's own quantized view both are.
+/// The `e2m1x2` cast lowers on CUDA alone, so a read reaching for it compiles on one vendor and
+/// dies in codegen everywhere else — on a worker thread, which surfaces as a zeroed output
+/// rather than as an error.
 #[cube]
 fn unpack_fp4_line<F: Numeric, NQ: Size, NF: Size>(words: Vector<u32, NQ>) -> Vector<F, NF> {
     let pair = comptime!(QuantValue::E2M1.native_packing());
@@ -90,7 +94,7 @@ fn unpack_fp4_line<F: Numeric, NQ: Size, NF: Size>(words: Vector<u32, NQ>) -> Ve
         #[unroll]
         for j in 0..bytes {
             let byte = (word >> comptime!((j * 8) as u32)) & 0xff;
-            let values = Vector::<F, Const<2>>::cast_from(e2m1x2::from_bits(byte as u8));
+            let values = e2m1_packed_bits_to_float::<F, Const<2>>(byte);
             out.insert(base + j * pair, values.extract(0usize));
             out.insert(base + j * pair + 1, values.extract(1usize));
         }

--- a/crates/cubek-tile/tests/tile/packed.rs
+++ b/crates/cubek-tile/tests/tile/packed.rs
@@ -125,6 +125,11 @@ fn nvfp4_shaped_matmul<E: Numeric>(
 /// axis, and a block of sixteen against words of eight.
 ///
 /// Nothing in the kernel names the format, the block, or the number of levels.
+///
+/// Every operand here is bound one element wide, so unlike the read tests below this asks nothing
+/// of the device's vector cap and runs everywhere. That matters: the decode it covers is the one
+/// that lowers differently per backend, so a device that skipped this would be the device most
+/// worth running it on.
 #[test]
 fn nvfp4_shaped_decode() {
     let (field, rows, cols, block, blocks) = (QuantValue::E2M1, 4, 4, 16, 2);
@@ -132,14 +137,6 @@ fn nvfp4_shaped_decode() {
     let factor = 32 / field.size_bits();
 
     let client = cubecl::test_device().client();
-    let max = client.properties().hardware.max_vector_size;
-    if factor > max {
-        TestOutcome::Validated(ValidationResult::Skipped(format!(
-            "device vectors cap at {max}, below the {factor}-value word"
-        )))
-        .enforce();
-        return;
-    }
 
     // Every code, cycled, so the whole value ladder and both signs are read back.
     let codes: Vec<u32> = (0..rows * depth).map(|i| (i % 16) as u32).collect();


### PR DESCRIPTION
## What

`unpack_fp4_line` in the packed tile view decoded a byte through `e2m1x2::from_bits`. That cast lowers on CUDA alone, so the view compiled on one vendor and died in codegen everywhere else, on a worker thread, which surfaces as a **zeroed output rather than an error**.

A quantized product against `e2m1` weights on Metal came back all zeros with nothing on the error path.

## Why this decoder

cubecl ships a software `e2m1` decoder for exactly this case, and says so in its module doc: a kernel that reaches for `e2m1x2::from_bits` runs on one vendor, while the arithmetic runs everywhere.

Two readers already follow that:

- cubecl's own quantized view, `cubecl-std/src/quant/dequantize.rs`, whose call site says the cast lowers on CUDA alone and that the software routine is the decoder every quantized read on every backend goes through.
- `cubek-quant`'s field read, `crates/cubek-quant/src/dequantize.rs`, decoded in software "so the read lowers on every backend rather than only where the conversion intrinsic exists".

The tile view was the one reader still asking for the intrinsic. Its doc claimed `e2m1x2` is "what the shared software decoder names", which is not so: that decoder names `u32` nibbles. Reading the byte with `N = 2` gives the low nibble as element 0 and the high one as element 1, which is the order the surrounding loop already assumes.

No dependency change. `cubek-tile` already builds cubecl with `stdlib`.

## Test

`nvfp4_shaped_decode` loses its vector-cap guard. Every operand in that test is bound one element wide, so the guard never applied to it, and skipping meant the one decode that lowers differently per backend went untested on the backends that lower it differently.

Verified on this branch:

| backend | before | after |
|---|---|---|
| `cubecl/metal` (wgpu-MSL) | fails, `at (0, 0): got 0, want -5.125` | passes |
| `cubecl/metal-native` | skipped | passes |

Full `cubek-tile` suite on `cubecl/metal`: 386 pass. `an_i8_operand_contracts_against_its_scales` fails, and it fails identically on a clean `main`, so it is not from this change.

The read tests below `nvfp4_shaped_decode` keep their guard, which is real: they bind an output as wide as the word, and Metal and wgpu cap a vector at four.

## Trade-off

Recent CUDA architectures lose the native cast on this path. Unmeasured. The intrinsic is registered only there, so the software path is what every other device needs regardless, and cubecl already accepted the same trade-off in its own view. Keeping both would need the runtime capability threaded into the view as a comptime flag.

## Downstream

Verified end to end in metabolic on Metal, through a temporary `[patch]`: `gemv_quantized_two_level_matches_reference` passes with this change and fails without it once the `e2m1` arm is admitted. metabolic currently carries a device-capability gate to keep that product off the packed path, which this makes deletable once the rev reaches its pin.