### PR TITLE
test(reduce): run the cube top-k tests on the CPU runtime again

### DIFF
--- a/crates/cubek-reduce/tests/reduce/it/topk_with_indices_cube.rs
+++ b/crates/cubek-reduce/tests/reduce/it/topk_with_indices_cube.rs
@@ -24,15 +24,6 @@ use cubek_reduce::{
 
 use crate::reduce::it::test_case::TestCase;
 
-/// The cube tree merge (`use_planes: false`) produces wrong top-k results for
-/// `k > 1` on the CPU runtime, for the values-only path through plain `reduce`
-/// just as much as for the fused one; every GPU backend passes. The affected
-/// tests skip that runtime so the pre-existing bug does not fail the CPU CI job.
-fn cpu_runtime() -> bool {
-    let client = cubecl::test_device().client();
-    client.name() == "cpu"
-}
-
 fn cube_strategy(use_planes: bool) -> ReduceStrategy {
     ReduceStrategy {
         vectorization: VectorizationStrategy {
@@ -99,17 +90,11 @@ fn cube_units_max_with_indices() {
 
 #[test]
 fn cube_units_topk_with_indices_k3() {
-    if cpu_runtime() {
-        return;
-    }
     case(false).test_topk_with_indices(3);
 }
 
 #[test]
 fn cube_units_topk_with_indices_k5() {
-    if cpu_runtime() {
-        return;
-    }
     case(false).test_topk_with_indices(5);
 }
 


### PR DESCRIPTION
## What

Deletes the `cpu_runtime()` guard in `topk_with_indices_cube.rs` and the two early returns
it fed, so `cube_units_topk_with_indices_k3` and `_k5` run on the CPU runtime like every
other test in the file.

## Why

The guard was added because the cube tree merge (`use_planes: false`) returned wrong top-k
values for `k > 1` on the CPU runtime, about 0.01 off with 5 of 12 elements wrong at k=3.
That does not happen any more. The CPU backend was rewritten wholesale in the meantime
(cubecl's pliron migration, and `Fix/cpu shared memory` after it), and I could not pin the
fix to one commit: a bisect has to move both repos, because a cubek from before the
migration does not build against a cubecl from after it.

## Verified

On this branch, built against the cubecl rev `main` pins, on the CPU runtime (plane size 1,
16 units per cube, so the 16-slot tree is genuinely built):

- The whole file: 12 passed. The two unguarded tests: 130 runs out of 130.
- The values-only shapes the original triangulation used, `test_topk(3)`, `test_topk(5)` and
  `test_argtopk(3)` through the cube-unit path: pass.
- They execute rather than passing on a kernel that never launched: under
  `policy = "fail-if-run"` all four `cube_units_*` tests come back red with "Actually
  passed, but fail-if-run policy active".
- `cargo fmt` clean, `clippy --tests -D warnings` clean.

## Not in this PR

Under `policy = "strict"` the file's eight `cube_planes_*` tests fail on CPU with "Trying to
launch a kernel using plane instructions, but there are not supported by the hardware". They
have never run on that runtime and report `ok` anyway. Worth making them skip visibly, in a
change of its own.

The diff is confined to one test file, so the burn validation the template asks for does not
apply.
