### PR TITLE
Serve a mutable tile view at an element other than its cells'

### DIFF
--- a/crates/cubek-tile/src/tile/view/cast.rs
+++ b/crates/cubek-tile/src/tile/view/cast.rs
@@ -5,10 +5,10 @@
 //! ([`PackedView`](super::PackedView)): it reads and writes the one element it works in and
 //! never casts.
 //!
-//! The consumer this is for is a memory-backed accumulator whose sum runs wider than its cells.
-//! A cell summed in its own element stops growing once a product falls under half its spacing —
-//! an `f16` sum of values near one goes no further than 2048 — so a half-precision accumulator
-//! sums in `f32`. That change is not in this commit; nothing reads this view yet.
+//! Neither element has to be the wider one. A memory-backed accumulator serves `f32` over `f16`
+//! cells, because a cell summed in its own element stops growing once a product falls under half
+//! its spacing — an `f16` sum of values near one goes no further than 2048. A drain serves the
+//! other way, `f16` over `f32` cells, and rounds the accumulated result on the way in.
 
 use std::marker::PhantomData;
 
@@ -23,9 +23,9 @@ use cubecl::{
     },
 };
 
-/// A [`ViewMut`] over cells stored at `S`, read and written as `Vector<E, V>`: widened on the
-/// way out, narrowed on the way in, and touched nowhere else. The mutable twin of the packed
-/// read, for the accumulating side.
+/// A [`ViewMut`] over cells stored at `S`, read and written as `Vector<E, V>`: cast to the
+/// served element on the way out, back to the stored one on the way in, and touched nowhere
+/// else. The mutable twin of the packed read, for the accumulating side.
 #[expect(dead_code, reason = "read through the expand impls below")]
 #[derive(CubeType, Clone)]
 pub(crate) struct CastViewMut<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> {
@@ -59,7 +59,7 @@ impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> CastViewMut<'a, S
 }
 
 impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> CastViewMutExpand<'a, S, E, V, C> {
-    fn widen(
+    fn to_served(
         &self,
         scope: &Scope,
         stored: NativeExpand<Vector<S, V>>,
@@ -67,7 +67,7 @@ impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> CastViewMutExpand
         Vector::<E, V>::__expand_cast_from::<Vector<S, V>>(scope, stored)
     }
 
-    fn narrow(
+    fn to_stored(
         &self,
         scope: &Scope,
         served: NativeExpand<Vector<E, V>>,
@@ -107,7 +107,7 @@ impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> ViewOperationsExp
         pos: C::ExpandType,
     ) -> NativeExpand<Vector<E, V>> {
         let stored = self.stored.clone().__expand_read_method(scope, pos);
-        self.widen(scope, stored)
+        self.to_served(scope, stored)
     }
 
     fn __expand_read_checked_method(
@@ -116,7 +116,7 @@ impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> ViewOperationsExp
         pos: C::ExpandType,
     ) -> NativeExpand<Vector<E, V>> {
         let stored = self.stored.clone().__expand_read_checked_method(scope, pos);
-        self.widen(scope, stored)
+        self.to_served(scope, stored)
     }
 
     fn __expand_read_masked_method(
@@ -126,13 +126,13 @@ impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> ViewOperationsExp
         mask_value: NativeExpand<Vector<E, V>>,
     ) -> NativeExpand<Vector<E, V>> {
         // The mask is a served value, so it is selected at the served element rather than
-        // narrowed into the store and widened back.
+        // cast into the store and back.
         let stored = self
             .stored
             .clone()
             .__expand_read_checked_method(scope, pos.clone());
         let in_bounds = self.__expand_is_in_bounds_method(scope, pos);
-        let value = self.widen(scope, stored);
+        let value = self.to_served(scope, stored);
         select::expand::<Vector<E, V>>(scope, in_bounds, value, mask_value)
     }
 
@@ -145,7 +145,7 @@ impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> ViewOperationsExp
             .stored
             .clone()
             .__expand_read_unchecked_method(scope, pos);
-        self.widen(scope, stored)
+        self.to_served(scope, stored)
     }
 
     fn __expand_as_linear_slice_method(
@@ -194,7 +194,7 @@ impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a>
         pos: C::ExpandType,
         value: NativeExpand<Vector<E, V>>,
     ) {
-        let stored = self.narrow(scope, value);
+        let stored = self.to_stored(scope, value);
         self.stored
             .clone()
             .__expand_write_method(scope, pos, stored);
@@ -206,7 +206,7 @@ impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a>
         pos: C::ExpandType,
         value: NativeExpand<Vector<E, V>>,
     ) {
-        let stored = self.narrow(scope, value);
+        let stored = self.to_stored(scope, value);
         self.stored
             .clone()
             .__expand_write_checked_method(scope, pos, stored);

--- a/crates/cubek-tile/src/tile/view/cast.rs
+++ b/crates/cubek-tile/src/tile/view/cast.rs
@@ -1,0 +1,232 @@
+//! Cells stored at one element, served at another.
+//!
+//! Where a consumer works in an element the cells are not stored at, the cast belongs to the
+//! view rather than to the reader, the way a packed operand's unpacking does
+//! ([`PackedView`](super::PackedView)): it reads and writes the one element it works in and
+//! never casts.
+//!
+//! The consumer this is for is a memory-backed accumulator whose sum runs wider than its cells.
+//! A cell summed in its own element stops growing once a product falls under half its spacing —
+//! an `f16` sum of values near one goes no further than 2048 — so a half-precision accumulator
+//! sums in `f32`. That change is not in this commit; nothing reads this view yet.
+
+use std::marker::PhantomData;
+
+use cubecl::ir::VectorSize;
+use cubecl::prelude::barrier::Barrier;
+use cubecl::unexpanded;
+use cubecl::{
+    prelude::*,
+    std::tensor::{
+        ViewMut, ViewMutExpand, ViewOperations, ViewOperationsExpand, ViewOperationsMut,
+        ViewOperationsMutExpand, layout::Coordinates,
+    },
+};
+
+/// A [`ViewMut`] over cells stored at `S`, read and written as `Vector<E, V>`: widened on the
+/// way out, narrowed on the way in, and touched nowhere else. The mutable twin of the packed
+/// read, for the accumulating side.
+#[expect(dead_code, reason = "read through the expand impls below")]
+#[derive(CubeType, Clone)]
+pub(crate) struct CastViewMut<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> {
+    stored: ViewMut<'a, Vector<S, V>, C>,
+    #[cube(comptime)]
+    _served: PhantomData<E>,
+}
+
+#[cube]
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> CastViewMut<'a, S, E, V, C> {
+    pub fn new(stored: ViewMut<'a, Vector<S, V>, C>) -> Self {
+        CastViewMut::<'a, S, E, V, C> {
+            stored,
+            _served: PhantomData,
+        }
+    }
+}
+
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> CastViewMut<'a, S, E, V, C> {
+    /// This view as a plain [`ViewMut`] of served values, which is what every accumulator takes.
+    pub fn view_mut(self) -> ViewMut<'a, Vector<E, V>, C> {
+        unexpanded!()
+    }
+
+    pub fn __expand_view_mut(
+        scope: &Scope,
+        this: CastViewMutExpand<'a, S, E, V, C>,
+    ) -> ViewMutExpand<'a, Vector<E, V>, C> {
+        this.__expand_view_mut_method(scope)
+    }
+}
+
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> CastViewMutExpand<'a, S, E, V, C> {
+    fn widen(
+        &self,
+        scope: &Scope,
+        stored: NativeExpand<Vector<S, V>>,
+    ) -> NativeExpand<Vector<E, V>> {
+        Vector::<E, V>::__expand_cast_from::<Vector<S, V>>(scope, stored)
+    }
+
+    fn narrow(
+        &self,
+        scope: &Scope,
+        served: NativeExpand<Vector<E, V>>,
+    ) -> NativeExpand<Vector<S, V>> {
+        Vector::<S, V>::__expand_cast_from::<Vector<E, V>>(scope, served)
+    }
+
+    pub fn __expand_view_mut_method(self, scope: &Scope) -> ViewMutExpand<'a, Vector<E, V>, C> {
+        ViewMutExpand::new(scope, self)
+    }
+}
+
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> Vectorized
+    for CastViewMut<'a, S, E, V, C>
+{
+}
+
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> VectorizedExpand
+    for CastViewMutExpand<'a, S, E, V, C>
+{
+    fn __expand_vector_size_method(&self, scope: &Scope) -> VectorSize {
+        self.stored.__expand_vector_size_method(scope)
+    }
+}
+
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> ViewOperations<Vector<E, V>, C>
+    for CastViewMut<'a, S, E, V, C>
+{
+}
+
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> ViewOperationsExpand<Vector<E, V>, C>
+    for CastViewMutExpand<'a, S, E, V, C>
+{
+    fn __expand_read_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+    ) -> NativeExpand<Vector<E, V>> {
+        let stored = self.stored.clone().__expand_read_method(scope, pos);
+        self.widen(scope, stored)
+    }
+
+    fn __expand_read_checked_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+    ) -> NativeExpand<Vector<E, V>> {
+        let stored = self.stored.clone().__expand_read_checked_method(scope, pos);
+        self.widen(scope, stored)
+    }
+
+    fn __expand_read_masked_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+        mask_value: NativeExpand<Vector<E, V>>,
+    ) -> NativeExpand<Vector<E, V>> {
+        // The mask is a served value, so it is selected at the served element rather than
+        // narrowed into the store and widened back.
+        let stored = self
+            .stored
+            .clone()
+            .__expand_read_checked_method(scope, pos.clone());
+        let in_bounds = self.__expand_is_in_bounds_method(scope, pos);
+        let value = self.widen(scope, stored);
+        select::expand::<Vector<E, V>>(scope, in_bounds, value, mask_value)
+    }
+
+    fn __expand_read_unchecked_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+    ) -> NativeExpand<Vector<E, V>> {
+        let stored = self
+            .stored
+            .clone()
+            .__expand_read_unchecked_method(scope, pos);
+        self.widen(scope, stored)
+    }
+
+    fn __expand_as_linear_slice_method(
+        &self,
+        _scope: &Scope,
+        _pos: C::ExpandType,
+        _end: C::ExpandType,
+    ) -> &SliceExpand<Vector<E, V>> {
+        panic!("CastViewMut: cells stored at another element have no raw slice of served values")
+    }
+
+    fn __expand_shape_method(&self, scope: &Scope) -> C::ExpandType {
+        self.stored.clone().__expand_shape_method(scope)
+    }
+
+    fn __expand_is_in_bounds_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+    ) -> NativeExpand<bool> {
+        self.stored.clone().__expand_is_in_bounds_method(scope, pos)
+    }
+
+    fn __expand_tensor_map_load_method(
+        &self,
+        _scope: &Scope,
+        _barrier: &NativeExpand<Barrier>,
+        _shared_memory: &mut SliceExpand<Vector<E, V>>,
+        _pos: C::ExpandType,
+    ) {
+        panic!("CastViewMut: a tensor map cannot cast on the fly")
+    }
+}
+
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a> ViewOperationsMut<Vector<E, V>, C>
+    for CastViewMut<'a, S, E, V, C>
+{
+}
+
+impl<'a, S: Numeric, E: Numeric, V: Size, C: Coordinates + 'a>
+    ViewOperationsMutExpand<Vector<E, V>, C> for CastViewMutExpand<'a, S, E, V, C>
+{
+    fn __expand_write_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+        value: NativeExpand<Vector<E, V>>,
+    ) {
+        let stored = self.narrow(scope, value);
+        self.stored
+            .clone()
+            .__expand_write_method(scope, pos, stored);
+    }
+
+    fn __expand_write_checked_method(
+        &self,
+        scope: &Scope,
+        pos: C::ExpandType,
+        value: NativeExpand<Vector<E, V>>,
+    ) {
+        let stored = self.narrow(scope, value);
+        self.stored
+            .clone()
+            .__expand_write_checked_method(scope, pos, stored);
+    }
+
+    fn __expand_as_linear_slice_mut_method(
+        &self,
+        _scope: &Scope,
+        _pos: C::ExpandType,
+        _end: C::ExpandType,
+    ) -> &mut SliceExpand<Vector<E, V>> {
+        panic!("CastViewMut: cells stored at another element have no raw slice of served values")
+    }
+
+    fn __expand_tensor_map_store_method(
+        &self,
+        _scope: &Scope,
+        _shared_memory: &SliceExpand<Vector<E, V>>,
+        _pos: C::ExpandType,
+    ) {
+        panic!("CastViewMut: a tensor map cannot cast on the fly")
+    }
+}

--- a/crates/cubek-tile/src/tile/view/masked.rs
+++ b/crates/cubek-tile/src/tile/view/masked.rs
@@ -114,8 +114,9 @@ impl<'a, T: CubePrimitive, C: Coordinates + 'a> MaskedViewMut<'a, T, C> {
 
 #[cube]
 impl<'a, S: Numeric, V: Size, C: Coordinates + 'a> MaskedViewMut<'a, Vector<S, V>, C> {
-    /// These cells served at `E`: read widened, written narrowed, masked the same. What a
-    /// consumer working in an element the cells are not stored at reads and writes through.
+    /// These cells served at `E`: cast on the read, cast back on the write, masked the same.
+    /// What a consumer working in an element the cells are not stored at reads and writes
+    /// through.
     pub(crate) fn cast<E: Numeric>(self) -> MaskedViewMut<'a, Vector<E, V>, C> {
         let check = comptime!(self.check);
         MaskedViewMut::<'a, Vector<E, V>, C>::new(

--- a/crates/cubek-tile/src/tile/view/masked.rs
+++ b/crates/cubek-tile/src/tile/view/masked.rs
@@ -3,6 +3,8 @@ use cubecl::{
     std::tensor::{View, ViewMut, layout::Coordinates},
 };
 
+use super::CastViewMut;
+
 /// A masked view over a [`Tile`](crate::Tile): a [`View`] re-shaped by some layout plus
 /// its own comptime `check` flag, so the leaf zeroes reads / skips writes past the
 /// partial-tile overhang; `false` is the unchecked fast path.
@@ -107,5 +109,18 @@ impl<'a, T: CubePrimitive, C: Coordinates + 'a> MaskedViewMut<'a, T, C> {
 
     pub fn shape(&self) -> C {
         self.view.shape()
+    }
+}
+
+#[cube]
+impl<'a, S: Numeric, V: Size, C: Coordinates + 'a> MaskedViewMut<'a, Vector<S, V>, C> {
+    /// These cells served at `E`: read widened, written narrowed, masked the same. What a
+    /// consumer working in an element the cells are not stored at reads and writes through.
+    pub(crate) fn cast<E: Numeric>(self) -> MaskedViewMut<'a, Vector<E, V>, C> {
+        let check = comptime!(self.check);
+        MaskedViewMut::<'a, Vector<E, V>, C>::new(
+            CastViewMut::<'a, S, E, V, C>::new(self.view).view_mut(),
+            check,
+        )
     }
 }

--- a/crates/cubek-tile/src/tile/view/mod.rs
+++ b/crates/cubek-tile/src/tile/view/mod.rs
@@ -1,7 +1,8 @@
 //! The layouts a leaf reads a [`Tile`](crate::Tile) through, and the views that wrap them:
-//! flat, 2-D matrix, gathered, packed, masked, and the accumulating one.
+//! flat, 2-D matrix, gathered, packed, masked, cast, and the accumulating one.
 
 mod accumulate;
+mod cast;
 mod coords;
 mod flat;
 mod masked;
@@ -11,6 +12,7 @@ mod projected;
 mod quant;
 
 pub(crate) use accumulate::*;
+pub(crate) use cast::*;
 // Crate-internal helpers, so this re-export carries no public item.
 pub(crate) use coords::*;
 pub use flat::*;


### PR DESCRIPTION
`CastViewMut` wraps a `ViewMut` over cells stored at one element and serves them as another: widened on read, narrowed on write, and touched nowhere else. `MaskedViewMut::cast` puts it behind the masked view a leaf already reads through, so a consumer states the element it works in and never casts itself — the way a packed operand's unpacking is a fact of the view rather than of its reader.