### PR TITLE
feat(tile): a fragment operand may lie transposed

### DIFF
--- a/crates/cubek-tile/src/ops/matmul/lower.rs
+++ b/crates/cubek-tile/src/ops/matmul/lower.rs
@@ -4,6 +4,7 @@
 //!
 //! The [`Semiring`] states the accumulation's algebra once, at the call that runs the steps.
 
+use cubecl::cmma::MatrixLayout;
 use cubecl::prelude::*;
 
 use crate::instruction::registers::contract;
@@ -228,7 +229,7 @@ impl<E: Numeric> PlaneTile<E> {
     ) {
         match self {
             PlaneTile::Cmma(d) => {
-                strided_2d(lhs, rhs, out, false);
+                strided_2d(lhs, rhs, out, transposed_fragment(rhs));
                 hardware_semiring(semiring);
                 d.mma(lhs, rhs)
             }
@@ -312,6 +313,24 @@ fn strided_2d<EL: Numeric, ER: Numeric>(
          leaf, or an unpromoted Gmem/Smem accumulator, whose software instruction is the \
          `contract::memory` arm of `mma_leaf`"
     ));
+}
+
+/// Whether `rhs` is a cmma fragment loaded col-major: a `(col, k)` window, the transpose of the
+/// role's own order, which the fragment reads as the same matrix ([`PlanePartition::store`]) and
+/// which is therefore the edge the contraction runs along, as it is for a folded register step.
+#[cube]
+fn transposed_fragment<ER: Numeric>(rhs: &Tile<ER>) -> comptime_type!(bool) {
+    match &rhs.tile_kind {
+        TileKind::PlaneTile(t) => match t {
+            PlaneTile::Cmma(d) => comptime!(d.layout == MatrixLayout::ColMajor),
+            PlaneTile::Mma(_) | PlaneTile::Register(_) => comptime!(false),
+        },
+        TileKind::Gmem(_)
+        | TileKind::Smem(_)
+        | TileKind::PlanePartition(_)
+        | TileKind::TmaGmem(_)
+        | TileKind::Procedural(_) => comptime!(false),
+    }
 }
 
 /// Asserts that operands contract their shared axes in the same order.

--- a/crates/cubek-tile/src/tile/cmma.rs
+++ b/crates/cubek-tile/src/tile/cmma.rs
@@ -23,18 +23,20 @@ pub struct CmmaData<T: Numeric> {
 #[cube]
 impl<T: Numeric> CmmaData<T> {
     /// Allocate an uninitialized fragment. `m`/`n`/`k` are the whole MMA tile, passed in
-    /// full whatever the role; the layout is `RowMajor` (how the stages are laid out).
+    /// full whatever the role; `layout` is how the stage it loads from lays the role's rows
+    /// out.
     pub(crate) fn alloc(
         #[comptime] ident: MatrixIdent,
         #[comptime] m: usize,
         #[comptime] n: usize,
         #[comptime] k: usize,
+        #[comptime] layout: MatrixLayout,
     ) -> CmmaData<T> {
-        let matrix = unsafe { Matrix::<T>::uninitialized(ident, m, n, k, MatrixLayout::RowMajor) };
+        let matrix = unsafe { Matrix::<T>::uninitialized(ident, m, n, k, layout) };
         CmmaData::<T> {
             matrix,
             ident,
-            layout: MatrixLayout::RowMajor,
+            layout,
         }
     }
 

--- a/crates/cubek-tile/src/tile/plane.rs
+++ b/crates/cubek-tile/src/tile/plane.rs
@@ -42,9 +42,13 @@ impl<T: Numeric> PlaneTile<T> {
         #[comptime] monoid: Monoid,
     ) -> PlaneTile<T> {
         match comptime!(form) {
-            PlaneForm::Cmma => {
-                PlaneTile::new_Cmma(CmmaData::<T>::alloc(MatrixIdent::Accumulator, m, n, k))
-            }
+            PlaneForm::Cmma => PlaneTile::new_Cmma(CmmaData::<T>::alloc(
+                MatrixIdent::Accumulator,
+                m,
+                n,
+                k,
+                MatrixLayout::RowMajor,
+            )),
             PlaneForm::Mma { io } => {
                 PlaneTile::new_Mma(MmaData::<T>::acc(m, n, k, MatrixLayout::RowMajor, io))
             }
@@ -60,24 +64,22 @@ impl<T: Numeric> PlaneTile<T> {
         }
     }
 
-    /// An operand tile in role `ident`, uninitialized. `k` is the operand's own contraction
-    /// depth, not the instruction's.
+    /// An operand tile in role `ident`, uninitialized, loaded in `layout`: the role's own row
+    /// order, or its transpose where the operand lies that way. `k` is the operand's own
+    /// contraction depth, not the instruction's.
     pub(crate) fn operand(
         #[comptime] form: PlaneForm,
         #[comptime] ident: MatrixIdent,
         #[comptime] m: usize,
         #[comptime] n: usize,
         #[comptime] k: usize,
+        #[comptime] layout: MatrixLayout,
     ) -> PlaneTile<T> {
         match comptime!(form) {
-            PlaneForm::Cmma => PlaneTile::new_Cmma(CmmaData::<T>::alloc(ident, m, n, k)),
+            PlaneForm::Cmma => PlaneTile::new_Cmma(CmmaData::<T>::alloc(ident, m, n, k, layout)),
             PlaneForm::Mma { io } => match comptime!(ident) {
-                MatrixIdent::A => {
-                    PlaneTile::new_Mma(MmaData::<T>::lhs(m, n, k, MatrixLayout::RowMajor, io))
-                }
-                MatrixIdent::B => {
-                    PlaneTile::new_Mma(MmaData::<T>::rhs(m, n, k, MatrixLayout::RowMajor, io))
-                }
+                MatrixIdent::A => PlaneTile::new_Mma(MmaData::<T>::lhs(m, n, k, layout, io)),
+                MatrixIdent::B => PlaneTile::new_Mma(MmaData::<T>::rhs(m, n, k, layout, io)),
                 MatrixIdent::Accumulator => {
                     panic!("PlaneTile::operand: an accumulator is not an operand")
                 }
@@ -279,18 +281,39 @@ impl<T: Numeric> PlanePartition<T> {
         let a0 = comptime!(window.axis_at(window.rank() - 2));
         let a1 = comptime!(window.axis_at(window.rank() - 1));
 
-        // `A` is `m×k`, `B` is `k×n`: the operand's role is where its contracted axis sits, and
-        // its fragments run along the accumulator's rows or columns accordingly, one deep along
-        // the contraction.
+        // The operand's role is which of the accumulator's axes it shares: `A` spans the rows,
+        // `B` the columns. Its fragments run along that axis, one deep along the contraction —
+        // counted in the window's own axis order, since that is how `at` addresses them.
         let contracted = comptime!(window.contraction(&out));
-        let (ident, t0, t1) = comptime!(if contracted == a1 {
-            (MatrixIdent::A, grid.0, 1)
+        let free = comptime!(if contracted == a1 {
+            a0
         } else {
             assert!(
                 contracted == a0,
                 "PlanePartition::store: the contracted axis must be one of the trailing two"
             );
-            (MatrixIdent::B, 1, grid.1)
+            a1
+        });
+        let out_rows = comptime!(out.axis_at(out.rank() - 2));
+        let (ident, tiles) = comptime!(if free == out_rows {
+            (MatrixIdent::A, grid.0)
+        } else {
+            assert!(
+                free == out.axis_at(out.rank() - 1),
+                "PlanePartition::store: the operand's free axis must be one of the output's \
+                 trailing two"
+            );
+            (MatrixIdent::B, grid.1)
+        });
+        let (t0, t1) = comptime!(if free == a0 { (tiles, 1) } else { (1, tiles) });
+        // The role's rows: `A` is `m×k` and `B` is `k×n`, so an operand whose window lists the
+        // axes in that order is row-major, and one listing them the other way — a weight
+        // stored `{n, k}`, read in lines along its contraction — is the same fragment loaded
+        // col-major off the same rows.
+        let layout = comptime!(if (ident == MatrixIdent::A) == (contracted == a1) {
+            MatrixLayout::RowMajor
+        } else {
+            MatrixLayout::ColMajor
         });
         let k = comptime!(window.extent(contracted));
 
@@ -299,7 +322,7 @@ impl<T: Numeric> PlanePartition<T> {
         for _i in 0..t0 {
             #[unroll]
             for _j in 0..t1 {
-                frags.push(PlaneTile::<T>::operand(form, ident, m, n, k));
+                frags.push(PlaneTile::<T>::operand(form, ident, m, n, k, layout));
             }
         }
         Tile::<T> {

--- a/crates/cubek-tile/tests/tile/matmul.rs
+++ b/crates/cubek-tile/tests/tile/matmul.rs
@@ -3928,9 +3928,29 @@ fn cmma_matmul_staged_k_walk_vectorized() {
     check_cmma_matmul_k_walk(16, 1, 2, StageLayout::Tiled);
 }
 
+/// The staged cmma K walk with the rhs stored `{N, K}`: the stage keeps that order and the `B`
+/// fragment loads col-major off it, so a weight contiguous along the contraction is staged in
+/// its own lines. Double-buffered, so the ring's prefetch moves that order too.
+#[test]
+fn cmma_matmul_double_buffered_k_walk_transposed_rhs() {
+    check_cmma_matmul_k_walk_with(32, 2, 1, StageLayout::Tiled, true);
+}
+
 /// The one level always stages, whatever its depth: a cmma leaf cannot consume the global inputs
 /// directly, so the kernel first materializes them in shared memory.
 fn check_cmma_matmul_k_walk(k: usize, depth: usize, v: usize, layout: StageLayout) {
+    check_cmma_matmul_k_walk_with(k, depth, v, layout, false)
+}
+
+/// [`check_cmma_matmul_k_walk`], the rhs stored `{K, N}` or — `transposed` — `{N, K}`, against
+/// the reference each storage order states over the same arange.
+fn check_cmma_matmul_k_walk_with(
+    k: usize,
+    depth: usize,
+    v: usize,
+    layout: StageLayout,
+    transposed: bool,
+) {
     let client = cubecl::test_device().client();
     if !require_cmma_8x8x8_f32(&client) {
         return;
@@ -3948,7 +3968,8 @@ fn check_cmma_matmul_k_walk(k: usize, depth: usize, v: usize, layout: StageLayou
     let a = TileInput::builder(&client, launcher.space().project(&[M, K]))
         .untiled()
         .arange();
-    let b = TileInput::builder(&client, launcher.space().project(&[K, N]))
+    let b_axes: &[Axis] = if transposed { &[N, K] } else { &[K, N] };
+    let b = TileInput::builder(&client, launcher.space().project(b_axes))
         .untiled()
         .arange();
     // Poisoned, not zeroed: the kernel zeroes the accumulator fragment.
@@ -3970,7 +3991,17 @@ fn check_cmma_matmul_k_walk(k: usize, depth: usize, v: usize, layout: StageLayou
         depth,
         f32::elem_type_native(),
     );
-    assert_matmul_arange(&client, c.handle(), m, n, k);
+    if transposed {
+        let output = HostData::from_tensor_handle(&client, c.handle(), HostDataType::F32);
+        let (_, expected) = TestInput::builder(client, shape![m, n])
+            .custom(folded_matmul_reference(m, n, k))
+            .generate_with_f32_host_data();
+        assert_equals_approx(&output, &expected, 1e-3)
+            .as_test_outcome()
+            .enforce()
+    } else {
+        assert_matmul_arange(&client, c.handle(), m, n, k);
+    }
 }
 
 /// The manual/raw-mma instruction: the raw-mma twin of `cmma_matmul_staged_k_walk`: the same


### PR DESCRIPTION
A partition takes its role from the accumulator axis it shares and its fragment layout from where its contracted axis sits, so a weight stored `{n, k}` stages in its own lines and loads col-major off the same rows. The cmma leaf accepts that fragment as the edge the contraction runs along.


Claude-Session: https://claude.ai/code/session_01Knnk5WNMsHcH48eumuHXRV

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
