### PR TITLE
Let the register block accumulator fold a step

### DIFF
--- a/crates/cubek-matmul/src/tiled/cpu_gemm/kernel.rs
+++ b/crates/cubek-matmul/src/tiled/cpu_gemm/kernel.rs
@@ -80,7 +80,7 @@ pub fn cpu_gemm_kernel<
     let mut c = c.tile(space);
 
     // The accumulator spans the cube's whole contraction: opened here, drained after it.
-    let mut acc = c.block_accumulator::<EA, EL>(&a, REGISTER_BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<EA, EL, ER>(&a, &b, REGISTER_BLOCK, Monoid::Sum);
     acc.zero();
 
     // This cube's box, K whole: one region.

--- a/crates/cubek-matmul/src/tiled/eval/split_cubes/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/split_cubes/mod.rs
@@ -91,8 +91,10 @@ fn atomic_matmul<E: Numeric>(
     for region in Walk::over(c.op_space(&a, &b)) {
         let mut c_cube = c.at(&region);
         let a_cube = a.at(&region);
-        let mut acc = c_cube.block_accumulator::<E, E>(&a_cube, REGISTER_BLOCK, Monoid::Sum);
-        acc.mm(&a_cube, &b.at(&region), Semiring::SUM_PROD);
+        let b_cube = b.at(&region);
+        let mut acc =
+            c_cube.block_accumulator::<E, E, E>(&a_cube, &b_cube, REGISTER_BLOCK, Monoid::Sum);
+        acc.mm(&a_cube, &b_cube, Semiring::SUM_PROD);
         acc.drain_cast_into(&mut c_cube);
     }
 }
@@ -114,7 +116,8 @@ fn atomic_matmul_lanes<E: Numeric>(
         let mut c_cube = c.at(&region);
         let a_cube = a.at(&region);
         let b_cube = b.at(&region);
-        let mut acc = c_cube.block_accumulator::<E, E>(&a_cube, REGISTER_BLOCK, Monoid::Sum);
+        let mut acc =
+            c_cube.block_accumulator::<E, E, E>(&a_cube, &b_cube, REGISTER_BLOCK, Monoid::Sum);
         acc.zero();
         for region in Walk::over(acc.op_space(&a_cube, &b_cube)) {
             let mut acc_lane = acc.at(&region);

--- a/crates/cubek-tile/src/instruction/registers/contract/base.rs
+++ b/crates/cubek-tile/src/instruction/registers/contract/base.rs
@@ -33,7 +33,7 @@ pub(crate) fn memory<E: Numeric, EL: Numeric, ER: Numeric>(
     let lw = lhs.vector_size();
     let rw = rhs.vector_size();
     let aw = comptime!(acc.store.vector_size);
-    let contracted_per_step = comptime!(step_contracted_per_step(
+    let contracted_per_step = comptime!(contracted_per_step(
         &lhs.space, &rhs.space, &space, lw, rw, aw
     ));
     // Whether a 2-D reading describes the operands is the operands' own answer, not an axis count:
@@ -90,7 +90,7 @@ pub(crate) fn memory_scaled<E: Numeric, EL: Numeric, ER: Numeric, ES: Numeric>(
     let lw = lhs.vector_size();
     let rw = rhs.vector_size();
     let aw = comptime!(acc.store.vector_size);
-    let contracted_per_step = comptime!(step_contracted_per_step(
+    let contracted_per_step = comptime!(contracted_per_step(
         &lhs.space, &rhs.space, &space, lw, rw, aw
     ));
     // Same question the plain contraction asks: whether a 2-D reading describes the operands, not
@@ -134,13 +134,16 @@ pub(crate) fn memory_scaled<E: Numeric, EL: Numeric, ER: Numeric, ES: Numeric>(
 }
 
 /// How many contracted values one step consumes, reconciled across both operands and the
-/// accumulator.
+/// accumulator: one where the rhs lines along the accumulator, its whole line where it lines
+/// along the contraction, so a block's lines are then partials of one cell.
 ///
 /// Asked per operand ([`Space::contracted_per_step`]) because the answer differs per operand: an lhs lined
 /// along the contracted axis folds, an rhs lined along the accumulator's innermost axis holds
 /// cells that must stay apart. Both must serve the same count, and the block's lanes mean one
-/// axis, so a folded step needs a scalar-contracted_per_step accumulator.
-fn step_contracted_per_step(
+/// axis, so a folded step needs a scalar-contracted_per_step accumulator. Settled once per block,
+/// whether the block is the memory leaf's or opened ahead of the walk
+/// ([`Tile::block_accumulator`]).
+pub(crate) fn contracted_per_step(
     lhs: &Space,
     rhs: &Space,
     acc: &Space,
@@ -207,14 +210,14 @@ mod tests {
     #[test]
     fn an_rhs_lined_along_the_accumulator_serves_one_value_a_step() {
         let (lhs, rhs, acc) = spaces(&[M, K], &[K, N]);
-        assert_eq!(step_contracted_per_step(&lhs, &rhs, &acc, 4, 2, 2), 1);
+        assert_eq!(contracted_per_step(&lhs, &rhs, &acc, 4, 2, 2), 1);
     }
 
     /// Both operands lined along the contracted axis: the lanes are partials of one cell.
     #[test]
     fn both_operands_lined_along_the_contracted_axis_serve_a_line() {
         let (lhs, rhs, acc) = spaces(&[M, K], &[N, K]);
-        assert_eq!(step_contracted_per_step(&lhs, &rhs, &acc, 4, 4, 1), 4);
+        assert_eq!(contracted_per_step(&lhs, &rhs, &acc, 4, 4, 1), 4);
     }
 
     /// A width the contracted extent does not divide would leave a masked tail.
@@ -222,7 +225,7 @@ mod tests {
     #[should_panic(expected = "served in whole lines")]
     fn a_width_that_misdivides_the_contracted_axis_is_refused() {
         let (lhs, rhs, acc) = spaces(&[M, K], &[N, K]);
-        step_contracted_per_step(&lhs, &rhs, &acc, 3, 3, 1);
+        contracted_per_step(&lhs, &rhs, &acc, 3, 3, 1);
     }
 
     /// A lined rhs has nothing to fold against when the lhs serves one value a step.
@@ -230,7 +233,7 @@ mod tests {
     #[should_panic(expected = "line the lhs along")]
     fn a_folded_step_needs_both_operands_lined() {
         let (lhs, rhs, acc) = spaces(&[M, K], &[N, K]);
-        step_contracted_per_step(&lhs, &rhs, &acc, 1, 4, 1);
+        contracted_per_step(&lhs, &rhs, &acc, 1, 4, 1);
     }
 
     /// The block's lanes mean one axis, and a lined accumulator has already claimed them.
@@ -238,7 +241,7 @@ mod tests {
     #[should_panic(expected = "cannot also be served")]
     fn a_folded_step_needs_a_scalar_accumulator() {
         let (lhs, rhs, acc) = spaces(&[M, K], &[N, K]);
-        step_contracted_per_step(&lhs, &rhs, &acc, 4, 4, 2);
+        contracted_per_step(&lhs, &rhs, &acc, 4, 4, 2);
     }
 
     /// The rhs and the accumulator share their line, so they share its width.
@@ -246,6 +249,6 @@ mod tests {
     #[should_panic(expected = "served at one width")]
     fn an_rhs_lined_along_the_accumulator_shares_its_width() {
         let (lhs, rhs, acc) = spaces(&[M, K], &[K, N]);
-        step_contracted_per_step(&lhs, &rhs, &acc, 4, 1, 2);
+        contracted_per_step(&lhs, &rhs, &acc, 4, 1, 2);
     }
 }

--- a/crates/cubek-tile/src/instruction/registers/contract/mod.rs
+++ b/crates/cubek-tile/src/instruction/registers/contract/mod.rs
@@ -14,5 +14,5 @@ mod promoted;
 mod scale;
 mod shape;
 
-pub(crate) use base::{memory, memory_scaled};
+pub(crate) use base::{contracted_per_step, memory, memory_scaled};
 pub(crate) use scale::scale_side;

--- a/crates/cubek-tile/src/instruction/registers/contract/promoted.rs
+++ b/crates/cubek-tile/src/instruction/registers/contract/promoted.rs
@@ -31,12 +31,15 @@ impl<T: Numeric> RegisterData<T> {
     ///
     /// The rhs may be packed too, and the width assert below is the whole of what governs it. A
     /// packed operand's `vector_size` is the *served* width — the binding's times the packing
-    /// factor — and the rhs's width must be the block's, so a packed rhs is served exactly when
-    /// the accumulator is declared at that served width. A caller that declares it narrower is
-    /// refused there, by an assert that names both widths; nothing packing-specific is left over
-    /// to refuse on its own. `a_packed_rhs_drains_from_a_promoted_accumulator` runs the unscaled
-    /// form, and `a_packed_decode_gemv_runs_in_this_spelling` the scaled one, which reaches this
-    /// same block through [`mma_scaled`](Self::mma_scaled).
+    /// factor — and the block was opened at the rhs's width, so a packed rhs is served exactly
+    /// when the same rhs opened the block. `a_packed_rhs_drains_from_a_promoted_accumulator`
+    /// runs the unscaled form, and `a_packed_decode_gemv_runs_in_this_spelling` the scaled one,
+    /// which reaches this same block through [`mma_scaled`](Self::mma_scaled).
+    ///
+    /// An rhs lined along the contraction is the folded step ([`fold`](Self::fold)): a step
+    /// consumes a whole line of each operand and the block's lanes are one cell's partials,
+    /// which [`store_cast_window`](Self::store_cast_window) collapses. The block must have been
+    /// opened that way: the lines are allocated at the open, not here.
     pub(crate) fn mma<EL: Numeric, ER: Numeric>(
         &mut self,
         lhs: &Tile<EL>,
@@ -52,21 +55,33 @@ impl<T: Numeric> RegisterData<T> {
         ));
         let vw = rhs.vector_size();
         let lw = lhs.vector_size();
+        let fold = comptime!(self.fold);
         // Either operand may be packed: the decode is the read's, and this is the only width
         // either one owes. A packed rhs is served at its packing factor, so it is this assert,
-        // not a packing test, that asks the accumulator to have been declared that wide.
+        // not a packing test, that asks the block to have been opened by the same rhs.
         comptime!(assert!(
             vw == self.vector_size,
             "RegisterData::mma: the block's lines are {} wide but the rhs serves {vw}; a packed \
-             rhs serves its packing factor, so declare the accumulator at that width",
+             rhs serves its packing factor, so open the block against the rhs it contracts",
             self.vector_size
         ));
-        // The block's lanes are neighbouring cells, so the rhs must line along the accumulator.
-        // A contracted axis is one both operands span, which is what this rules out.
+        // A contracted axis is one both operands span. The rhs lining along one is the folded
+        // step, and the block's lines mean one thing for the whole walk.
+        let lined_along_k = comptime!(lhs.space.contains(rhs.space.axis_at(rhs.space.rank() - 1)));
         comptime!(assert!(
-            !lhs.space.contains(rhs.space.axis_at(rhs.space.rank() - 1)),
-            "RegisterData::mma: the rhs lines along a contracted axis, which folds into one cell; \
-             the memory-backed leaf serves that step"
+            lined_along_k == (fold > 1),
+            "RegisterData::mma: the block's lines hold {fold} partials of a cell but the rhs lines \
+             along {}; open the block against the operands it contracts",
+            if lined_along_k {
+                "the contraction"
+            } else {
+                "the accumulator"
+            }
+        ));
+        comptime!(assert!(
+            fold == 1 || lw == fold,
+            "RegisterData::mma: a step consumes {fold} contracted values, so the lhs must line \
+             along the contraction at that width (it is {lw} wide)"
         ));
 
         let size!(L) = lw;
@@ -78,7 +93,12 @@ impl<T: Numeric> RegisterData<T> {
         // than off the last axis, so a split column group stays one edge.
         let cols = comptime!(MatrixAxes::accumulator(&out, &lhs.space).cols(&out));
         let lhs_axes = comptime!(MatrixAxes::of(&lhs.space, mr, kc));
-        let rhs_axes = comptime!(MatrixAxes::of(&rhs.space, kc, cols));
+        // Lined along the contraction the rhs reads as `(col, k)`, along the accumulator `(k, col)`.
+        let rhs_axes = comptime!(if fold > 1 {
+            MatrixAxes::of(&rhs.space, cols, kc)
+        } else {
+            MatrixAxes::of(&rhs.space, kc, cols)
+        });
         let lhs_mat = lhs.matrix_packed::<L>(lhs_axes, 0usize);
         // The rhs and the block share the width `RA` (asserted above, `vw == self.vector_size`).
         let rhs_mat = rhs.matrix_packed::<RA>(rhs_axes, 0usize);
@@ -92,7 +112,7 @@ impl<T: Numeric> RegisterData<T> {
             &rhs_mat,
             &mut self.data,
             lw,
-            1usize,
+            fold,
             mr,
             nr,
             kc,
@@ -126,17 +146,19 @@ impl<T: Numeric> RegisterData<T> {
         let inner = scales.index(0);
         let sw = inner.vector_size();
         // As [`mma`](Self::mma): a packed rhs — the decode gemv's whole shape — serves its
-        // packing factor, so this is the assert that asks the accumulator to be that wide.
+        // packing factor, so this is the assert that asks the block to have been opened by it.
         comptime!(assert!(
             vw == self.vector_size,
             "RegisterData::mma_scaled: the block's lines are {} wide but the rhs serves {vw}; a \
-             packed rhs serves its packing factor, so declare the accumulator at that width",
+             packed rhs serves its packing factor, so open the block against the rhs it contracts",
             self.vector_size
         ));
-        // The block's lanes are neighbouring cells, so the rhs must line along the accumulator.
+        // The scaled walk steps one contracted value at a time, so its block's lanes are
+        // neighbouring cells: a folded step here would need the scale level to step by lines.
         comptime!(assert!(
-            !lhs.space.contains(rhs.space.axis_at(rhs.space.rank() - 1)),
-            "RegisterData::mma_scaled: the rhs lines along a contracted axis, which folds into              one cell; the memory-backed leaf serves that step"
+            self.fold == 1,
+            "RegisterData::mma_scaled: the rhs lines along a contracted axis, which folds into \
+             one cell; the memory-backed leaf serves that step (Tile::mma_scaled_with)"
         ));
 
         let size!(L) = lw;

--- a/crates/cubek-tile/src/ops/matmul/lower.rs
+++ b/crates/cubek-tile/src/ops/matmul/lower.rs
@@ -267,7 +267,7 @@ impl<E: Numeric> PlaneTile<E> {
     ) {
         match self {
             PlaneTile::Cmma(d) => {
-                strided_2d(lhs, rhs, out);
+                strided_2d(lhs, rhs, out, false);
                 hardware_semiring(semiring);
                 d.mma(lhs, rhs)
             }
@@ -277,7 +277,7 @@ impl<E: Numeric> PlaneTile<E> {
                 d.mma(lhs, rhs)
             }
             PlaneTile::Register(d) => {
-                strided_2d(lhs, rhs, comptime!(out.clone()));
+                strided_2d(lhs, rhs, comptime!(out.clone()), comptime!(d.fold > 1));
                 d.mma(lhs, rhs, out, semiring)
             }
         }
@@ -299,7 +299,7 @@ impl<E: Numeric> PlaneTile<E> {
     ) {
         match self {
             PlaneTile::Register(d) => {
-                strided_2d(lhs, rhs, comptime!(out.clone()));
+                strided_2d(lhs, rhs, comptime!(out.clone()), false);
                 d.mma_scaled(lhs, rhs, scales, out, semiring)
             }
             PlaneTile::Cmma(_) | PlaneTile::Mma(_) => panic!(
@@ -322,16 +322,27 @@ fn hardware_semiring(#[comptime] semiring: Semiring) {
 /// Asserts that operands are not gathered and read as one matrix each. A fragment contracts over
 /// one `k` edge, which is not one contracted *axis*: axes carried as one run flatten into an edge,
 /// and a partitioned contraction is exactly that. What it cannot read is a contraction its axes
-/// give no edge for.
+/// give no edge for. The rhs reads `(k, col)`, or `(col, k)` where a register block folds a step
+/// (`rhs_along_k`): lined along the contraction, its matrix is the transpose.
 #[cube]
-fn strided_2d<EL: Numeric, ER: Numeric>(lhs: &Tile<EL>, rhs: &Tile<ER>, #[comptime] out: Space) {
+fn strided_2d<EL: Numeric, ER: Numeric>(
+    lhs: &Tile<EL>,
+    rhs: &Tile<ER>,
+    #[comptime] out: Space,
+    #[comptime] rhs_along_k: bool,
+) {
     let lhs_gathered = lhs.gathered();
     let rhs_gathered = rhs.gathered();
     let flat = comptime!({
         let kc = Space::merge(&[&lhs.space, &rhs.space]).contracted_extent(&out);
         let axes = MatrixAxes::accumulator(&out, &lhs.space);
-        MatrixAxes::find(&lhs.space, axes.rows(&out), kc).is_some()
-            && MatrixAxes::find(&rhs.space, kc, axes.cols(&out)).is_some()
+        let cols = axes.cols(&out);
+        let rhs_matrix = if rhs_along_k {
+            MatrixAxes::find(&rhs.space, cols, kc)
+        } else {
+            MatrixAxes::find(&rhs.space, kc, cols)
+        };
+        MatrixAxes::find(&lhs.space, axes.rows(&out), kc).is_some() && rhs_matrix.is_some()
     });
     comptime!(assert!(
         !lhs_gathered && !rhs_gathered && flat,

--- a/crates/cubek-tile/src/ops/normalize.rs
+++ b/crates/cubek-tile/src/ops/normalize.rs
@@ -158,6 +158,7 @@ mod tests {
             MatrixAxes::trailing_pair(&Space::new(&[(Axis(0), 8), (Axis(1), 8)])),
             8,
             1,
+            1,
             Lanes {
                 share: LaneShare::Whole,
                 work: LaneWork::Repeated,

--- a/crates/cubek-tile/src/tile/accumulator.rs
+++ b/crates/cubek-tile/src/tile/accumulator.rs
@@ -11,6 +11,7 @@
 
 use cubecl::prelude::*;
 
+use crate::instruction::registers::contract;
 use crate::*;
 
 #[cube]
@@ -24,7 +25,8 @@ impl<Acc: Numeric> Tile<Acc> {
         lhs: &Tile<EL>,
         #[comptime] monoid: Monoid,
     ) -> Tile<EA> {
-        self.accumulator_in::<EA, EL>(lhs, comptime!(PlaneForm::Cmma), monoid)
+        let vector_size = self.vector_size();
+        self.accumulator_in::<EA, EL>(lhs, comptime!(PlaneForm::Cmma), vector_size, 1usize, monoid)
     }
 
     /// [`cmma_accumulator`](Tile::cmma_accumulator) through the manual-mma instruction, whose
@@ -35,30 +37,90 @@ impl<Acc: Numeric> Tile<Acc> {
         #[comptime] io: MmaIOConfig,
         #[comptime] monoid: Monoid,
     ) -> Tile<EA> {
-        self.accumulator_in::<EA, EL>(lhs, comptime!(PlaneForm::Mma { io }), monoid)
+        let vector_size = self.vector_size();
+        self.accumulator_in::<EA, EL>(
+            lhs,
+            comptime!(PlaneForm::Mma { io }),
+            vector_size,
+            1usize,
+            monoid,
+        )
     }
 
     /// [`cmma_accumulator`](Tile::cmma_accumulator) through the software instruction: a register
     /// block per fragment of the grid, run under `config`.
-    pub fn block_accumulator<EA: Numeric, EL: Numeric>(
+    ///
+    /// The block's lines are the rhs's, which is why it reads both operands where the hardware
+    /// forms read the lhs alone. An rhs lined along the accumulator gives lines of neighbouring
+    /// cells, as wide as this tile's; one lined along the contraction gives each cell a line of
+    /// its own partials, folded on drain, and this tile is then scalar. Either way the sum stays
+    /// in `EA` across the walk, so a half-precision output summing a long reduction is served
+    /// here whatever axis its weight is stored along.
+    pub fn block_accumulator<EA: Numeric, EL: Numeric, ER: Numeric>(
         &self,
         lhs: &Tile<EL>,
+        rhs: &Tile<ER>,
         #[comptime] config: RegisterBlock,
         #[comptime] monoid: Monoid,
     ) -> Tile<EA> {
-        self.accumulator_in::<EA, EL>(lhs, comptime!(PlaneForm::Registers { config }), monoid)
+        let lw = lhs.vector_size();
+        let rw = rhs.vector_size();
+        let aw = self.vector_size();
+        let fold = comptime!(contract::contracted_per_step(
+            &lhs.space.final_space(),
+            &rhs.space.final_space(),
+            &self.space.final_space(),
+            lw,
+            rw,
+            aw
+        ));
+        // A memory leaf spreads a line wider than its scalar sink across cells; a block that
+        // outlives the leaf has no such step, so its lines and the sink's agree or fold.
+        comptime!(assert!(
+            fold > 1 || rw == aw,
+            "Tile::block_accumulator: the block's lines are the rhs's ({rw} wide) and drain into \
+             {aw}-wide cells; a stage served wider than its sink is the memory-backed leaf's \
+             (Tile::mma_with)"
+        ));
+        self.accumulator_in::<EA, EL>(
+            lhs,
+            comptime!(PlaneForm::Registers { config }),
+            rw,
+            fold,
+            monoid,
+        )
+    }
+
+    /// [`block_accumulator`](Tile::block_accumulator) for a reduction, whose one operand is
+    /// `input`: the block's lines are this tile's, there being no rhs to line them by.
+    pub fn block_reducer<EA: Numeric, In: Numeric>(
+        &self,
+        input: &Tile<In>,
+        #[comptime] config: RegisterBlock,
+        #[comptime] monoid: Monoid,
+    ) -> Tile<EA> {
+        let vector_size = self.vector_size();
+        self.accumulator_in::<EA, In>(
+            input,
+            comptime!(PlaneForm::Registers { config }),
+            vector_size,
+            1usize,
+            monoid,
+        )
     }
 
     /// The plane-resident partition an accumulator contracts in, in `form`, uninitialized and
-    /// shaped to meet `lhs` at the instruction.
+    /// shaped to meet `lhs` at the instruction. `vector_size` is its lines' width and `fold` what
+    /// a line holds ([`RegisterData::fold`]); only the software form reads them.
     pub(crate) fn accumulator_in<EA: Numeric, EL: Numeric>(
         &self,
         lhs: &Tile<EL>,
         #[comptime] form: PlaneForm,
+        #[comptime] vector_size: usize,
+        #[comptime] fold: usize,
         #[comptime] monoid: Monoid,
     ) -> Tile<EA> {
         let k = comptime!(lhs.space.final_space().contracted_extent(&self.space));
-        let vector_size = self.vector_size();
         let lanes = comptime!(self.space.lanes());
         PlanePartition::<EA>::mirror(
             comptime!(self.space.clone()),
@@ -69,6 +131,7 @@ impl<Acc: Numeric> Tile<Acc> {
             comptime!(form),
             comptime!(k),
             vector_size,
+            fold,
             lanes,
             monoid,
         )

--- a/crates/cubek-tile/src/tile/plane.rs
+++ b/crates/cubek-tile/src/tile/plane.rs
@@ -28,7 +28,8 @@ pub enum PlaneTile<T: Numeric> {
 #[cube]
 impl<T: Numeric> PlaneTile<T> {
     /// An accumulator tile over the whole `m × n` MMA tile, uninitialized, in the `form` the
-    /// instruction contracts through.
+    /// instruction contracts through. `vector_size` and `fold` shape the software block's lines
+    /// ([`RegisterData::fold`]); the hardware encodings have no say in their layout.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn acc(
         #[comptime] form: PlaneForm,
@@ -37,6 +38,7 @@ impl<T: Numeric> PlaneTile<T> {
         #[comptime] axes: MatrixAxes,
         #[comptime] k: usize,
         #[comptime] vector_size: usize,
+        #[comptime] fold: usize,
         #[comptime] lanes: Lanes,
         #[comptime] monoid: Monoid,
     ) -> PlaneTile<T> {
@@ -47,13 +49,12 @@ impl<T: Numeric> PlaneTile<T> {
             PlaneForm::Mma { io } => {
                 PlaneTile::new_Mma(MmaData::<T>::acc(m, n, k, MatrixLayout::RowMajor, io))
             }
-            // `vector_size` is the promoting tile's, so the block's lines match the memory it
-            // will drain into; the hardware encodings above have no say in their layout.
             PlaneForm::Registers { config } => PlaneTile::new_Register(RegisterData::<T>::alloc(
                 m,
                 n,
                 axes,
                 vector_size,
+                fold,
                 lanes,
                 config,
                 monoid,
@@ -207,12 +208,14 @@ impl<T: Numeric> PlanePartition<T> {
 
     /// The plane-resident form of an accumulator over `space`: a partition mirroring its grid,
     /// tiles uninitialized. Opening the scope is purely structural; the caller states the init.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn mirror(
         #[comptime] space: Space,
         #[comptime] axes: MatrixAxes,
         #[comptime] form: PlaneForm,
         #[comptime] k: usize,
         #[comptime] vector_size: usize,
+        #[comptime] fold: usize,
         #[comptime] lanes: Lanes,
         #[comptime] monoid: Monoid,
     ) -> Tile<T> {
@@ -235,6 +238,7 @@ impl<T: Numeric> PlanePartition<T> {
                     axes,
                     k,
                     vector_size,
+                    fold,
                     lanes,
                     monoid,
                 ));

--- a/crates/cubek-tile/src/tile/register.rs
+++ b/crates/cubek-tile/src/tile/register.rs
@@ -3,7 +3,10 @@
 
 use cubecl::prelude::*;
 
-use crate::{instruction::plane, *};
+use crate::{
+    instruction::{plane, registers::horizontal},
+    *,
+};
 
 // The block's line width, as a scope-registered size rather than a generic. `RA` names the
 // vector element `data` is allocated at; `alloc` binds it to the promoting tile's width with
@@ -18,10 +21,15 @@ define_size!(pub(crate) RA);
 /// encoding of a [`PlaneTile`].
 ///
 /// The block exists so the software leaf can accumulate the way the hardware ones do: created by
-/// [`accumulate`](Tile::accumulate) and passed in, it outlives a single leaf call and only meets
-/// memory on drain. An accumulator allocated inside the instruction would round-trip its partials
-/// through the output's element on every visit, so a deep contraction into `f16` would lose
-/// precision it does not have to.
+/// [`block_accumulator`](Tile::block_accumulator) and passed in, it outlives a single leaf call
+/// and only meets memory on drain. An accumulator allocated inside the instruction would
+/// round-trip its partials through the output's element on every visit, so a deep contraction
+/// into `f16` would lose precision it does not have to.
+///
+/// Its lines are the rhs's. Lined along the accumulator, a line is `RA` neighbouring cells;
+/// lined along the contraction, it is `RA` partials of *one* cell ([`fold`](Self::fold)), which
+/// the drain collapses before it writes. The second is what a weight stored along `K` deals a
+/// lane, and the block carries it so that sum, too, stays in `T` across the walk.
 #[derive(CubeType, Clone)]
 #[expand(derive(Clone))]
 pub struct RegisterData<T: Numeric> {
@@ -30,10 +38,16 @@ pub struct RegisterData<T: Numeric> {
     /// Physical line width, the numeric twin of `RA`; comptime, for the line arithmetic.
     #[cube(comptime)]
     pub(crate) vector_size: usize,
+    /// Contracted values a line holds of one cell: `1` where its lanes are neighbouring cells,
+    /// the line width where they are that cell's partials. What [`vector_size`](Self::vector_size)
+    /// means, not how wide it is.
+    #[cube(comptime)]
+    pub(crate) fold: usize,
     /// Rows in the block.
     #[cube(comptime)]
     pub(crate) mr: usize,
-    /// Lines per row: the `n` extent divided by [`vector_size`](Self::vector_size).
+    /// Lines per row: the `n` extent divided by [`vector_size`](Self::vector_size), or `n` itself
+    /// where every cell has a line of its own partials.
     #[cube(comptime)]
     pub(crate) nr: usize,
     /// The sink's matrix, the one this block was sized against. Carried rather than re-derived:
@@ -51,8 +65,8 @@ pub struct RegisterData<T: Numeric> {
     #[cube(comptime)]
     pub(crate) config: RegisterBlock,
     /// How this block's partials merge: the `⊕` it accumulates under. Stated where the block is
-    /// built ([`Tile::accumulate`]), because comptime state cannot be set afterwards, and read on
-    /// drain next to [`lane_share`](Self::lane_share): that one says partials exist, this one says
+    /// built ([`Tile::block_accumulator`]), because comptime state cannot be set afterwards, and
+    /// read on drain next to [`lanes`](Self::lanes): that one says partials exist, this one says
     /// what combining them means. A matmul's is [`Sum`](Monoid::Sum).
     #[cube(comptime)]
     pub(crate) monoid: Monoid,
@@ -68,26 +82,35 @@ fn register_block_size(#[comptime] vector_size: usize) {
 
 #[cube]
 impl<T: Numeric> RegisterData<T> {
-    /// An uninitialized `m × n` block at `vector_size`. `n` must divide into whole lines; the
-    /// leaf reads and writes nothing narrower.
+    /// An uninitialized `m × n` block at `vector_size`, its lines `fold` partials of one cell or,
+    /// at a `fold` of one, `vector_size` neighbouring cells, in which case `n` must divide into
+    /// whole lines: the leaf reads and writes nothing narrower.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn alloc(
         #[comptime] m: usize,
         #[comptime] n: usize,
         #[comptime] axes: MatrixAxes,
         #[comptime] vector_size: usize,
+        #[comptime] fold: usize,
         #[comptime] lanes: Lanes,
         #[comptime] config: RegisterBlock,
         #[comptime] monoid: Monoid,
     ) -> RegisterData<T> {
         comptime!(assert!(
-            vector_size > 0 && n.is_multiple_of(vector_size),
+            fold == 1 || fold == vector_size,
+            "RegisterData::alloc: a line holds the {fold} partials of one cell, so it is that wide, \
+             not {vector_size}"
+        ));
+        comptime!(assert!(
+            vector_size > 0 && (fold > 1 || n.is_multiple_of(vector_size)),
             "RegisterData::alloc: n ({n}) must be a whole number of {vector_size}-wide lines"
         ));
         register_block_size(vector_size);
-        let nr = comptime!(n / vector_size);
+        let nr = comptime!(if fold > 1 { n } else { n / vector_size });
         RegisterData::<T> {
             data: Array::<Vector<T, RA>>::new(comptime!(m * nr)),
             vector_size,
+            fold,
             mr: m,
             nr,
             axes,
@@ -128,14 +151,30 @@ impl<T: Numeric> RegisterData<T> {
     /// [`AccumulateView::commit`] uses: a block is sized to the leaf, so it may overhang the real
     /// extent, and the lines past the edge belong to the next row. The mask is a comptime flag,
     /// so a block that fits emits a straight-line store.
+    ///
+    /// A line of one cell's partials ([`fold`](Self::fold)) is collapsed after the lanes are
+    /// combined and lands in a scalar cell; a line of neighbouring cells lands as it is.
     pub(crate) fn store_cast_window<Out: Numeric>(
         &self,
         mem: &mut MemData<Out>,
         #[comptime] space: Space,
     ) {
+        if comptime!(self.fold > 1) {
+            let size!(A) = 1usize;
+            self.drain::<Out, A>(mem, space);
+        } else {
+            self.drain::<Out, RA>(mem, space);
+        }
+    }
+
+    /// [`store_cast_window`](Self::store_cast_window) into a sink addressed in `A`-wide cells:
+    /// the block's own width, or scalar where a line folds into one cell.
+    fn drain<Out: Numeric, A: Size>(&self, mem: &mut MemData<Out>, #[comptime] space: Space) {
         let mem_write = comptime!(mem.access.write);
-        // Addressed in lines at the width the block was promoted at, bounded by the window extent.
-        let mut sink = mem.matrix_mut::<RA>(0usize, comptime!(self.axes), space);
+        let fold = comptime!(self.fold);
+        let monoid = comptime!(self.monoid);
+        // Bounded by the window extent.
+        let mut sink = mem.matrix_mut::<A>(0usize, comptime!(self.axes), space);
 
         // Split comptime rather than branching per line: a value-producing `match` plus a
         // lane guard emits a binding the CPU backend cannot resolve ("Value should have been
@@ -148,10 +187,9 @@ impl<T: Numeric> RegisterData<T> {
                 for i in 0..comptime!(self.mr) {
                     #[unroll]
                     for n in 0..comptime!(self.nr) {
-                        sink.write(
-                            ((i as u32).runtime(), (n as u32).runtime()),
-                            Vector::<Out, RA>::cast_from(self.data[comptime!(i * self.nr + n)]),
-                        );
+                        let cell =
+                            cell::<T, Out, A>(self.data[comptime!(i * self.nr + n)], fold, monoid);
+                        sink.write(((i as u32).runtime(), (n as u32).runtime()), cell);
                     }
                 }
             }
@@ -161,11 +199,10 @@ impl<T: Numeric> RegisterData<T> {
                 for i in 0..comptime!(self.mr) {
                     #[unroll]
                     for n in 0..comptime!(self.nr) {
+                        let cell =
+                            cell::<T, Out, A>(self.data[comptime!(i * self.nr + n)], fold, monoid);
                         if UNIT_POS_X == 0 {
-                            sink.write(
-                                ((i as u32).runtime(), (n as u32).runtime()),
-                                Vector::<Out, RA>::cast_from(self.data[comptime!(i * self.nr + n)]),
-                            );
+                            sink.write(((i as u32).runtime(), (n as u32).runtime()), cell);
                         }
                     }
                 }
@@ -178,13 +215,11 @@ impl<T: Numeric> RegisterData<T> {
                     for n in 0..comptime!(self.nr) {
                         let combined = plane::broadcast::<Vector<T, RA>>(
                             self.data[comptime!(i * self.nr + n)],
-                            comptime!(self.monoid),
+                            monoid,
                         );
+                        let cell = cell::<T, Out, A>(combined, fold, monoid);
                         if UNIT_POS_X == 0 {
-                            sink.write(
-                                ((i as u32).runtime(), (n as u32).runtime()),
-                                Vector::<Out, RA>::cast_from(combined),
-                            );
+                            sink.write(((i as u32).runtime(), (n as u32).runtime()), cell);
                         }
                     }
                 }
@@ -198,18 +233,31 @@ impl<T: Numeric> RegisterData<T> {
                         let combined = plane::group::<T, RA>(
                             self.data[comptime!(i * self.nr + n)],
                             comptime!(fold_mask),
-                            comptime!(self.monoid),
+                            monoid,
                         );
+                        let cell = cell::<T, Out, A>(combined, fold, monoid);
                         let lane_in_group = UNIT_POS_X & comptime!(fold_mask as u32);
                         if lane_in_group == 0 {
-                            sink.write(
-                                ((i as u32).runtime(), (n as u32).runtime()),
-                                Vector::<Out, RA>::cast_from(combined),
-                            );
+                            sink.write(((i as u32).runtime(), (n as u32).runtime()), cell);
                         }
                     }
                 }
             }
         }
+    }
+}
+
+/// What a drained line lands as: the line itself, cast, where its lanes are neighbouring cells;
+/// their fold under `monoid`, cast, where they are `fold` partials of one cell.
+#[cube]
+fn cell<T: Numeric, Out: Numeric, A: Size>(
+    line: Vector<T, RA>,
+    #[comptime] fold: usize,
+    #[comptime] monoid: Monoid,
+) -> Vector<Out, A> {
+    if comptime!(fold > 1) {
+        Vector::<Out, A>::cast_from(horizontal::vector::<T, RA>(line, fold, monoid))
+    } else {
+        Vector::<Out, A>::cast_from(line)
     }
 }

--- a/crates/cubek-tile/tests/tile/blocked.rs
+++ b/crates/cubek-tile/tests/tile/blocked.rs
@@ -702,7 +702,7 @@ fn promoted_matmul<E: Numeric>(
     let a = a.tile(comptime!(space.clone()));
     let b = b.tile(comptime!(space.clone()));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<E, E>(&a, BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<E, E, E>(&a, &b, BLOCK, Monoid::Sum);
     acc.zero();
     for region in Walk::over(acc.op_space(&a, &b)).unrolled() {
         let mut acc_region = acc.at(&region);
@@ -798,7 +798,7 @@ fn wide_scaled_promoted<E: Numeric, SW: Size>(
     let b = b.tile(comptime!(space.clone()));
     let scale = scale.tile(comptime!(space.clone()));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<E, E>(&a, BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<E, E, E>(&a, &b, BLOCK, Monoid::Sum);
     acc.zero();
     for region in Walk::over(acc.op_space(&a, &b)).unrolled() {
         let mut scales = Sequence::new();

--- a/crates/cubek-tile/tests/tile/decode_gemv.rs
+++ b/crates/cubek-tile/tests/tile/decode_gemv.rs
@@ -103,8 +103,12 @@ fn decode_gemv_promoted<E: Numeric, S: Numeric, VX: Size, VO: Size>(
     let mut scales = Sequence::new();
     scales.push(scale.tile(comptime!(space.clone())));
     let mut out = out.tile(space);
-    let mut acc =
-        out.block_accumulator::<E, E>(&w, comptime!(RegisterBlock::new(budget)), Monoid::Sum);
+    let mut acc = out.block_accumulator::<E, E, E>(
+        &w,
+        &x,
+        comptime!(RegisterBlock::new(budget)),
+        Monoid::Sum,
+    );
     acc.zero();
     for region in Walk::over(acc.op_space(&w, &x)) {
         let acc_cube = acc.at(&region);

--- a/crates/cubek-tile/tests/tile/erased.rs
+++ b/crates/cubek-tile/tests/tile/erased.rs
@@ -261,7 +261,7 @@ fn buffer_matmul<E: Numeric, EA: Numeric>(
     let a = a.tile(comptime!(space.clone()));
     let b = b.tile(comptime!(space.clone()));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<EA, E>(&a, BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<EA, E, E>(&a, &b, BLOCK, Monoid::Sum);
     acc.zero();
     // The K steps select the one fragment by comptime coordinate, so the walk unrolls.
     for region in Walk::over(acc.op_space(&a, &b)).unrolled() {
@@ -298,7 +298,7 @@ fn sink_matmul<E: Numeric, EA: Numeric>(
         comptime!(c.spec.clone()),
         Write::Replace,
     );
-    let mut acc = c.block_accumulator::<EA, E>(&a, BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<EA, E, E>(&a, &b, BLOCK, Monoid::Sum);
     acc.zero();
     // The K steps select the one fragment by comptime coordinate, so the walk unrolls.
     for region in Walk::over(acc.op_space(&a, &b)).unrolled() {
@@ -335,7 +335,7 @@ fn source_matmul<E: Numeric, EA: Numeric>(
     );
     let b = b.tile(comptime!(space.clone()));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<EA, E>(&a, BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<EA, E, E>(&a, &b, BLOCK, Monoid::Sum);
     acc.zero();
     // The K steps select the one fragment by comptime coordinate, so the walk unrolls.
     for region in Walk::over(acc.op_space(&a, &b)).unrolled() {

--- a/crates/cubek-tile/tests/tile/matmul.rs
+++ b/crates/cubek-tile/tests/tile/matmul.rs
@@ -18,6 +18,7 @@ use cubek_test_utils::{
 };
 
 use cubek_tile::*;
+use half::f16;
 
 use super::references;
 
@@ -444,7 +445,7 @@ fn promoted_matmul_in_place<E: Numeric, EA: Numeric, AV: Size, BV: Size, CV: Siz
     let a = a.tile(comptime!(space.clone()));
     let b = b.tile(comptime!(space.clone()));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<EA, E>(&a, config, comptime!(semiring.add()));
+    let mut acc = c.block_accumulator::<EA, E, E>(&a, &b, config, comptime!(semiring.add()));
     acc.init(Monoid::identity::<EA>(comptime!(semiring.add())));
     for region in Walk::over(acc.op_space(&a, &b)) {
         let mut acc_r = acc.at(&region);
@@ -472,7 +473,7 @@ fn promoted_matmul_two_levels_in_place<E: Numeric, EA: Numeric, V: Size>(
         let mut c_o = c.at(&outer);
         let a_o = a.at(&outer);
         let b_o = b.at(&outer);
-        let mut acc = c_o.block_accumulator::<EA, E>(&a_o, config, Monoid::Sum);
+        let mut acc = c_o.block_accumulator::<EA, E, E>(&a_o, &b_o, config, Monoid::Sum);
         acc.zero();
         for region in Walk::over(acc.op_space(&a_o, &b_o)) {
             let mut acc_r = acc.at(&region);
@@ -496,7 +497,7 @@ fn block_matmul_two_levels_smem_below<E: Numeric>(
     let a = a.tile(comptime!(space.clone()));
     let b = b.tile(comptime!(space.clone()));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<E, E>(&a, REGISTER_BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<E, E, E>(&a, &b, REGISTER_BLOCK, Monoid::Sum);
     acc.zero();
     for outer in Walk::over(acc.op_space(&a, &b)) {
         let acc_o = acc.at(&outer);
@@ -855,7 +856,7 @@ fn promoted_matmul_quant_lhs_in_place<I: Numeric, E: Numeric, EA: Numeric>(
     let a = a.tile::<E>(comptime!(space.clone()));
     let b = b.tile(comptime!(space.clone()));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<EA, E>(&a, config, Monoid::Sum);
+    let mut acc = c.block_accumulator::<EA, E, E>(&a, &b, config, Monoid::Sum);
     acc.zero();
     for region in Walk::over(acc.op_space(&a, &b)) {
         let mut acc_r = acc.at(&region);
@@ -2735,6 +2736,108 @@ fn register_matmul_folded_step_rolled() {
     check_folded_step(lined_lhs_space(4, 4, 8), (4, 4, 8), 8);
 }
 
+/// The folded step through a promoted block. The rhs lines along `K`, so the block's lines are
+/// one cell's partials, collapsed on drain rather than committed per visit: the sum never meets
+/// the output between regions, which is what lets it run wider than the output
+/// ([`a_promoted_folded_step_sums_wider_than_its_output`]).
+#[test]
+fn register_matmul_promoted_folded_step() {
+    let client = cubecl::test_device().client();
+    let (m, n, k) = (4usize, 4usize, 8usize);
+    let space = lined_lhs_space(m, n, k);
+
+    let a = TileInput::builder(&client, space.project(&[M, K]))
+        .untiled()
+        .arange();
+    let b = TileInput::builder(&client, space.project(&[N, K]))
+        .untiled()
+        .arange();
+    let c = TileInput::builder(&client, space.project(&[M, N]))
+        .untiled()
+        .uniform(4242, 10., 100.);
+
+    let dtype = f32::elem_type_native();
+    promoted_matmul_in_place::launch(
+        &client,
+        space.cube_count(),
+        space.cube_dim(&client),
+        4,
+        4,
+        1,
+        a.arg(),
+        b.arg(),
+        c.arg(),
+        space,
+        RegisterBlock::new(64),
+        Semiring::SUM_PROD,
+        dtype,
+        dtype,
+    );
+
+    let output = HostData::from_tensor_handle(&client, c.handle(), HostDataType::F32);
+    let (_, expected) = TestInput::builder(client, shape![m, n])
+        .custom(folded_matmul_reference(m, n, k))
+        .generate_with_f32_host_data();
+    assert_equals_approx(&output, &expected, 1e-3)
+        .as_test_outcome()
+        .enforce()
+}
+
+/// A half-precision output summing a long folded contraction: `4096` products of one. Summed in
+/// its own element the cell stops at `2048`, where one more product falls under half its spacing
+/// and rounds away; carried in `f32` across the walk and cast once on drain, it lands `4096`.
+/// The property a weight stored along `K` needs from a register block, the folded step being
+/// the only way such a weight contracts.
+#[test]
+fn a_promoted_folded_step_sums_wider_than_its_output() {
+    let client = cubecl::test_device().client();
+    let (m, n, k) = (1usize, 1usize, 4096usize);
+    let space = lined_lhs_space(m, n, k);
+    let out = f16::elem_type_native();
+    let acc = f32::elem_type_native();
+
+    let ones = vec![1.0f32; k];
+    let (a, _) = TestInput::builder(client.clone(), shape![m, k])
+        .dtype(out)
+        .custom(ones.clone())
+        .generate_with_f32_host_data();
+    let (b, _) = TestInput::builder(client.clone(), shape![n, k])
+        .dtype(out)
+        .custom(ones)
+        .generate_with_f32_host_data();
+    let c = TestInput::builder(client.clone(), shape![m, n])
+        .dtype(out)
+        .zeros()
+        .generate_without_host_data();
+
+    promoted_matmul_in_place::launch(
+        &client,
+        space.cube_count(),
+        space.cube_dim(&client),
+        4,
+        4,
+        1,
+        TileArgLaunch::new(a.binding().into_tensor_arg(), TileSpec::direct(&[M, K])),
+        TileArgLaunch::new(b.binding().into_tensor_arg(), TileSpec::direct(&[N, K])),
+        TileArgLaunch::new(
+            c.clone().binding().into_tensor_arg(),
+            TileSpec::direct(&[M, N]),
+        ),
+        space,
+        RegisterBlock::new(64),
+        Semiring::SUM_PROD,
+        out,
+        acc,
+    );
+
+    let got = HostData::from_tensor_handle(&client, c, HostDataType::F32);
+    let have = got.get_f32(&[0, 0]);
+    assert!(
+        have == k as f32,
+        "an f16 cell summed in f32 holds {k}, got {have}"
+    );
+}
+
 /// The N-D nest at a folded step: two contracted axes, both operands lined along the faster of
 /// them. The reduce nest steps by the served width, so each step lands on a line start.
 #[test]
@@ -2978,6 +3081,57 @@ fn register_matmul_promoted_lane_group_fold() {
         dtype,
     );
     assert_matmul_arange(&client, c.handle(), m, n, k);
+}
+
+/// The gemv's own layout, promoted: a plane split into groups, each owning a row, its lanes
+/// interleaving `K`, and the weight stored along `K` lining both operands along the contraction.
+/// Every lane's block is one line of partials, so the drain folds twice, across the line and then
+/// across the group, and the cell is written once at the end. The memory-backed leaf does both
+/// folds per visit and rounds the cell at each; a half-precision cell rounds away the walk that
+/// way, so this is the block a half-precision gemv runs in.
+#[test]
+fn register_matmul_promoted_folded_step_lane_group_fold() {
+    let client = cubecl::test_device().client();
+    let lanes = client.properties().hardware.plane_size_max as usize;
+    let (group_lanes, edge, n) = (8usize, 4usize, 1usize);
+    let (groups, k) = (lanes / group_lanes, group_lanes * edge);
+    let (m, dtype) = (groups, f32::elem_type_native());
+    let space = lane_group_fold_space(lanes, group_lanes, edge, n);
+
+    let a = TileInput::builder(&client, space.project(&[M, K]))
+        .untiled()
+        .arange();
+    let b = TileInput::builder(&client, space.project(&[N, K]))
+        .untiled()
+        .arange();
+    let c = TileInput::builder(&client, space.project(&[M, N]))
+        .untiled()
+        .uniform(4242, 10., 100.);
+
+    promoted_matmul_in_place::launch(
+        &client,
+        space.cube_count(),
+        space.cube_dim(&client),
+        edge,
+        edge,
+        1,
+        a.arg(),
+        b.arg(),
+        c.arg(),
+        space,
+        RegisterBlock::new(edge * n),
+        Semiring::SUM_PROD,
+        dtype,
+        dtype,
+    );
+
+    let output = HostData::from_tensor_handle(&client, c.handle(), HostDataType::F32);
+    let (_, expected) = TestInput::builder(client, shape![m, n])
+        .custom(folded_matmul_reference(m, n, k))
+        .generate_with_f32_host_data();
+    assert_equals_approx(&output, &expected, 1e-3)
+        .as_test_outcome()
+        .enforce()
 }
 
 /// A packed lhs contracts into a register block to the product its scales and values describe.

--- a/crates/cubek-tile/tests/tile/packed.rs
+++ b/crates/cubek-tile/tests/tile/packed.rs
@@ -325,7 +325,7 @@ fn packed_gemv<E: Numeric, V: Size>(
     scales.push(scale.tile(comptime!(space.clone())));
     let mut c = c.tile(space);
     // The accumulator lives in registers across the whole walk and drains once.
-    let mut acc = c.block_accumulator::<E, E>(&x, REGISTER_BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<E, E, E>(&x, &w, REGISTER_BLOCK, Monoid::Sum);
     acc.zero();
     for region in Walk::over(acc.op_space(&x, &w)) {
         let mut acc_r = acc.at(&region);
@@ -1674,7 +1674,7 @@ fn packed_gemv_unscaled<E: Numeric, V: Size>(
     let x = x.tile(comptime!(space.clone()));
     let w = w.tile_packed::<E>(comptime!(space.clone()));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<E, E>(&x, REGISTER_BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<E, E, E>(&x, &w, REGISTER_BLOCK, Monoid::Sum);
     acc.zero();
     for region in Walk::over(acc.op_space(&x, &w)) {
         let mut acc_r = acc.at(&region);

--- a/crates/cubek-tile/tests/tile/reduce.rs
+++ b/crates/cubek-tile/tests/tile/reduce.rs
@@ -1161,7 +1161,7 @@ fn resident_fold_kernel<E: Numeric>(
 ) {
     let input = input.tile(comptime!(space.clone()));
     let mut out = output.tile(space);
-    let mut acc = out.block_accumulator::<E, E>(&input, REGISTER_BLOCK, monoid);
+    let mut acc = out.block_reducer::<E, E>(&input, REGISTER_BLOCK, monoid);
     acc.init(Monoid::identity::<E>(monoid));
     for region in Walk::over(acc.reduce_space(&input)) {
         let mut acc_region = acc.at(&region);

--- a/crates/cubek-tile/tests/tile/scaled.rs
+++ b/crates/cubek-tile/tests/tile/scaled.rs
@@ -83,7 +83,7 @@ fn scaled_matmul_promoted<E: Numeric, S: Numeric>(
     let mut scales = Sequence::new();
     scales.push(scale.tile(comptime!(space.clone())));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<E, E>(&a, REGISTER_BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<E, E, E>(&a, &b, REGISTER_BLOCK, Monoid::Sum);
     acc.zero();
     for region in Walk::over(acc.op_space(&a, &b)) {
         let mut acc_r = acc.at(&region);
@@ -1073,7 +1073,7 @@ fn wide_rhs_scaled_matmul_promoted<E: Numeric, S: Numeric, SW: Size>(
     let mut scales = Sequence::new();
     scales.push(scale.tile(comptime!(space.clone())));
     let mut c = c.tile(space);
-    let mut acc = c.block_accumulator::<E, E>(&a, REGISTER_BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<E, E, E>(&a, &b, REGISTER_BLOCK, Monoid::Sum);
     acc.zero();
     for region in Walk::over(acc.op_space(&a, &b)) {
         let mut acc_r = acc.at(&region);

--- a/crates/cubek-tile/tests/tile/split_k.rs
+++ b/crates/cubek-tile/tests/tile/split_k.rs
@@ -316,7 +316,7 @@ fn atomic_split_matmul<E: Numeric>(
     let mut c = out.tile(space);
     // The accumulator mirrors the output's grid at this level: opened above the walk, one
     // fragment per region, drained once through the sink after it.
-    let mut acc = c.block_accumulator::<E, E>(&a, REGISTER_BLOCK, Monoid::Sum);
+    let mut acc = c.block_accumulator::<E, E, E>(&a, &b, REGISTER_BLOCK, Monoid::Sum);
     acc.zero();
     for region in Walk::over(c.op_space(&a, &b)) {
         let mut acc_region = acc.at(&region);

--- a/crates/cubek-tile/tests/tile/stream.rs
+++ b/crates/cubek-tile/tests/tile/stream.rs
@@ -303,7 +303,12 @@ fn stream_matmul<E: Numeric>(
         let mut c_region = c.at(&region);
         let a_region = a.at(&region);
         let b_region = b.at(&region);
-        let mut acc = c_region.block_accumulator::<E, E>(&a_region, REGISTER_BLOCK, Monoid::Sum);
+        let mut acc = c_region.block_accumulator::<E, E, E>(
+            &a_region,
+            &b_region,
+            REGISTER_BLOCK,
+            Monoid::Sum,
+        );
         acc.zero();
         for cell in Walk::over(acc.op_space(&a_region, &b_region)).window(from, steps) {
             let mut acc_cell = acc.at(&cell);
@@ -338,7 +343,12 @@ fn stream_matmul_staged_rhs<E: Numeric>(
         let mut c_region = c.at(&region);
         let a_region = a.at(&region);
         let b_region = b.at(&region);
-        let mut acc = c_region.block_accumulator::<E, E>(&a_region, REGISTER_BLOCK, Monoid::Sum);
+        let mut acc = c_region.block_accumulator::<E, E, E>(
+            &a_region,
+            &b_region,
+            REGISTER_BLOCK,
+            Monoid::Sum,
+        );
         acc.zero();
         let cells = Walk::over(acc.op_space(&a_region, &b_region)).window(from, steps);
         let mut ring = Ring::smem_single(&cells, &b_region, StageStorage::Strided, 1usize);


### PR DESCRIPTION
The promoted block refused an rhs lined along the contraction, sending a weight stored along K to the memory-backed leaf, whose sum round-trips through the output's element on every visit and, at half precision, stops growing at 2048. The block now carries that step: `RegisterData::fold` says a line holds one cell's K partials, `mma` contracts a whole line a step and the drain collapses the line before the lane fold and the cast. The fold is derived where the block opens, so `Tile::block_accumulator` reads both operands (the block's lines are the rhs's); a reduction opens through `Tile::block_reducer`