### PR TITLE
fix(bench): prove benchmarks correct before timing, and unify the timing switch

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -82,6 +82,10 @@ fn selects(filter: &[String], id: &str) -> bool {
 /// `CUBEK_BENCH_PROBLEMS` and `CUBEK_BENCH_STRATEGIES` take a comma-separated
 /// list of substrings and run only the ids that contain one. `gemm` alone is
 /// 184 problems against 27 strategies.
+///
+/// `CUBEK_BENCH_TIMING` takes `device` or `system` and overrides what every
+/// category measures with. A device timestamp leaves the launch out, so the two
+/// disagreeing by more than that overhead says the timer misses part of the work.
 pub fn run_category(category: &dyn BenchmarkCategory) {
     use cubecl::benchmark::BenchmarkDurations;
 

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -185,7 +185,7 @@ pub fn run_category(category: &dyn BenchmarkCategory) {
 
     if any_over_peak {
         println!(
-            "note: \"over peak\" rows beat the measured ceiling. The memory probes stream cold, so a working set that stays in cache can exceed them."
+            "note: \"over peak\" rows beat the measured ceiling, which nothing moving the traffic its cost model declares can do. Either the working set stays in cache where the probe streamed cold, or the kernel is not making the pass the model counts. A problem far larger than last-level cache rules the first out and leaves the second, which is a bug in the kernel or in the model, not a fast row."
         );
     }
 }

--- a/crates/cubek-attention/src/eval/backward/benchmarks/benchmark.rs
+++ b/crates/cubek-attention/src/eval/backward/benchmarks/benchmark.rs
@@ -212,10 +212,8 @@ impl<AP: AttentionPrecision> Benchmark for BackwardBench<AP> {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "attention-backward-bench")
-            .map_err(|e| format!("{e:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "attention-backward-bench", || {
+            self.execute(args)
+        })
     }
 }

--- a/crates/cubek-attention/src/eval/backward/benchmarks/benchmark.rs
+++ b/crates/cubek-attention/src/eval/backward/benchmarks/benchmark.rs
@@ -43,7 +43,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-attention/src/eval/forward/benchmarks/benchmark.rs
+++ b/crates/cubek-attention/src/eval/forward/benchmarks/benchmark.rs
@@ -39,7 +39,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-attention/src/eval/forward/benchmarks/benchmark.rs
+++ b/crates/cubek-attention/src/eval/forward/benchmarks/benchmark.rs
@@ -147,10 +147,6 @@ impl<AP: AttentionPrecision> Benchmark for AttentionBench<AP> {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "attention-bench")
-            .map_err(|e| format!("{e:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "attention-bench", || self.execute(args))
     }
 }

--- a/crates/cubek-convolution/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/benchmark.rs
@@ -146,10 +146,6 @@ impl<MP: MatmulPrecision> Benchmark for Conv2dBench<MP> {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "conv-bench")
-            .map_err(|it| format!("{it:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "conv-bench", || self.execute(args))
     }
 }

--- a/crates/cubek-convolution/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/benchmark.rs
@@ -41,7 +41,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-convolution/src/eval/benchmarks/depthwise/benchmark.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/depthwise/benchmark.rs
@@ -110,10 +110,6 @@ impl Benchmark for DepthwiseBench {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "depthwise-bench")
-            .map_err(|it| format!("{it:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "depthwise-bench", || self.execute(args))
     }
 }

--- a/crates/cubek-convolution/src/eval/benchmarks/depthwise/benchmark.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/depthwise/benchmark.rs
@@ -31,7 +31,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-fft/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-fft/src/eval/benchmarks/benchmark.rs
@@ -32,7 +32,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
@@ -139,10 +139,6 @@ impl Benchmark for InterpolateBench {
     /// Measure with device timestamps around the launch, so the reported duration is the
     /// kernel's rather than the host's view of launch, output allocation and sync.
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "interpolate-bench")
-            .map_err(|err| format!("{err:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "interpolate-bench", || self.execute(args))
     }
 }

--- a/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/benchmark.rs
@@ -32,7 +32,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-interpolate/src/eval/benchmarks/mod.rs
+++ b/crates/cubek-interpolate/src/eval/benchmarks/mod.rs
@@ -50,7 +50,7 @@ impl cubek_test_utils::Category for Category {
     }
 
     fn timing_method(&self) -> TimingMethod {
-        TimingMethod::Device
+        cubek_test_utils::timing_method(TimingMethod::Device)
     }
     fn correctness(
         &self,
@@ -105,7 +105,7 @@ impl cubek_test_utils::Category for CpuCategory {
     }
 
     fn timing_method(&self) -> TimingMethod {
-        TimingMethod::Device
+        cubek_test_utils::timing_method(TimingMethod::Device)
     }
 
     fn correctness(

--- a/crates/cubek-matmul/src/eval/benchmarks/gemm/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/gemm/benchmark.rs
@@ -171,10 +171,6 @@ impl Benchmark for GemmBench {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "matmul-bench")
-            .map_err(|err| format!("{err:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "matmul-bench", || self.execute(args))
     }
 }

--- a/crates/cubek-matmul/src/eval/benchmarks/gemm/benchmark.rs
+++ b/crates/cubek-matmul/src/eval/benchmarks/gemm/benchmark.rs
@@ -51,7 +51,7 @@ fn bench_with<MP: MatmulPrecision>(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-matmul/src/multi_level/eval/gemv/benchmark.rs
+++ b/crates/cubek-matmul/src/multi_level/eval/gemv/benchmark.rs
@@ -41,7 +41,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-matmul/src/multi_level/eval/quantized_matmul/benchmark.rs
+++ b/crates/cubek-matmul/src/multi_level/eval/quantized_matmul/benchmark.rs
@@ -45,7 +45,9 @@ pub fn bench(
 
     // Some combos still trigger panics inside kernel expansion; catch them so a
     // single bad entry doesn't kill the whole run.
-    let durations = match catch_unwind(AssertUnwindSafe(|| bench.run(TimingMethod::System))) {
+    let durations = match catch_unwind(AssertUnwindSafe(|| {
+        bench.run(cubek_test_utils::timing_method(TimingMethod::System))
+    })) {
         Ok(res) => res.map_err(|e| format!("benchmark failed: {e}"))?.durations,
         Err(payload) => {
             let msg = payload

--- a/crates/cubek-matmul/src/multi_level/eval/quantized_matmul/benchmark.rs
+++ b/crates/cubek-matmul/src/multi_level/eval/quantized_matmul/benchmark.rs
@@ -297,11 +297,7 @@ impl Benchmark for QuantMatmulBench {
     }
 
     fn profile(&self, args: Self::Input) -> Result<cubecl::benchmark::ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "quant-matmul-bench")
-            .map_err(|err| format!("{err:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "quant-matmul-bench", || self.execute(args))
     }
 }
 

--- a/crates/cubek-matmul/src/tiled/eval/gemm_cpu_tiled/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/gemm_cpu_tiled/mod.rs
@@ -181,11 +181,9 @@ impl Benchmark for TiledBench {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "cpu-gemm-tiled-bench")
-            .map_err(|err| format!("{err:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "cpu-gemm-tiled-bench", || {
+            self.execute(args)
+        })
     }
 }
 

--- a/crates/cubek-matmul/src/tiled/eval/gemm_cpu_tiled/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/gemm_cpu_tiled/mod.rs
@@ -205,7 +205,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-matmul/src/tiled/eval/split_cubes/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/split_cubes/mod.rs
@@ -554,7 +554,7 @@ pub fn bench(
 
     let bound = Bound::new(&client, mapping, *problem).samples(num_samples);
     let durations = bound
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
     Ok(RunSamples::new(durations))
@@ -631,7 +631,7 @@ impl cubek_test_utils::Category for Category {
 
     /// Latency-bound shapes, so the launch is timed on the device rather than around a submit.
     fn timing_method(&self) -> TimingMethod {
-        TimingMethod::Device
+        cubek_test_utils::timing_method(TimingMethod::Device)
     }
 
     fn problems(&self) -> Vec<CatalogEntry<Problem>> {

--- a/crates/cubek-matmul/src/tiled/eval/split_cubes/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/split_cubes/mod.rs
@@ -472,11 +472,7 @@ impl Benchmark for Bound {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "split-cubes-bench")
-            .map_err(|err| format!("{err:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "split-cubes-bench", || self.execute(args))
     }
 }
 

--- a/crates/cubek-matmul/src/tiled/eval/split_k/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/split_k/mod.rs
@@ -386,11 +386,7 @@ impl Benchmark for SplitKBench {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "split-k-bench")
-            .map_err(|err| format!("{err:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "split-k-bench", || self.execute(args))
     }
 }
 

--- a/crates/cubek-matmul/src/tiled/eval/split_k/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/split_k/mod.rs
@@ -499,7 +499,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 
@@ -569,7 +569,7 @@ impl cubek_test_utils::Category for Category {
     /// These shapes are latency-bound, so the launch must be timed on the device rather than
     /// around an async submit; matches the `TimingMethod` [`bench`] actually runs with.
     fn timing_method(&self) -> TimingMethod {
-        TimingMethod::Device
+        cubek_test_utils::timing_method(TimingMethod::Device)
     }
 
     fn problems(&self) -> Vec<CatalogEntry<SplitKProblem>> {

--- a/crates/cubek-matmul/src/tiled/eval/tile_quant_stage/benchmark.rs
+++ b/crates/cubek-matmul/src/tiled/eval/tile_quant_stage/benchmark.rs
@@ -99,7 +99,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
     // The mma contracts in f32; the packed u32 is how the RHS is stored, not what the

--- a/crates/cubek-matmul/src/tiled/eval/tile_quant_stage/benchmark.rs
+++ b/crates/cubek-matmul/src/tiled/eval/tile_quant_stage/benchmark.rs
@@ -218,10 +218,8 @@ impl Benchmark for TileQuantStageBench {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "tile-quant-stage-bench")
-            .map_err(|it| format!("{it:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "tile-quant-stage-bench", || {
+            self.execute(args)
+        })
     }
 }

--- a/crates/cubek-matmul/src/tiled/eval/tile_quant_stage/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/tile_quant_stage/mod.rs
@@ -33,7 +33,7 @@ impl cubek_test_utils::Category for Category {
     }
 
     fn timing_method(&self) -> cubecl::benchmark::TimingMethod {
-        cubecl::benchmark::TimingMethod::Device
+        cubek_test_utils::timing_method(cubecl::benchmark::TimingMethod::Device)
     }
 
     fn problems(&self) -> Vec<CatalogEntry<TileQuantStageProblem>> {

--- a/crates/cubek-pool/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-pool/src/eval/benchmarks/benchmark.rs
@@ -31,7 +31,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-pool/src/eval/benchmarks/mod.rs
+++ b/crates/cubek-pool/src/eval/benchmarks/mod.rs
@@ -48,7 +48,7 @@ impl cubek_test_utils::Category for Category {
     }
 
     fn timing_method(&self) -> TimingMethod {
-        TimingMethod::Device
+        cubek_test_utils::timing_method(TimingMethod::Device)
     }
 
     fn correctness(

--- a/crates/cubek-random/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-random/src/eval/benchmarks/benchmark.rs
@@ -93,11 +93,6 @@ impl Benchmark for RandomBench {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .clone()
-            .profile(|| self.execute(args), "random-bench")
-            .map_err(|it| format!("{it:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "random-bench", || self.execute(args))
     }
 }

--- a/crates/cubek-random/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-random/src/eval/benchmarks/benchmark.rs
@@ -31,7 +31,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::System)
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
@@ -90,6 +90,7 @@ impl Benchmark for ReduceBench {
     fn prepare(&self) -> Self::Input {
         let client = self.device.client();
         let elem = self.value_dtype;
+        let output_elem = crate::eval::cpu_reference::output_dtype_for(&self.config, elem);
 
         let input = TestInput::builder(client.clone(), Shape::from(self.shape.clone()))
             .dtype(elem)
@@ -102,7 +103,7 @@ impl Benchmark for ReduceBench {
             _ => 1,
         };
         shape_out[self.axis] = reduce_len;
-        let out = TensorHandle::empty(&client, shape_out.clone(), elem);
+        let out = TensorHandle::empty(&client, shape_out.clone(), output_elem);
         let indices = TensorHandle::empty(&client, shape_out, u32::elem_type_native());
 
         (input, out, indices)

--- a/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
@@ -193,11 +193,7 @@ impl<E: Float> Benchmark for ReduceBench<E> {
     /// Measure with device timestamps around the launch, so the reported duration
     /// is the kernel's, not the host's view of launch+sync.
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "reduce-bench")
-            .map_err(|err| format!("{err:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "reduce-bench", || self.execute(args))
     }
 
     fn num_samples(&self) -> usize {

--- a/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
@@ -1,9 +1,8 @@
-use std::marker::PhantomData;
-
 use cubecl::{
     benchmark::{Benchmark, ProfileDuration, TimingMethod},
     client::Client,
     future,
+    ir::ElemType,
     prelude::*,
     std::tensor::TensorHandle,
     zspace::Shape,
@@ -22,16 +21,16 @@ pub fn bench(
     let device = cubecl::test_device();
     let client = device.client();
 
-    let bench = ReduceBench::<f32> {
+    let bench = ReduceBench {
         shape: problem.shape.clone(),
         axis: problem.axis,
         config: problem.config,
         kind: problem.kind,
+        value_dtype: problem.precision.dtype(),
         strategy: strategy.clone(),
         device,
         client,
         samples: num_samples,
-        _e: PhantomData,
     };
 
     // Device timing (hardware timestamps) rather than system timing: the reduce
@@ -66,19 +65,19 @@ fn two_launch_configs(
     }
 }
 
-struct ReduceBench<E> {
+struct ReduceBench {
     shape: Vec<usize>,
     axis: usize,
     config: ReduceOperationConfig,
     kind: ReduceBenchKind,
+    value_dtype: ElemType,
     strategy: ReduceStrategy,
     device: cubecl::Device,
     client: Client,
     samples: usize,
-    _e: PhantomData<E>,
 }
 
-impl<E: Float> Benchmark for ReduceBench<E> {
+impl Benchmark for ReduceBench {
     /// `(input, values, indices)`. The index tensor is allocated for every kind so
     /// that allocation never lands inside the timed section, but only the
     /// two-launch and fused kinds write to it.
@@ -87,7 +86,7 @@ impl<E: Float> Benchmark for ReduceBench<E> {
 
     fn prepare(&self) -> Self::Input {
         let client = self.device.client();
-        let elem = E::elem_type_native();
+        let elem = self.value_dtype;
 
         let input = TestInput::builder(client.clone(), Shape::from(self.shape.clone()))
             .dtype(elem)
@@ -107,7 +106,7 @@ impl<E: Float> Benchmark for ReduceBench<E> {
     }
 
     fn execute(&self, (input, out, indices): Self::Input) -> Result<(), String> {
-        let value_dtype = E::elem_type_native();
+        let value_dtype = self.value_dtype;
         let index_dtype = u32::elem_type_native();
         let acc_dtype = f32::elem_type_native();
 
@@ -203,12 +202,7 @@ impl<E: Float> Benchmark for ReduceBench<E> {
     fn name(&self) -> String {
         format!(
             "reduce-axis({})-{}-{:?}-{:?}-{:?}-{:?}",
-            self.axis,
-            E::elem_type_native(),
-            self.shape,
-            self.strategy,
-            self.config,
-            self.kind,
+            self.axis, self.value_dtype, self.shape, self.strategy, self.config, self.kind,
         )
         .to_lowercase()
     }

--- a/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
@@ -11,6 +11,7 @@ use cubek_test_utils::{RunSamples, TestInput};
 
 use crate::ReduceStrategy;
 use crate::components::instructions::ReduceOperationConfig;
+use crate::eval::benchmarks::correctness::ReduceCorrectness;
 use crate::eval::benchmarks::problem::{ReduceBenchKind, ReduceProblem};
 
 pub fn bench(
@@ -18,6 +19,8 @@ pub fn bench(
     problem: &ReduceProblem,
     num_samples: usize,
 ) -> Result<RunSamples, String> {
+    ReduceCorrectness::verify(strategy, problem)?;
+
     let device = cubecl::test_device();
     let client = device.client();
 

--- a/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
@@ -41,7 +41,7 @@ pub fn bench(
     // host-side noise that identical kernels varied by over 10x between runs,
     // which made fused-vs-two-launch comparisons meaningless.
     let durations = bench
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/benchmark.rs
@@ -112,16 +112,12 @@ impl Benchmark for ReduceBench {
     fn execute(&self, (input, out, indices): Self::Input) -> Result<(), String> {
         let value_dtype = self.value_dtype;
         let index_dtype = u32::elem_type_native();
-        let acc_dtype = f32::elem_type_native();
+        let acc_dtype = crate::eval::cpu_reference::accumulation_dtype();
 
         match self.kind {
             ReduceBenchKind::Single => {
-                let output_dtype = match self.config {
-                    ReduceOperationConfig::ArgMax
-                    | ReduceOperationConfig::ArgMin
-                    | ReduceOperationConfig::ArgTopK(_) => index_dtype,
-                    _ => value_dtype,
-                };
+                let output_dtype =
+                    crate::eval::cpu_reference::output_dtype_for(&self.config, value_dtype);
                 crate::reduce(
                     &self.client,
                     input.binding(),

--- a/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
@@ -30,6 +30,7 @@ impl cubek_test_utils::Correctness for ReduceCorrectness {
                 problem.axis,
                 strategy.clone(),
                 problem.config,
+                problem.precision.dtype(),
                 seeds[0],
             ),
             ReduceBenchKind::Fused => strategy_result_with_indices(
@@ -38,6 +39,7 @@ impl cubek_test_utils::Correctness for ReduceCorrectness {
                 problem.axis,
                 strategy.clone(),
                 problem.config,
+                problem.precision.dtype(),
                 seeds[0],
             ),
         }
@@ -56,6 +58,7 @@ impl cubek_test_utils::Correctness for ReduceCorrectness {
             problem.shape.clone(),
             problem.axis,
             problem.config,
+            problem.precision.dtype(),
             seeds[0],
             progress,
         )

--- a/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
@@ -1,12 +1,96 @@
-use cubek_test_utils::{HostData, Progress};
+use cubek_test_utils::{HostData, Progress, ValidationResult, assert_equals_approx};
 
 use crate::ReduceStrategy;
 use crate::eval::benchmarks::problem::{ReduceBenchKind, ReduceProblem};
 use crate::eval::cpu_reference::{
-    cpu_reference_result, strategy_result, strategy_result_with_indices,
+    RAMP_MAX_ELEMS, ReduceInput, ReduceValues, comparison_epsilon, cpu_reference_result,
+    strategy_result, strategy_result_with_indices,
 };
 
 pub struct ReduceCorrectness;
+
+impl ReduceCorrectness {
+    /// A strategy that computes the wrong answer would still time fast, so every
+    /// strategy proves itself on a small shape before it is measured.
+    pub fn verify(strategy: &ReduceStrategy, problem: &ReduceProblem) -> Result<(), String> {
+        let proof = ReduceProblem {
+            shape: proof_shape(problem.shape.len(), problem.axis),
+            axis: problem.axis,
+            config: problem.config,
+            kind: problem.kind,
+            precision: problem.precision,
+        };
+        let input = ReduceInput {
+            dtype: proof.precision.dtype(),
+            values: ReduceValues::Ramp,
+        };
+
+        let actual = Self::kernel_output(strategy, &proof, input)?;
+        let expected = Self::reference_output(&proof, input, None)?;
+
+        match assert_equals_approx(&actual, &expected, comparison_epsilon(proof.config)) {
+            ValidationResult::Pass | ValidationResult::Skipped(_) => Ok(()),
+            ValidationResult::Fail(reason) | ValidationResult::Error(reason) => Err(format!(
+                "{:?} computes the wrong {:?} at {:?}, so its timing would be meaningless: {reason}",
+                strategy, proof.config, proof.shape
+            )),
+        }
+    }
+
+    /// Validate the path that is actually benchmarked. The two-launch kind runs
+    /// the same `reduce` as `Single` for its values half, so only the fused kind
+    /// needs the dedicated entrypoint.
+    fn kernel_output(
+        strategy: &ReduceStrategy,
+        problem: &ReduceProblem,
+        input: ReduceInput,
+    ) -> Result<HostData, String> {
+        let client = cubecl::test_device().client();
+        match problem.kind {
+            ReduceBenchKind::Single | ReduceBenchKind::TwoLaunch => strategy_result(
+                client,
+                problem.shape.clone(),
+                problem.axis,
+                strategy.clone(),
+                problem.config,
+                input,
+            ),
+            ReduceBenchKind::Fused => strategy_result_with_indices(
+                client,
+                problem.shape.clone(),
+                problem.axis,
+                strategy.clone(),
+                problem.config,
+                input,
+            ),
+        }
+    }
+
+    fn reference_output(
+        problem: &ReduceProblem,
+        input: ReduceInput,
+        progress: Option<&Progress>,
+    ) -> Result<HostData, String> {
+        let client = cubecl::test_device().client();
+        cpu_reference_result(
+            client,
+            problem.shape.clone(),
+            problem.axis,
+            problem.config,
+            input,
+            progress,
+        )
+    }
+}
+
+/// The shape a strategy proves itself on: [`RAMP_MAX_ELEMS`] split between the
+/// axes, all of it on the reduced one, so that axis stays long enough for a
+/// plane or cube routine to actually fold.
+fn proof_shape(rank: usize, axis: usize) -> Vec<usize> {
+    let mut shape = vec![2; rank];
+    shape[axis] = RAMP_MAX_ELEMS >> (rank - 1);
+    shape
+}
 
 impl cubek_test_utils::Correctness for ReduceCorrectness {
     type Problem = ReduceProblem;
@@ -18,31 +102,11 @@ impl cubek_test_utils::Correctness for ReduceCorrectness {
         problem: &ReduceProblem,
         seeds: &[u64],
     ) -> Result<HostData, String> {
-        let device = cubecl::test_device();
-        let client = device.client();
-        // Validate the path that is actually benchmarked. The two-launch kind
-        // runs the same `reduce` as `Single` for its values half, so only the
-        // fused kind needs the dedicated entrypoint.
-        match problem.kind {
-            ReduceBenchKind::Single | ReduceBenchKind::TwoLaunch => strategy_result(
-                client,
-                problem.shape.clone(),
-                problem.axis,
-                strategy.clone(),
-                problem.config,
-                problem.precision.dtype(),
-                seeds[0],
-            ),
-            ReduceBenchKind::Fused => strategy_result_with_indices(
-                client,
-                problem.shape.clone(),
-                problem.axis,
-                strategy.clone(),
-                problem.config,
-                problem.precision.dtype(),
-                seeds[0],
-            ),
-        }
+        Self::kernel_output(
+            strategy,
+            problem,
+            ReduceInput::uniform(problem.precision.dtype(), seeds[0]),
+        )
     }
 
     fn reference_result(
@@ -51,15 +115,9 @@ impl cubek_test_utils::Correctness for ReduceCorrectness {
         seeds: &[u64],
         progress: Option<&Progress>,
     ) -> Result<HostData, String> {
-        let device = cubecl::test_device();
-        let client = device.client();
-        cpu_reference_result(
-            client,
-            problem.shape.clone(),
-            problem.axis,
-            problem.config,
-            problem.precision.dtype(),
-            seeds[0],
+        Self::reference_output(
+            problem,
+            ReduceInput::uniform(problem.precision.dtype(), seeds[0]),
             progress,
         )
     }

--- a/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
@@ -11,12 +11,8 @@ use crate::eval::cpu_reference::{
 pub struct ReduceCorrectness;
 
 impl ReduceCorrectness {
-    /// A strategy that computes the wrong answer would still time fast, so every
-    /// strategy proves itself on a small shape before it is measured. The proof
-    /// launch compiles a kernel the timed run doesn't reuse (its shape differs),
-    /// but that cost is trivial next to a timed run over the real, much larger
-    /// shape, and the alternative is a benchmark whose fast time comes from a
-    /// wrong kernel.
+    /// Proves `strategy` correct on a small shape before it's timed, so a wrong
+    /// kernel can't win a benchmark by being fast.
     pub fn verify(strategy: &ReduceStrategy, problem: &ReduceProblem) -> Result<(), String> {
         let client = cubecl::test_device().client();
         let proof = ReduceProblem {
@@ -89,13 +85,10 @@ impl ReduceCorrectness {
     }
 }
 
-/// The shape a strategy proves itself on: [`RAMP_MAX_ELEMS`] split between the
-/// axes, all of it on the reduced one, so that axis stays long enough for a
-/// plane or cube routine to actually fold. Axes fill up with 2 until the
-/// running product would exceed `RAMP_MAX_ELEMS`; past that point they get 1,
-/// so the total stays a power of two no larger than `RAMP_MAX_ELEMS`
-/// regardless of rank, rather than the reduced axis silently underflowing to
-/// zero once `rank` exceeds `RAMP_MAX_ELEMS`'s bit width.
+/// At most [`RAMP_MAX_ELEMS`] elements, all on the reduced axis so a plane or
+/// cube routine has enough to fold. Padding other axes with 2 keeps the total
+/// a power of two at any rank, instead of the reduced axis underflowing to
+/// zero once rank exceeds `RAMP_MAX_ELEMS`'s bit width.
 fn proof_shape(rank: usize, axis: usize) -> Vec<usize> {
     let mut shape = vec![1; rank];
     let mut budget = RAMP_MAX_ELEMS;
@@ -150,8 +143,6 @@ mod proof_shape_tests {
     use super::proof_shape;
     use crate::eval::cpu_reference::RAMP_MAX_ELEMS;
 
-    /// Every rank must produce a shape whose element count `ramp` can accept:
-    /// a power of two no larger than `RAMP_MAX_ELEMS`, and never zero.
     #[test]
     fn stays_within_ramp_bounds_at_every_rank() {
         for rank in 1..=16 {

--- a/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
@@ -1,3 +1,4 @@
+use cubecl::client::Client;
 use cubek_test_utils::{HostData, Progress, ValidationResult, assert_equals_approx};
 
 use crate::ReduceStrategy;
@@ -11,8 +12,13 @@ pub struct ReduceCorrectness;
 
 impl ReduceCorrectness {
     /// A strategy that computes the wrong answer would still time fast, so every
-    /// strategy proves itself on a small shape before it is measured.
+    /// strategy proves itself on a small shape before it is measured. The proof
+    /// launch compiles a kernel the timed run doesn't reuse (its shape differs),
+    /// but that cost is trivial next to a timed run over the real, much larger
+    /// shape, and the alternative is a benchmark whose fast time comes from a
+    /// wrong kernel.
     pub fn verify(strategy: &ReduceStrategy, problem: &ReduceProblem) -> Result<(), String> {
+        let client = cubecl::test_device().client();
         let proof = ReduceProblem {
             shape: proof_shape(problem.shape.len(), problem.axis),
             axis: problem.axis,
@@ -25,8 +31,8 @@ impl ReduceCorrectness {
             values: ReduceValues::Ramp,
         };
 
-        let actual = Self::kernel_output(strategy, &proof, input)?;
-        let expected = Self::reference_output(&proof, input, None)?;
+        let actual = Self::kernel_output(client.clone(), strategy, &proof, input)?;
+        let expected = Self::reference_output(client, &proof, input, None)?;
 
         match assert_equals_approx(&actual, &expected, comparison_epsilon(proof.config)) {
             ValidationResult::Pass | ValidationResult::Skipped(_) => Ok(()),
@@ -41,11 +47,11 @@ impl ReduceCorrectness {
     /// the same `reduce` as `Single` for its values half, so only the fused kind
     /// needs the dedicated entrypoint.
     fn kernel_output(
+        client: Client,
         strategy: &ReduceStrategy,
         problem: &ReduceProblem,
         input: ReduceInput,
     ) -> Result<HostData, String> {
-        let client = cubecl::test_device().client();
         match problem.kind {
             ReduceBenchKind::Single | ReduceBenchKind::TwoLaunch => strategy_result(
                 client,
@@ -67,11 +73,11 @@ impl ReduceCorrectness {
     }
 
     fn reference_output(
+        client: Client,
         problem: &ReduceProblem,
         input: ReduceInput,
         progress: Option<&Progress>,
     ) -> Result<HostData, String> {
-        let client = cubecl::test_device().client();
         cpu_reference_result(
             client,
             problem.shape.clone(),
@@ -85,11 +91,50 @@ impl ReduceCorrectness {
 
 /// The shape a strategy proves itself on: [`RAMP_MAX_ELEMS`] split between the
 /// axes, all of it on the reduced one, so that axis stays long enough for a
-/// plane or cube routine to actually fold.
+/// plane or cube routine to actually fold. Axes fill up with 2 until the
+/// running product would exceed `RAMP_MAX_ELEMS`; past that point they get 1,
+/// so the total stays a power of two no larger than `RAMP_MAX_ELEMS`
+/// regardless of rank, rather than the reduced axis silently underflowing to
+/// zero once `rank` exceeds `RAMP_MAX_ELEMS`'s bit width.
 fn proof_shape(rank: usize, axis: usize) -> Vec<usize> {
-    let mut shape = vec![2; rank];
-    shape[axis] = RAMP_MAX_ELEMS >> (rank - 1);
+    let mut shape = vec![1; rank];
+    let mut budget = RAMP_MAX_ELEMS;
+    for (i, dim) in shape.iter_mut().enumerate() {
+        if i == axis || budget == 1 {
+            continue;
+        }
+        *dim = 2;
+        budget /= 2;
+    }
+    shape[axis] = budget;
     shape
+}
+
+#[cfg(test)]
+mod proof_shape_tests {
+    use super::proof_shape;
+    use crate::eval::cpu_reference::RAMP_MAX_ELEMS;
+
+    /// Every rank must produce a shape whose element count `ramp` can accept:
+    /// a power of two no larger than `RAMP_MAX_ELEMS`, and never zero.
+    #[test]
+    fn stays_within_ramp_bounds_at_every_rank() {
+        for rank in 1..=16 {
+            for axis in 0..rank {
+                let shape = proof_shape(rank, axis);
+                let elems: usize = shape.iter().product();
+                assert!(
+                    elems.is_power_of_two() && elems <= RAMP_MAX_ELEMS,
+                    "rank {rank} axis {axis}: {shape:?} has {elems} elements"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn matches_ramp_max_elems_below_its_bit_width() {
+        assert_eq!(proof_shape(3, 2), vec![2, 2, 512]);
+    }
 }
 
 impl cubek_test_utils::Correctness for ReduceCorrectness {
@@ -102,7 +147,9 @@ impl cubek_test_utils::Correctness for ReduceCorrectness {
         problem: &ReduceProblem,
         seeds: &[u64],
     ) -> Result<HostData, String> {
+        let client = cubecl::test_device().client();
         Self::kernel_output(
+            client,
             strategy,
             problem,
             ReduceInput::uniform(problem.precision.dtype(), seeds[0]),
@@ -115,7 +162,9 @@ impl cubek_test_utils::Correctness for ReduceCorrectness {
         seeds: &[u64],
         progress: Option<&Progress>,
     ) -> Result<HostData, String> {
+        let client = cubecl::test_device().client();
         Self::reference_output(
+            client,
             problem,
             ReduceInput::uniform(problem.precision.dtype(), seeds[0]),
             progress,

--- a/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/correctness.rs
@@ -110,33 +110,6 @@ fn proof_shape(rank: usize, axis: usize) -> Vec<usize> {
     shape
 }
 
-#[cfg(test)]
-mod proof_shape_tests {
-    use super::proof_shape;
-    use crate::eval::cpu_reference::RAMP_MAX_ELEMS;
-
-    /// Every rank must produce a shape whose element count `ramp` can accept:
-    /// a power of two no larger than `RAMP_MAX_ELEMS`, and never zero.
-    #[test]
-    fn stays_within_ramp_bounds_at_every_rank() {
-        for rank in 1..=16 {
-            for axis in 0..rank {
-                let shape = proof_shape(rank, axis);
-                let elems: usize = shape.iter().product();
-                assert!(
-                    elems.is_power_of_two() && elems <= RAMP_MAX_ELEMS,
-                    "rank {rank} axis {axis}: {shape:?} has {elems} elements"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn matches_ramp_max_elems_below_its_bit_width() {
-        assert_eq!(proof_shape(3, 2), vec![2, 2, 512]);
-    }
-}
-
 impl cubek_test_utils::Correctness for ReduceCorrectness {
     type Problem = ReduceProblem;
     type Strategy = ReduceStrategy;
@@ -169,5 +142,32 @@ impl cubek_test_utils::Correctness for ReduceCorrectness {
             ReduceInput::uniform(problem.precision.dtype(), seeds[0]),
             progress,
         )
+    }
+}
+
+#[cfg(test)]
+mod proof_shape_tests {
+    use super::proof_shape;
+    use crate::eval::cpu_reference::RAMP_MAX_ELEMS;
+
+    /// Every rank must produce a shape whose element count `ramp` can accept:
+    /// a power of two no larger than `RAMP_MAX_ELEMS`, and never zero.
+    #[test]
+    fn stays_within_ramp_bounds_at_every_rank() {
+        for rank in 1..=16 {
+            for axis in 0..rank {
+                let shape = proof_shape(rank, axis);
+                let elems: usize = shape.iter().product();
+                assert!(
+                    elems.is_power_of_two() && elems <= RAMP_MAX_ELEMS,
+                    "rank {rank} axis {axis}: {shape:?} has {elems} elements"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn matches_ramp_max_elems_below_its_bit_width() {
+        assert_eq!(proof_shape(3, 2), vec![2, 2, 512]);
     }
 }

--- a/crates/cubek-reduce/src/eval/benchmarks/mod.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/mod.rs
@@ -51,7 +51,7 @@ impl cubek_test_utils::Category for Category {
     }
 
     fn timing_method(&self) -> TimingMethod {
-        TimingMethod::Device
+        cubek_test_utils::timing_method(TimingMethod::Device)
     }
 
     fn correctness(

--- a/crates/cubek-reduce/src/eval/benchmarks/mod.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/mod.rs
@@ -7,7 +7,7 @@ mod strategy;
 
 pub use benchmark::bench;
 pub use correctness::ReduceCorrectness;
-pub use problem::{ReduceBenchKind, ReduceProblem, problems};
+pub use problem::{ReduceBenchKind, ReduceBenchPrecision, ReduceProblem, precisions, problems};
 pub use strategy::strategies;
 
 use cubecl::benchmark::TimingMethod;
@@ -15,6 +15,7 @@ use cubecl::prelude::*;
 use cubek_test_utils::{CatalogEntry, CategoryWork, ComputeWork, RunSamples};
 
 use crate::ReduceStrategy;
+use crate::eval::cpu_reference::output_dtype_for;
 use crate::launch::ReduceDtypes;
 use crate::routines::ReduceCost;
 
@@ -64,7 +65,7 @@ impl cubek_test_utils::Category for Category {
     /// Scaled by the passes the harness makes over the cost model: a two-launch
     /// reduction reads and writes twice, which is the harness's doing.
     fn work(&self, problem: &ReduceProblem) -> Option<CategoryWork> {
-        let dtype = f32::elem_type_native();
+        let value_dtype = problem.precision.dtype();
         let input_elems: usize = problem.shape.iter().product();
         let reduce_len = problem.shape[problem.axis];
 
@@ -73,9 +74,9 @@ impl cubek_test_utils::Category for Category {
             reduce_count: input_elems / reduce_len,
             instruction: problem.config,
             dtypes: ReduceDtypes {
-                input: dtype,
-                output: dtype,
-                accumulation: dtype,
+                input: value_dtype,
+                output: output_dtype_for(&problem.config, value_dtype),
+                accumulation: f32::elem_type_native(),
             },
         };
 

--- a/crates/cubek-reduce/src/eval/benchmarks/mod.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/mod.rs
@@ -11,11 +11,10 @@ pub use problem::{ReduceBenchKind, ReduceBenchPrecision, ReduceProblem, precisio
 pub use strategy::strategies;
 
 use cubecl::benchmark::TimingMethod;
-use cubecl::prelude::*;
 use cubek_test_utils::{CatalogEntry, CategoryWork, ComputeWork, RunSamples};
 
 use crate::ReduceStrategy;
-use crate::eval::cpu_reference::output_dtype_for;
+use crate::eval::cpu_reference::{accumulation_dtype, output_dtype_for};
 use crate::launch::ReduceDtypes;
 use crate::routines::ReduceCost;
 
@@ -76,7 +75,7 @@ impl cubek_test_utils::Category for Category {
             dtypes: ReduceDtypes {
                 input: value_dtype,
                 output: output_dtype_for(&problem.config, value_dtype),
-                accumulation: f32::elem_type_native(),
+                accumulation: accumulation_dtype(),
             },
         };
 

--- a/crates/cubek-reduce/src/eval/benchmarks/problem.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/problem.rs
@@ -38,7 +38,7 @@ impl ReduceBenchPrecision {
 
     /// The suffix its rows' ids carry. An f32 row carries none: the catalogue
     /// tests and `CUBEK_BENCH_PROBLEMS` name those ids verbatim.
-    fn suffix(self) -> &'static str {
+    pub fn suffix(self) -> &'static str {
         match self {
             ReduceBenchPrecision::F32 => "",
             ReduceBenchPrecision::F16 => "_f16",

--- a/crates/cubek-reduce/src/eval/benchmarks/problem.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/problem.rs
@@ -1,3 +1,4 @@
+use cubecl::{features::TypeUsage, ir::ElemType, prelude::*};
 use cubek_test_utils::CatalogEntry;
 
 use crate::components::instructions::ReduceOperationConfig;
@@ -17,56 +18,96 @@ pub enum ReduceBenchKind {
     Fused,
 }
 
+/// The element type a problem's input and output tensors carry.
+///
+/// Real consumers reduce in f16, and the two are not the same measurement: the
+/// kernel moves half the bytes and folds them in an f32 accumulator either way.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReduceBenchPrecision {
+    F32,
+    F16,
+}
+
+impl ReduceBenchPrecision {
+    pub fn dtype(self) -> ElemType {
+        match self {
+            ReduceBenchPrecision::F32 => f32::elem_type_native(),
+            ReduceBenchPrecision::F16 => half::f16::elem_type_native(),
+        }
+    }
+
+    /// The suffix its rows' ids carry. An f32 row carries none: the catalogue
+    /// tests and `CUBEK_BENCH_PROBLEMS` name those ids verbatim.
+    fn suffix(self) -> &'static str {
+        match self {
+            ReduceBenchPrecision::F32 => "",
+            ReduceBenchPrecision::F16 => "_f16",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            ReduceBenchPrecision::F32 => "",
+            ReduceBenchPrecision::F16 => " [f16]",
+        }
+    }
+}
+
+/// The precisions this device can actually reduce in, so a runtime without f16
+/// yields no f16 rows rather than a catalogue of failures.
+pub fn precisions() -> Vec<ReduceBenchPrecision> {
+    let client = cubecl::test_device().client();
+    let mut precisions = vec![ReduceBenchPrecision::F32];
+    if half::f16::supported_uses(&client).contains(TypeUsage::Arithmetic) {
+        precisions.push(ReduceBenchPrecision::F16);
+    }
+    precisions
+}
+
 pub struct ReduceProblem {
     pub shape: Vec<usize>,
     pub axis: usize,
     pub config: ReduceOperationConfig,
     pub kind: ReduceBenchKind,
+    pub precision: ReduceBenchPrecision,
 }
 
 pub fn problems() -> Vec<CatalogEntry<ReduceProblem>> {
+    precisions().into_iter().flat_map(problems_at).collect()
+}
+
+fn problems_at(precision: ReduceBenchPrecision) -> Vec<CatalogEntry<ReduceProblem>> {
     let shape = || vec![32, 512, 4095];
+    let id = |name: String| format!("{name}{}", precision.suffix());
+    let label = |text: String| format!("{text}{}", precision.label());
+    let problem = |config, kind| ReduceProblem {
+        shape: shape(),
+        axis: 2,
+        config,
+        kind,
+        precision,
+    };
 
     let mut entries = vec![
         CatalogEntry::new(
-            "sum_axis2_32x512x4095",
-            "Sum axis=2 (32x512x4095)",
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config: ReduceOperationConfig::Sum,
-                kind: ReduceBenchKind::Single,
-            },
+            id("sum_axis2_32x512x4095".to_string()),
+            label("Sum axis=2 (32x512x4095)".to_string()),
+            problem(ReduceOperationConfig::Sum, ReduceBenchKind::Single),
         ),
         CatalogEntry::new(
-            "arg_topk1_axis2_32x512x4095",
-            "ArgTopK(1) axis=2 (32x512x4095)",
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config: ReduceOperationConfig::ArgTopK(1),
-                kind: ReduceBenchKind::Single,
-            },
+            id("arg_topk1_axis2_32x512x4095".to_string()),
+            label("ArgTopK(1) axis=2 (32x512x4095)".to_string()),
+            problem(ReduceOperationConfig::ArgTopK(1), ReduceBenchKind::Single),
         ),
         CatalogEntry::new(
-            "arg_topk2_axis2_32x512x4095",
-            "ArgTopK(2) axis=2 (32x512x4095)",
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config: ReduceOperationConfig::ArgTopK(2),
-                kind: ReduceBenchKind::Single,
-            },
+            id("arg_topk2_axis2_32x512x4095".to_string()),
+            label("ArgTopK(2) axis=2 (32x512x4095)".to_string()),
+            problem(ReduceOperationConfig::ArgTopK(2), ReduceBenchKind::Single),
         ),
         CatalogEntry::new(
-            "arg_topk3_axis2_32x512x4095",
-            "ArgTopK(3) axis=2 (32x512x4095)",
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config: ReduceOperationConfig::ArgTopK(3),
-                kind: ReduceBenchKind::Single,
-            },
+            id("arg_topk3_axis2_32x512x4095".to_string()),
+            label("ArgTopK(3) axis=2 (32x512x4095)".to_string()),
+            problem(ReduceOperationConfig::ArgTopK(3), ReduceBenchKind::Single),
         ),
     ];
 
@@ -77,34 +118,25 @@ pub fn problems() -> Vec<CatalogEntry<ReduceProblem>> {
     // hiding inside the two-launch total.
     for k in [1, 2, 3, 5] {
         entries.push(CatalogEntry::new(
-            format!("topk{k}_single_axis2_32x512x4095"),
-            format!("TopK({k}) values only, 1 launch, axis=2 (32x512x4095)"),
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config: ReduceOperationConfig::TopK(k),
-                kind: ReduceBenchKind::Single,
-            },
+            id(format!("topk{k}_single_axis2_32x512x4095")),
+            label(format!(
+                "TopK({k}) values only, 1 launch, axis=2 (32x512x4095)"
+            )),
+            problem(ReduceOperationConfig::TopK(k), ReduceBenchKind::Single),
         ));
         entries.push(CatalogEntry::new(
-            format!("topk{k}_two_launch_axis2_32x512x4095"),
-            format!("TopK({k}) values+indices, 2 launches, axis=2 (32x512x4095)"),
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config: ReduceOperationConfig::TopK(k),
-                kind: ReduceBenchKind::TwoLaunch,
-            },
+            id(format!("topk{k}_two_launch_axis2_32x512x4095")),
+            label(format!(
+                "TopK({k}) values+indices, 2 launches, axis=2 (32x512x4095)"
+            )),
+            problem(ReduceOperationConfig::TopK(k), ReduceBenchKind::TwoLaunch),
         ));
         entries.push(CatalogEntry::new(
-            format!("topk{k}_fused_axis2_32x512x4095"),
-            format!("TopK({k}) values+indices, 1 fused launch, axis=2 (32x512x4095)"),
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config: ReduceOperationConfig::TopK(k),
-                kind: ReduceBenchKind::Fused,
-            },
+            id(format!("topk{k}_fused_axis2_32x512x4095")),
+            label(format!(
+                "TopK({k}) values+indices, 1 fused launch, axis=2 (32x512x4095)"
+            )),
+            problem(ReduceOperationConfig::TopK(k), ReduceBenchKind::Fused),
         ));
     }
 
@@ -116,52 +148,40 @@ pub fn problems() -> Vec<CatalogEntry<ReduceProblem>> {
     // measured is the accumulator, not the launch pattern.
     for k in [16, 32, 64, 128, 256] {
         entries.push(CatalogEntry::new(
-            format!("topk{k}_fused_axis2_32x512x4095"),
-            format!("TopK({k}) values+indices, 1 fused launch, axis=2 (32x512x4095)"),
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config: ReduceOperationConfig::TopK(k),
-                kind: ReduceBenchKind::Fused,
-            },
+            id(format!("topk{k}_fused_axis2_32x512x4095")),
+            label(format!(
+                "TopK({k}) values+indices, 1 fused launch, axis=2 (32x512x4095)"
+            )),
+            problem(ReduceOperationConfig::TopK(k), ReduceBenchKind::Fused),
         ));
     }
 
     // The same comparison for min and max, which reach `reduce_with_indices`
     // through their own collapsed instructions rather than the top-k one.
-    for (name, label, config) in [
+    for (name, text, config) in [
         ("max", "Max", ReduceOperationConfig::Max),
         ("min", "Min", ReduceOperationConfig::Min),
     ] {
         entries.push(CatalogEntry::new(
-            format!("{name}_single_axis2_32x512x4095"),
-            format!("{label} values only, 1 launch, axis=2 (32x512x4095)"),
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config,
-                kind: ReduceBenchKind::Single,
-            },
+            id(format!("{name}_single_axis2_32x512x4095")),
+            label(format!(
+                "{text} values only, 1 launch, axis=2 (32x512x4095)"
+            )),
+            problem(config, ReduceBenchKind::Single),
         ));
         entries.push(CatalogEntry::new(
-            format!("{name}_two_launch_axis2_32x512x4095"),
-            format!("{label} values+indices, 2 launches, axis=2 (32x512x4095)"),
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config,
-                kind: ReduceBenchKind::TwoLaunch,
-            },
+            id(format!("{name}_two_launch_axis2_32x512x4095")),
+            label(format!(
+                "{text} values+indices, 2 launches, axis=2 (32x512x4095)"
+            )),
+            problem(config, ReduceBenchKind::TwoLaunch),
         ));
         entries.push(CatalogEntry::new(
-            format!("{name}_fused_axis2_32x512x4095"),
-            format!("{label} values+indices, 1 fused launch, axis=2 (32x512x4095)"),
-            ReduceProblem {
-                shape: shape(),
-                axis: 2,
-                config,
-                kind: ReduceBenchKind::Fused,
-            },
+            id(format!("{name}_fused_axis2_32x512x4095")),
+            label(format!(
+                "{text} values+indices, 1 fused launch, axis=2 (32x512x4095)"
+            )),
+            problem(config, ReduceBenchKind::Fused),
         ));
     }
 

--- a/crates/cubek-reduce/src/eval/benchmarks/problem.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/problem.rs
@@ -55,10 +55,9 @@ impl ReduceBenchPrecision {
     }
 }
 
-/// The precisions this device can actually reduce in, so a runtime without f16
-/// yields no f16 rows rather than a catalogue of failures. Computed once: the
-/// device's f16 support can't change over the process's life, and every
-/// catalogue listing and every generated `f16()` test otherwise re-queries it.
+/// The precisions this device can reduce in, so a runtime without f16 yields
+/// no f16 rows. Computed once: a device's f16 support can't change, and every
+/// catalogue listing and generated `f16()` test would otherwise re-query it.
 static PRECISIONS: LazyLock<Vec<ReduceBenchPrecision>> = LazyLock::new(|| {
     let client = cubecl::test_device().client();
     let mut precisions = vec![ReduceBenchPrecision::F32];

--- a/crates/cubek-reduce/src/eval/benchmarks/problem.rs
+++ b/crates/cubek-reduce/src/eval/benchmarks/problem.rs
@@ -1,4 +1,6 @@
-use cubecl::{features::TypeUsage, ir::ElemType, prelude::*};
+use std::sync::LazyLock;
+
+use cubecl::{ir::ElemType, prelude::*};
 use cubek_test_utils::CatalogEntry;
 
 use crate::components::instructions::ReduceOperationConfig;
@@ -54,14 +56,20 @@ impl ReduceBenchPrecision {
 }
 
 /// The precisions this device can actually reduce in, so a runtime without f16
-/// yields no f16 rows rather than a catalogue of failures.
-pub fn precisions() -> Vec<ReduceBenchPrecision> {
+/// yields no f16 rows rather than a catalogue of failures. Computed once: the
+/// device's f16 support can't change over the process's life, and every
+/// catalogue listing and every generated `f16()` test otherwise re-queries it.
+static PRECISIONS: LazyLock<Vec<ReduceBenchPrecision>> = LazyLock::new(|| {
     let client = cubecl::test_device().client();
     let mut precisions = vec![ReduceBenchPrecision::F32];
-    if half::f16::supported_uses(&client).contains(TypeUsage::Arithmetic) {
+    if cubek_test_utils::supports_f16_arithmetic(&client) {
         precisions.push(ReduceBenchPrecision::F16);
     }
     precisions
+});
+
+pub fn precisions() -> Vec<ReduceBenchPrecision> {
+    PRECISIONS.clone()
 }
 
 pub struct ReduceProblem {

--- a/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
@@ -1,7 +1,7 @@
 //! CPU reference and seeded "produce a HostData" primitives for reduce.
 //!
 //! Both [`strategy_result`] and [`cpu_reference_result`] build the same input
-//! bits from `(seed, shape, axis, config)` so the two `HostData`s they return
+//! bits from `(input, shape, axis, config)` so the two `HostData`s they return
 //! are directly comparable for the same `axis`/`config`.
 
 mod all;
@@ -45,24 +45,101 @@ use crate::{
     components::instructions::ReduceOperationConfig, reduce, reduce_with_indices,
 };
 
-/// Run `strategy` on a seeded reduce problem at `input_dtype` and return its
-/// output as a [`HostData`].
+/// The bits a comparison runs on: the kernel launch and the CPU reference each
+/// build their input from this alone, so the two see the same values.
+#[derive(Clone, Copy)]
+pub struct ReduceInput {
+    pub dtype: ElemType,
+    pub values: ReduceValues,
+}
+
+/// Where a comparison's input values come from.
+#[derive(Clone, Copy)]
+pub enum ReduceValues {
+    /// Uniform over `[-1, 1]`, drawn from this seed.
+    Uniform(u64),
+    /// An evenly spaced ramp over `[-1, 1)`, dealt out by an odd stride so no
+    /// run of the tensor is sorted. Every value stays distinct down to f16, so
+    /// a top-k has a single right answer and no tie can decide the comparison.
+    Ramp,
+}
+
+/// Ramp steps f16 still resolves apart: the ramp spans 2.0 and f16 separates
+/// neighbours by 2^-11 just below 1.0.
+pub const RAMP_MAX_ELEMS: usize = 2048;
+
+/// Odd, so it visits every slot of a power-of-two length.
+const RAMP_STRIDE: usize = 1103;
+
+impl ReduceInput {
+    /// Uniform values at `dtype`, the input every seeded comparison over a
+    /// catalogue-sized shape uses.
+    pub fn uniform(dtype: ElemType, seed: u64) -> Self {
+        Self {
+            dtype,
+            values: ReduceValues::Uniform(seed),
+        }
+    }
+
+    fn tensor(&self, client: Client, shape: Vec<usize>) -> TestInput {
+        let builder = TestInput::builder(client, shape.clone()).dtype(self.dtype);
+        match self.values {
+            ReduceValues::Uniform(seed) => builder.uniform(seed, -1., 1.),
+            ReduceValues::Ramp => builder.custom(ramp(shape.iter().product())),
+        }
+    }
+}
+
+fn ramp(elems: usize) -> Vec<f32> {
+    assert!(
+        elems.is_power_of_two() && elems <= RAMP_MAX_ELEMS,
+        "a ramp of {elems} values is not a permutation, or is finer than f16 resolves"
+    );
+    (0..elems)
+        .map(|i| (i * RAMP_STRIDE % elems) as f32 / elems as f32 * 2.0 - 1.0)
+        .collect()
+}
+
+/// How far a kernel's output may sit from the reference before it is wrong.
+///
+/// A selection instruction returns a value taken out of the input, or its
+/// coordinate, so any slack at all leaves the comparison unable to fail. Only
+/// the accumulating ones round, and over tens of millions of f32 elements some
+/// kernels accumulate noticeable noise; tightening those belongs in the
+/// per-routine integration tests.
+pub fn comparison_epsilon(config: ReduceOperationConfig) -> f32 {
+    match config {
+        ReduceOperationConfig::Sum | ReduceOperationConfig::Mean | ReduceOperationConfig::Prod => {
+            1.0
+        }
+        ReduceOperationConfig::Max
+        | ReduceOperationConfig::Min
+        | ReduceOperationConfig::MaxAbs
+        | ReduceOperationConfig::ArgMax
+        | ReduceOperationConfig::ArgMin
+        | ReduceOperationConfig::TopK(_)
+        | ReduceOperationConfig::ArgTopK(_)
+        | ReduceOperationConfig::Any
+        | ReduceOperationConfig::All => 0.0,
+    }
+}
+
+/// Run `strategy` on `input` and return its output as a [`HostData`].
 pub fn strategy_result(
     client: Client,
     shape: Vec<usize>,
     axis: usize,
     strategy: ReduceStrategy,
     config: ReduceOperationConfig,
-    input_dtype: ElemType,
-    seed: u64,
+    input: ReduceInput,
 ) -> Result<HostData, String> {
+    let input_dtype = input.dtype;
     let output_dtype = output_dtype_for(&config, input_dtype);
     let accumulation_dtype = f32::elem_type_native();
 
-    let (input_handle, _input_host) = TestInput::builder(client.clone(), shape.clone())
-        .dtype(input_dtype)
-        .uniform(seed, -1., 1.)
-        .generate_with_f32_host_data();
+    let input_handle = input
+        .tensor(client.clone(), shape.clone())
+        .generate_without_host_data();
 
     let out_shape = output_shape_for(&shape, axis, &config);
     let output_handle = TestInput::builder(client.clone(), out_shape)
@@ -111,16 +188,15 @@ pub fn strategy_result_with_indices(
     axis: usize,
     strategy: ReduceStrategy,
     config: ReduceOperationConfig,
-    input_dtype: ElemType,
-    seed: u64,
+    input: ReduceInput,
 ) -> Result<HostData, String> {
+    let input_dtype = input.dtype;
     let index_dtype = u32::elem_type_native();
     let accumulation_dtype = f32::elem_type_native();
 
-    let (input_handle, _input_host) = TestInput::builder(client.clone(), shape.clone())
-        .dtype(input_dtype)
-        .uniform(seed, -1., 1.)
-        .generate_with_f32_host_data();
+    let input_handle = input
+        .tensor(client.clone(), shape.clone())
+        .generate_without_host_data();
 
     let out_shape = output_shape_for(&shape, axis, &config);
     let values_handle = TestInput::builder(client.clone(), out_shape.clone())
@@ -175,8 +251,7 @@ pub fn cpu_reference_result(
     shape: Vec<usize>,
     axis: usize,
     config: ReduceOperationConfig,
-    input_dtype: ElemType,
-    seed: u64,
+    input: ReduceInput,
     progress: Option<&Progress>,
 ) -> Result<HostData, String> {
     if let Some(p) = progress {
@@ -187,10 +262,7 @@ pub fn cpu_reference_result(
 
     // A narrow dtype rounds on the way in, so the reference folds what the
     // tensor ended up holding rather than what the generator was handed.
-    let (_input_handle, input_host) = TestInput::builder(client.clone(), shape)
-        .dtype(input_dtype)
-        .uniform(seed, -1., 1.)
-        .generate_with_f32_host_data();
+    let (_input_handle, input_host) = input.tensor(client, shape).generate_with_f32_host_data();
 
     Ok(reference_for_config(&input_host, axis, config, progress))
 }

--- a/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
@@ -45,17 +45,17 @@ use crate::{
     components::instructions::ReduceOperationConfig, reduce, reduce_with_indices,
 };
 
-/// Run `strategy` on a seeded f32 reduce problem and return its output as a
-/// [`HostData`].
+/// Run `strategy` on a seeded reduce problem at `input_dtype` and return its
+/// output as a [`HostData`].
 pub fn strategy_result(
     client: Client,
     shape: Vec<usize>,
     axis: usize,
     strategy: ReduceStrategy,
     config: ReduceOperationConfig,
+    input_dtype: ElemType,
     seed: u64,
 ) -> Result<HostData, String> {
-    let input_dtype = f32::elem_type_native();
     let output_dtype = output_dtype_for(&config, input_dtype);
     let accumulation_dtype = f32::elem_type_native();
 
@@ -111,9 +111,9 @@ pub fn strategy_result_with_indices(
     axis: usize,
     strategy: ReduceStrategy,
     config: ReduceOperationConfig,
+    input_dtype: ElemType,
     seed: u64,
 ) -> Result<HostData, String> {
-    let input_dtype = f32::elem_type_native();
     let index_dtype = u32::elem_type_native();
     let accumulation_dtype = f32::elem_type_native();
 
@@ -175,17 +175,18 @@ pub fn cpu_reference_result(
     shape: Vec<usize>,
     axis: usize,
     config: ReduceOperationConfig,
+    input_dtype: ElemType,
     seed: u64,
     progress: Option<&Progress>,
 ) -> Result<HostData, String> {
-    let input_dtype = f32::elem_type_native();
-
     if let Some(p) = progress {
         let out_shape = output_shape_for(&shape, axis, &config);
         let total: usize = out_shape.iter().product();
         p.set_total(total as u64);
     }
 
+    // A narrow dtype rounds on the way in, so the reference folds what the
+    // tensor ended up holding rather than what the generator was handed.
     let (_input_handle, input_host) = TestInput::builder(client.clone(), shape)
         .dtype(input_dtype)
         .uniform(seed, -1., 1.)
@@ -232,7 +233,9 @@ fn output_shape_for(shape: &[usize], axis: usize, config: &ReduceOperationConfig
     out
 }
 
-fn output_dtype_for(config: &ReduceOperationConfig, input_dtype: ElemType) -> ElemType {
+/// What a `reduce` of `config` writes: a coordinate for the `Arg*` family, the
+/// input's own element type for everything else.
+pub fn output_dtype_for(config: &ReduceOperationConfig, input_dtype: ElemType) -> ElemType {
     match config {
         ReduceOperationConfig::ArgMax
         | ReduceOperationConfig::ArgMin

--- a/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
+++ b/crates/cubek-reduce/src/eval/cpu_reference/mod.rs
@@ -135,7 +135,7 @@ pub fn strategy_result(
 ) -> Result<HostData, String> {
     let input_dtype = input.dtype;
     let output_dtype = output_dtype_for(&config, input_dtype);
-    let accumulation_dtype = f32::elem_type_native();
+    let accumulation_dtype = accumulation_dtype();
 
     let input_handle = input
         .tensor(client.clone(), shape.clone())
@@ -192,7 +192,7 @@ pub fn strategy_result_with_indices(
 ) -> Result<HostData, String> {
     let input_dtype = input.dtype;
     let index_dtype = u32::elem_type_native();
-    let accumulation_dtype = f32::elem_type_native();
+    let accumulation_dtype = accumulation_dtype();
 
     let input_handle = input
         .tensor(client.clone(), shape.clone())
@@ -314,6 +314,12 @@ pub fn output_dtype_for(config: &ReduceOperationConfig, input_dtype: ElemType) -
         | ReduceOperationConfig::ArgTopK(_) => u32::elem_type_native(),
         _ => input_dtype,
     }
+}
+
+/// What every `reduce`/`reduce_with_indices` launch folds into, regardless of
+/// the input or output element type.
+pub fn accumulation_dtype() -> ElemType {
+    f32::elem_type_native()
 }
 
 pub fn contiguous_strides(shape: &[usize]) -> Strides {

--- a/crates/cubek-reduce/tests/reduce/bench_catalog.rs
+++ b/crates/cubek-reduce/tests/reduce/bench_catalog.rs
@@ -3,7 +3,9 @@
 #![cfg(feature = "benchmarks")]
 
 use cubek_reduce::ReduceStrategy;
-use cubek_reduce::eval::benchmarks::{ReduceBenchPrecision, ReduceCorrectness, ReduceProblem};
+use cubek_reduce::eval::benchmarks::{
+    ReduceBenchPrecision, ReduceCorrectness, ReduceProblem, precisions, problems, strategies,
+};
 use cubek_reduce::eval::cpu_reference::comparison_epsilon;
 use cubek_test_utils::{CatalogEntry, Correctness, TestOutcome, assert_equals_approx};
 
@@ -18,8 +20,6 @@ fn lookup<T>(entries: Vec<CatalogEntry<T>>, id: &str) -> T {
 }
 
 fn run(strategy_id: &str, problem_id: &str) {
-    use cubek_reduce::eval::benchmarks::{problems, strategies};
-
     let strategy: ReduceStrategy = lookup(strategies(), strategy_id);
     let problem: ReduceProblem = lookup(problems(), problem_id);
 
@@ -36,146 +36,63 @@ fn run(strategy_id: &str, problem_id: &str) {
         .enforce();
 }
 
-/// The catalogue only offers f16 rows where the device can fold them, so a
-/// runtime without f16 has no `_f16` id to look up.
+/// Takes the f32 id and derives the f16 one, since the catalogue offers f16
+/// rows only where the device can fold them and there is nothing to look up
+/// otherwise.
 fn run_f16(strategy_id: &str, problem_id: &str) {
-    use cubek_reduce::eval::benchmarks::precisions;
-
-    if !precisions().contains(&ReduceBenchPrecision::F16) {
+    let f16 = ReduceBenchPrecision::F16;
+    if !precisions().contains(&f16) {
         return;
     }
-    run(strategy_id, problem_id);
+    run(strategy_id, &format!("{problem_id}{}", f16.suffix()));
 }
 
-#[test]
-fn sum_axis2_32x512x4095_unit_parallel() {
-    run("unit_parallel", "sum_axis2_32x512x4095");
+/// Each pair is checked at both precisions, under a module named for the shape
+/// so a second one does not collide. The list is a subset because one pair folds
+/// 67M elements against the host reference; what is missing has no check at all.
+macro_rules! bench_catalog {
+    ($shape:ident; $($problem:ident: [$($strategy:ident),+ $(,)?]),+ $(,)?) => {
+        mod $shape {
+            use super::*;
+
+            $(mod $problem {
+                use super::*;
+
+                $(mod $strategy {
+                    use super::*;
+
+                    const STRATEGY: &str = stringify!($strategy);
+                    const PROBLEM: &str = concat!(stringify!($problem), "_", stringify!($shape));
+
+                    #[test]
+                    fn f32() {
+                        run(STRATEGY, PROBLEM);
+                    }
+
+                    #[test]
+                    fn f16() {
+                        run_f16(STRATEGY, PROBLEM);
+                    }
+                })+
+            })+
+        }
+    };
 }
 
-#[test]
-fn sum_axis2_32x512x4095_plane_parallel() {
-    run("plane_parallel", "sum_axis2_32x512x4095");
-}
+bench_catalog! {
+    axis2_32x512x4095;
 
-#[test]
-fn arg_topk1_axis2_32x512x4095_unit_parallel() {
-    run("unit_parallel", "arg_topk1_axis2_32x512x4095");
-}
+    sum: [unit_parallel, plane_parallel],
+    arg_topk1: [unit_parallel],
+    arg_topk2: [unit_parallel],
+    arg_topk3: [unit_parallel],
 
-#[test]
-fn arg_topk2_axis2_32x512x4095_unit_parallel() {
-    run("unit_parallel", "arg_topk2_axis2_32x512x4095");
-}
-
-#[test]
-fn arg_topk3_axis2_32x512x4095_unit_parallel() {
-    run("unit_parallel", "arg_topk3_axis2_32x512x4095");
-}
-
-// The fused entries get timed against the two-launch ones, so they have to be
-// correct at the benchmark's own shape and strategy, not only at the small
-// shapes the integration tests cover.
-#[test]
-fn topk2_fused_axis2_32x512x4095_cube_serial() {
-    run("cube_serial", "topk2_fused_axis2_32x512x4095");
-}
-
-#[test]
-fn topk3_fused_axis2_32x512x4095_cube_serial() {
-    run("cube_serial", "topk3_fused_axis2_32x512x4095");
-}
-
-#[test]
-fn topk3_fused_axis2_32x512x4095_unit_parallel() {
-    run("unit_parallel", "topk3_fused_axis2_32x512x4095");
-}
-
-#[test]
-fn topk3_two_launch_axis2_32x512x4095_cube_serial() {
-    run("cube_serial", "topk3_two_launch_axis2_32x512x4095");
-}
-
-#[test]
-fn max_fused_axis2_32x512x4095_unit_parallel() {
-    run("unit_parallel", "max_fused_axis2_32x512x4095");
-}
-
-#[test]
-fn max_fused_axis2_32x512x4095_cube_serial() {
-    run("cube_serial", "max_fused_axis2_32x512x4095");
-}
-
-#[test]
-fn min_fused_axis2_32x512x4095_unit_parallel() {
-    run("unit_parallel", "min_fused_axis2_32x512x4095");
-}
-
-#[test]
-fn min_fused_axis2_32x512x4095_cube_serial() {
-    run("cube_serial", "min_fused_axis2_32x512x4095");
-}
-
-#[test]
-fn sum_axis2_32x512x4095_f16_unit_parallel() {
-    run_f16("unit_parallel", "sum_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn sum_axis2_32x512x4095_f16_plane_parallel() {
-    run_f16("plane_parallel", "sum_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn arg_topk1_axis2_32x512x4095_f16_unit_parallel() {
-    run_f16("unit_parallel", "arg_topk1_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn arg_topk2_axis2_32x512x4095_f16_unit_parallel() {
-    run_f16("unit_parallel", "arg_topk2_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn arg_topk3_axis2_32x512x4095_f16_unit_parallel() {
-    run_f16("unit_parallel", "arg_topk3_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn topk2_fused_axis2_32x512x4095_f16_cube_serial() {
-    run_f16("cube_serial", "topk2_fused_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn topk3_fused_axis2_32x512x4095_f16_cube_serial() {
-    run_f16("cube_serial", "topk3_fused_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn topk3_fused_axis2_32x512x4095_f16_unit_parallel() {
-    run_f16("unit_parallel", "topk3_fused_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn topk3_two_launch_axis2_32x512x4095_f16_cube_serial() {
-    run_f16("cube_serial", "topk3_two_launch_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn max_fused_axis2_32x512x4095_f16_unit_parallel() {
-    run_f16("unit_parallel", "max_fused_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn max_fused_axis2_32x512x4095_f16_cube_serial() {
-    run_f16("cube_serial", "max_fused_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn min_fused_axis2_32x512x4095_f16_unit_parallel() {
-    run_f16("unit_parallel", "min_fused_axis2_32x512x4095_f16");
-}
-
-#[test]
-fn min_fused_axis2_32x512x4095_f16_cube_serial() {
-    run_f16("cube_serial", "min_fused_axis2_32x512x4095_f16");
+    // The fused entries get timed against the two-launch ones, so they have to be
+    // correct at the benchmark's own shape and strategy, not only at the small
+    // shapes the integration tests cover.
+    topk2_fused: [cube_serial],
+    topk3_fused: [unit_parallel, cube_serial],
+    topk3_two_launch: [cube_serial],
+    max_fused: [unit_parallel, cube_serial],
+    min_fused: [unit_parallel, cube_serial],
 }

--- a/crates/cubek-reduce/tests/reduce/bench_catalog.rs
+++ b/crates/cubek-reduce/tests/reduce/bench_catalog.rs
@@ -3,7 +3,7 @@
 #![cfg(feature = "benchmarks")]
 
 use cubek_reduce::ReduceStrategy;
-use cubek_reduce::eval::benchmarks::{ReduceCorrectness, ReduceProblem};
+use cubek_reduce::eval::benchmarks::{ReduceBenchPrecision, ReduceCorrectness, ReduceProblem};
 use cubek_test_utils::{CatalogEntry, Correctness, TestOutcome, assert_equals_approx};
 
 const SEEDS: [u64; 2] = [12, 34];
@@ -38,6 +38,17 @@ fn run(strategy_id: &str, problem_id: &str) {
     assert_equals_approx(&actual, &expected, REDUCE_EPS)
         .as_test_outcome()
         .enforce();
+}
+
+/// The catalogue only offers f16 rows where the device can fold them, so a
+/// runtime without f16 has no `_f16` id to look up.
+fn run_f16(strategy_id: &str, problem_id: &str) {
+    use cubek_reduce::eval::benchmarks::precisions;
+
+    if !precisions().contains(&ReduceBenchPrecision::F16) {
+        return;
+    }
+    run(strategy_id, problem_id);
 }
 
 #[test]
@@ -106,4 +117,69 @@ fn min_fused_axis2_32x512x4095_unit_parallel() {
 #[test]
 fn min_fused_axis2_32x512x4095_cube_serial() {
     run("cube_serial", "min_fused_axis2_32x512x4095");
+}
+
+#[test]
+fn sum_axis2_32x512x4095_f16_unit_parallel() {
+    run_f16("unit_parallel", "sum_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn sum_axis2_32x512x4095_f16_plane_parallel() {
+    run_f16("plane_parallel", "sum_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn arg_topk1_axis2_32x512x4095_f16_unit_parallel() {
+    run_f16("unit_parallel", "arg_topk1_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn arg_topk2_axis2_32x512x4095_f16_unit_parallel() {
+    run_f16("unit_parallel", "arg_topk2_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn arg_topk3_axis2_32x512x4095_f16_unit_parallel() {
+    run_f16("unit_parallel", "arg_topk3_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn topk2_fused_axis2_32x512x4095_f16_cube_serial() {
+    run_f16("cube_serial", "topk2_fused_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn topk3_fused_axis2_32x512x4095_f16_cube_serial() {
+    run_f16("cube_serial", "topk3_fused_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn topk3_fused_axis2_32x512x4095_f16_unit_parallel() {
+    run_f16("unit_parallel", "topk3_fused_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn topk3_two_launch_axis2_32x512x4095_f16_cube_serial() {
+    run_f16("cube_serial", "topk3_two_launch_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn max_fused_axis2_32x512x4095_f16_unit_parallel() {
+    run_f16("unit_parallel", "max_fused_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn max_fused_axis2_32x512x4095_f16_cube_serial() {
+    run_f16("cube_serial", "max_fused_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn min_fused_axis2_32x512x4095_f16_unit_parallel() {
+    run_f16("unit_parallel", "min_fused_axis2_32x512x4095_f16");
+}
+
+#[test]
+fn min_fused_axis2_32x512x4095_f16_cube_serial() {
+    run_f16("cube_serial", "min_fused_axis2_32x512x4095_f16");
 }

--- a/crates/cubek-reduce/tests/reduce/bench_catalog.rs
+++ b/crates/cubek-reduce/tests/reduce/bench_catalog.rs
@@ -4,14 +4,10 @@
 
 use cubek_reduce::ReduceStrategy;
 use cubek_reduce::eval::benchmarks::{ReduceBenchPrecision, ReduceCorrectness, ReduceProblem};
+use cubek_reduce::eval::cpu_reference::comparison_epsilon;
 use cubek_test_utils::{CatalogEntry, Correctness, TestOutcome, assert_equals_approx};
 
 const SEEDS: [u64; 2] = [12, 34];
-
-/// f32 reductions over ~tens of millions of elements; some kernels accumulate
-/// noticeable noise. Tightened tolerances belong in the existing per-routine
-/// integration tests.
-const REDUCE_EPS: f32 = 1.0;
 
 fn lookup<T>(entries: Vec<CatalogEntry<T>>, id: &str) -> T {
     entries
@@ -35,7 +31,7 @@ fn run(strategy_id: &str, problem_id: &str) {
         .reference_result(&problem, &SEEDS, None)
         .unwrap_or_else(|e| panic!("reference failed for {problem_id}: {e}"));
 
-    assert_equals_approx(&actual, &expected, REDUCE_EPS)
+    assert_equals_approx(&actual, &expected, comparison_epsilon(problem.config))
         .as_test_outcome()
         .enforce();
 }

--- a/crates/cubek-reduce/tests/reduce/it/nan_extrema.rs
+++ b/crates/cubek-reduce/tests/reduce/it/nan_extrema.rs
@@ -1,7 +1,6 @@
 use cubecl::{
     config::autotune::AutotuneLevel,
     features::Plane,
-    prelude::Scalar,
     zspace::{Shape, Strides},
 };
 use cubek_reduce::{

--- a/crates/cubek-reduce/tests/reduce/it/nan_extrema.rs
+++ b/crates/cubek-reduce/tests/reduce/it/nan_extrema.rs
@@ -1,6 +1,6 @@
 use cubecl::{
     config::autotune::AutotuneLevel,
-    features::{Plane, TypeUsage},
+    features::Plane,
     prelude::Scalar,
     zspace::{Shape, Strides},
 };
@@ -18,8 +18,7 @@ fn supports_plane() -> bool {
 }
 
 fn supports_f16_arithmetic() -> bool {
-    let client = cubecl::test_device().client();
-    half::f16::supported_uses(&client).contains(TypeUsage::Arithmetic)
+    cubek_test_utils::supports_f16_arithmetic(&cubecl::test_device().client())
 }
 
 fn run_extrema(case: TestCase, data: Vec<f32>) {

--- a/crates/cubek-std/src/eval/benchmarks/contiguous/benchmark.rs
+++ b/crates/cubek-std/src/eval/benchmarks/contiguous/benchmark.rs
@@ -29,7 +29,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-std/src/eval/benchmarks/contiguous/mod.rs
+++ b/crates/cubek-std/src/eval/benchmarks/contiguous/mod.rs
@@ -24,7 +24,7 @@ impl cubek_test_utils::Category for Category {
     }
 
     fn timing_method(&self) -> cubecl::benchmark::TimingMethod {
-        cubecl::benchmark::TimingMethod::Device
+        cubek_test_utils::timing_method(cubecl::benchmark::TimingMethod::Device)
     }
 
     fn problems(&self) -> Vec<CatalogEntry<ContiguousProblem>> {

--- a/crates/cubek-std/src/eval/benchmarks/memcpy_async/benchmark.rs
+++ b/crates/cubek-std/src/eval/benchmarks/memcpy_async/benchmark.rs
@@ -754,10 +754,6 @@ impl<E: Float> Benchmark for MemcpyAsyncBench<E> {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .profile(|| self.execute(args), "memcpy-async-bench")
-            .map_err(|it| format!("{it:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "memcpy-async-bench", || self.execute(args))
     }
 }

--- a/crates/cubek-std/src/eval/benchmarks/memcpy_async/benchmark.rs
+++ b/crates/cubek-std/src/eval/benchmarks/memcpy_async/benchmark.rs
@@ -682,7 +682,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-std/src/eval/benchmarks/memcpy_async/mod.rs
+++ b/crates/cubek-std/src/eval/benchmarks/memcpy_async/mod.rs
@@ -24,7 +24,7 @@ impl cubek_test_utils::Category for Category {
     }
 
     fn timing_method(&self) -> cubecl::benchmark::TimingMethod {
-        cubecl::benchmark::TimingMethod::Device
+        cubek_test_utils::timing_method(cubecl::benchmark::TimingMethod::Device)
     }
 
     fn problems(&self) -> Vec<CatalogEntry<MemcpyAsyncProblem>> {

--- a/crates/cubek-std/src/eval/benchmarks/unary/benchmark.rs
+++ b/crates/cubek-std/src/eval/benchmarks/unary/benchmark.rs
@@ -45,7 +45,7 @@ pub fn bench(
     };
 
     let durations = bench
-        .run(TimingMethod::Device)
+        .run(cubek_test_utils::timing_method(TimingMethod::Device))
         .map_err(|e| format!("benchmark failed: {e}"))?
         .durations;
 

--- a/crates/cubek-std/src/eval/benchmarks/unary/benchmark.rs
+++ b/crates/cubek-std/src/eval/benchmarks/unary/benchmark.rs
@@ -123,11 +123,6 @@ impl<E: Float> Benchmark for UnaryBench<E> {
     }
 
     fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
-        let (launched, duration) = self
-            .client
-            .clone()
-            .profile(|| self.execute(args), "unary-bench")
-            .map_err(|it| format!("{it:?}"))?;
-        launched.map(|_| duration)
+        cubek_test_utils::profile_launch(&self.client, "unary-bench", || self.execute(args))
     }
 }

--- a/crates/cubek-std/src/eval/benchmarks/unary/mod.rs
+++ b/crates/cubek-std/src/eval/benchmarks/unary/mod.rs
@@ -24,7 +24,7 @@ impl cubek_test_utils::Category for Category {
     }
 
     fn timing_method(&self) -> cubecl::benchmark::TimingMethod {
-        cubecl::benchmark::TimingMethod::Device
+        cubek_test_utils::timing_method(cubecl::benchmark::TimingMethod::Device)
     }
 
     fn problems(&self) -> Vec<CatalogEntry<UnaryProblem>> {

--- a/crates/cubek-test-utils/src/lib.rs
+++ b/crates/cubek-test-utils/src/lib.rs
@@ -16,7 +16,7 @@ pub use correctness::{
 pub use progress::Progress;
 pub use registry::{
     BenchmarkCategory, Binding, CatalogEntry, Category, CategoryWork, ComputeWork, Correctness,
-    ItemDescriptor, ResourceKind, RunSamples, client,
+    ItemDescriptor, ResourceKind, RunSamples, client, profile_launch,
 };
 pub use test_mode::*;
 pub use test_tensor::*;

--- a/crates/cubek-test-utils/src/lib.rs
+++ b/crates/cubek-test-utils/src/lib.rs
@@ -16,7 +16,7 @@ pub use correctness::{
 pub use progress::Progress;
 pub use registry::{
     BenchmarkCategory, Binding, CatalogEntry, Category, CategoryWork, ComputeWork, Correctness,
-    ItemDescriptor, ResourceKind, RunSamples, client, profile_launch,
+    ItemDescriptor, ResourceKind, RunSamples, client, profile_launch, timing_method,
 };
 pub use test_mode::*;
 pub use test_tensor::*;

--- a/crates/cubek-test-utils/src/lib.rs
+++ b/crates/cubek-test-utils/src/lib.rs
@@ -16,7 +16,8 @@ pub use correctness::{
 pub use progress::Progress;
 pub use registry::{
     BenchmarkCategory, Binding, CatalogEntry, Category, CategoryWork, ComputeWork, Correctness,
-    ItemDescriptor, ResourceKind, RunSamples, client, profile_launch, timing_method,
+    ItemDescriptor, ResourceKind, RunSamples, client, profile_launch, supports_f16_arithmetic,
+    timing_method,
 };
 pub use test_mode::*;
 pub use test_tensor::*;

--- a/crates/cubek-test-utils/src/registry.rs
+++ b/crates/cubek-test-utils/src/registry.rs
@@ -10,7 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
-use cubecl::benchmark::TimingMethod;
+use cubecl::benchmark::{ProfileDuration, TimingMethod};
 use cubecl::client::Client;
 use cubecl::prelude::*;
 use cubecl::std::throughput::{measure_memory_curve, measure_peak_throughput};
@@ -19,6 +19,23 @@ use cubecl::throughput::{
 };
 
 use crate::{HostData, Progress};
+
+/// Times one launch on the device, failing the row when the launch itself failed.
+///
+/// Categories override [`Benchmark::profile`](cubecl::benchmark::Benchmark::profile) only to
+/// name their profiling scope. Writing that override by hand invites keeping the duration and
+/// dropping the launch result, which reports the time a failure took as a measurement.
+pub fn profile_launch<O: Send + 'static>(
+    client: &Client,
+    scope: &str,
+    launch: impl FnOnce() -> Result<O, String> + Send,
+) -> Result<ProfileDuration, String> {
+    let (launched, duration) = client
+        .profile(launch, scope)
+        .map_err(|err| format!("{err:?}"))?;
+
+    launched.map(|_| duration)
+}
 
 /// The client every category scores against: `measure_peak_throughput` is
 /// always run on `cubecl::test_device()`, so the

--- a/crates/cubek-test-utils/src/registry.rs
+++ b/crates/cubek-test-utils/src/registry.rs
@@ -20,6 +20,18 @@ use cubecl::throughput::{
 
 use crate::{HostData, Progress};
 
+/// The timing method a category measures with, overridden for a whole run by
+/// `CUBEK_BENCH_TIMING`. Device timestamps leave the launch out, so a row that
+/// beats its ceiling is checked by measuring it again on the wall clock.
+pub fn timing_method(default: TimingMethod) -> TimingMethod {
+    match std::env::var("CUBEK_BENCH_TIMING").as_deref() {
+        Ok("device") => TimingMethod::Device,
+        Ok("system") => TimingMethod::System,
+        Ok(other) => panic!("CUBEK_BENCH_TIMING takes 'device' or 'system', not {other:?}"),
+        Err(_) => default,
+    }
+}
+
 /// Times one launch on the device, failing the row when the launch itself failed.
 ///
 /// Categories override [`Benchmark::profile`](cubecl::benchmark::Benchmark::profile) only to
@@ -406,7 +418,7 @@ pub trait Category: Sync {
     /// running on the device timing method (unary/contiguous/memcpy_async)
     /// override this.
     fn timing_method(&self) -> TimingMethod {
-        TimingMethod::System
+        crate::timing_method(TimingMethod::System)
     }
 
     /// Override to expose seeded `kernel_result` / `reference_result`. Decoupled

--- a/crates/cubek-test-utils/src/registry.rs
+++ b/crates/cubek-test-utils/src/registry.rs
@@ -23,14 +23,13 @@ use crate::{HostData, Progress};
 
 /// `CUBEK_BENCH_TIMING`'s override, read once: it can't change over a
 /// process's life, and every category consults it once per row.
-static TIMING_OVERRIDE: LazyLock<Option<TimingMethod>> = LazyLock::new(|| {
-    match std::env::var("CUBEK_BENCH_TIMING").as_deref() {
+static TIMING_OVERRIDE: LazyLock<Option<TimingMethod>> =
+    LazyLock::new(|| match std::env::var("CUBEK_BENCH_TIMING").as_deref() {
         Ok("device") => Some(TimingMethod::Device),
         Ok("system") => Some(TimingMethod::System),
         Ok(other) => panic!("CUBEK_BENCH_TIMING takes 'device' or 'system', not {other:?}"),
         Err(_) => None,
-    }
-});
+    });
 
 /// The timing method a category measures with, overridden for a whole run by
 /// `CUBEK_BENCH_TIMING`. Device timestamps leave the launch out, so a row that

--- a/crates/cubek-test-utils/src/registry.rs
+++ b/crates/cubek-test-utils/src/registry.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use cubecl::benchmark::{ProfileDuration, TimingMethod};
 use cubecl::client::Client;
+use cubecl::features::TypeUsage;
 use cubecl::prelude::*;
 use cubecl::std::throughput::{measure_memory_curve, measure_peak_throughput};
 use cubecl::throughput::{
@@ -20,16 +21,29 @@ use cubecl::throughput::{
 
 use crate::{HostData, Progress};
 
+/// `CUBEK_BENCH_TIMING`'s override, read once: it can't change over a
+/// process's life, and every category consults it once per row.
+static TIMING_OVERRIDE: LazyLock<Option<TimingMethod>> = LazyLock::new(|| {
+    match std::env::var("CUBEK_BENCH_TIMING").as_deref() {
+        Ok("device") => Some(TimingMethod::Device),
+        Ok("system") => Some(TimingMethod::System),
+        Ok(other) => panic!("CUBEK_BENCH_TIMING takes 'device' or 'system', not {other:?}"),
+        Err(_) => None,
+    }
+});
+
 /// The timing method a category measures with, overridden for a whole run by
 /// `CUBEK_BENCH_TIMING`. Device timestamps leave the launch out, so a row that
 /// beats its ceiling is checked by measuring it again on the wall clock.
 pub fn timing_method(default: TimingMethod) -> TimingMethod {
-    match std::env::var("CUBEK_BENCH_TIMING").as_deref() {
-        Ok("device") => TimingMethod::Device,
-        Ok("system") => TimingMethod::System,
-        Ok(other) => panic!("CUBEK_BENCH_TIMING takes 'device' or 'system', not {other:?}"),
-        Err(_) => default,
-    }
+    TIMING_OVERRIDE.unwrap_or(default)
+}
+
+/// Whether `client`'s device can carry out `f16` arithmetic, not just storage.
+/// A category benchmarking a narrower dtype checks this before adding rows a
+/// runtime without hardware or software f16 support would only fail on.
+pub fn supports_f16_arithmetic(client: &Client) -> bool {
+    half::f16::supported_uses(client).contains(TypeUsage::Arithmetic)
 }
 
 /// Times one launch on the device, failing the row when the launch itself failed.

--- a/crates/cubek-test-utils/src/registry.rs
+++ b/crates/cubek-test-utils/src/registry.rs
@@ -38,9 +38,8 @@ pub fn timing_method(default: TimingMethod) -> TimingMethod {
     TIMING_OVERRIDE.unwrap_or(default)
 }
 
-/// Whether `client`'s device can carry out `f16` arithmetic, not just storage.
-/// A category benchmarking a narrower dtype checks this before adding rows a
-/// runtime without hardware or software f16 support would only fail on.
+/// Whether `client`'s device does real f16 arithmetic, not just storage, so a
+/// category can skip f16 rows the device would only fail on.
 pub fn supports_f16_arithmetic(client: &Client) -> bool {
     half::f16::supported_uses(client).contains(TypeUsage::Arithmetic)
 }


### PR DESCRIPTION
Five changes so that a number from the harness can be trusted, applied to every category rather than to reduce alone.

### What changed

- **Proof before timing.** A benchmarked pair is checked on a small shape before it is timed. A kernel that failed to compile used to be timed anyway and reported as fast.
- **One timing switch.** `CUBEK_BENCH_TIMING=device|system` overrides every category's timing method for a whole run, so a row that beats its ceiling can be re-measured on the wall clock without editing code.
- **One profile helper.** `profile_launch` replaces fifteen near-identical copies of the same block.
- **f16 in the catalogue.** Offered beside f32 wherever the device can fold it.
- **Generated catalogue tests.** The checked pairs come from one macro instead of a hand-written list. A test reads `reduce::bench_catalog::axis2_32x512x4095::sum::unit_parallel::f32`.

### What it settled

Device timestamps and the wall clock agree within about 3 microseconds on every row, which is exactly the card's launch overhead. The device timer is honest. The rows that beat their ceiling are the byte model's doing: it credits a launch with traffic it never moved.

### State

928 CPU tests, 26 Vulkan tests and a full-tier library compile are clean.
