### PR TITLE
fix(matmul): pass the split-k bench its local dtype

### DIFF
--- a/crates/cubek-matmul/src/tiled/eval/split_k/mod.rs
+++ b/crates/cubek-matmul/src/tiled/eval/split_k/mod.rs
@@ -354,7 +354,7 @@ impl Benchmark for SplitKBench {
                 TileArgLaunch::new(rhs_arg(b, self.mapping), b.spec()),
                 TileArgLaunch::new(c.tensor_arg(1), c.spec()),
                 self.launcher.partitioning_arg(),
-                self.dtype,
+                dtype,
             ),
             Levels::Two => split_k_matmul_two_levels::launch(
                 &self.client,
@@ -364,7 +364,7 @@ impl Benchmark for SplitKBench {
                 TileArgLaunch::new(rhs_arg(b, self.mapping), b.spec()),
                 TileArgLaunch::new(c.tensor_arg(1), c.spec()),
                 self.launcher.partitioning_arg(),
-                self.self.dtype,
+                dtype,
             ),
         }
         Ok(())


### PR DESCRIPTION
The two launch arms read `self.dtype` and `self.self.dtype`, neither of which is a field on `SplitKBench`. The local the function already computes is what both meant. Behind the `benchmarks` feature, which nothing in CI builds, so main has been unbuildable for every cubek benchmark since #632.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn. 

### Instructions

- [ ] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [ ] Update the main [Cargo.toml](https://github.com/tracel-ai/burn/blob/40aa993fb5969351a006b560ec89da5119dc9721/Cargo.toml#L159=L161) with this PR hash.
- [ ] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.
