### PR TITLE
feat(conv): add a benchmark catalogue for the direct routine

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -116,6 +116,10 @@ name = "depthwise"
 
 [[bench]]
 harness = false
+name = "direct_conv"
+
+[[bench]]
+harness = false
 name = "memcpy_async"
 
 [[bench]]

--- a/benchmarks/benches/direct_conv.rs
+++ b/benchmarks/benches/direct_conv.rs
@@ -1,0 +1,1 @@
+benchmarks::run_bench!(direct_conv);

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -4,6 +4,7 @@ pub use cubek_attention::eval::backward::benchmarks as attention_backward;
 pub use cubek_attention::eval::forward::benchmarks as attention;
 pub use cubek_convolution::eval::benchmarks as conv2d;
 pub use cubek_convolution::eval::benchmarks::depthwise;
+pub use cubek_convolution::eval::benchmarks::direct as direct_conv;
 pub use cubek_fft::eval::benchmarks as fft;
 pub use cubek_interpolate::eval::benchmarks as interpolate;
 pub use cubek_matmul::eval::benchmarks::gemm;

--- a/crates/cubek-convolution/src/eval/benchmarks/direct/benchmark.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/direct/benchmark.rs
@@ -1,0 +1,113 @@
+use cubecl::{
+    benchmark::{Benchmark, ProfileDuration, TimingMethod},
+    client::Client,
+    future,
+    prelude::*,
+    std::tensor::TensorHandle,
+    zspace::Shape,
+};
+use cubek_test_utils::{RunSamples, TestInput};
+
+use crate::{ConvolutionArgs, DirectTensors, launch_direct};
+
+use super::problem::{DirectProblem, DirectStrategy};
+
+pub fn bench(
+    strategy: &DirectStrategy,
+    problem: &DirectProblem,
+    num_samples: usize,
+) -> Result<RunSamples, String> {
+    let device = cubecl::test_device();
+    let client = device.client();
+
+    let bench = DirectBench {
+        problem: *problem,
+        strategy: *strategy,
+        client,
+        device,
+        samples: num_samples,
+    };
+
+    let durations = bench
+        .run(cubek_test_utils::timing_method(TimingMethod::System))
+        .map_err(|e| format!("benchmark failed: {e}"))?
+        .durations;
+
+    Ok(RunSamples::new(durations))
+}
+
+struct DirectBench {
+    problem: DirectProblem,
+    #[allow(dead_code)]
+    strategy: DirectStrategy,
+    device: cubecl::Device,
+    client: Client,
+    samples: usize,
+}
+
+fn dtype() -> ElemType {
+    f32::elem_type_native()
+}
+
+fn uniform(client: &Client, shape: [usize; 4], seed: u64) -> TensorHandle {
+    TestInput::builder(client.clone(), Shape::new(shape))
+        .dtype(dtype())
+        .uniform(seed, 0.0, 1.0)
+        .generate_without_host_data()
+}
+
+impl Benchmark for DirectBench {
+    type Input = (TensorHandle, TensorHandle);
+    type Output = ();
+
+    fn prepare(&self) -> Self::Input {
+        (
+            uniform(&self.client, self.problem.in_shape(), 0),
+            uniform(&self.client, self.problem.weight_shape(), 1),
+        )
+    }
+
+    fn execute(&self, (input, weight): Self::Input) -> Result<(), String> {
+        let problem = &self.problem;
+        let out: TensorHandle =
+            TensorHandle::empty(&self.client, problem.out_shape().to_vec(), dtype());
+
+        let padding = problem.padding();
+        let args = ConvolutionArgs::<2> {
+            stride: [problem.stride; 2],
+            padding: [padding; 2],
+            dilation: [1; 2],
+        };
+
+        launch_direct::<2>(
+            &self.client,
+            DirectTensors {
+                input: input.binding(),
+                weight: weight.binding(),
+                bias: None,
+                out: out.binding(),
+            },
+            args,
+            1,
+            dtype(),
+        )
+        .map_err(|e| format!("{e:?}"))
+    }
+
+    fn num_samples(&self) -> usize {
+        self.samples
+    }
+
+    fn name(&self) -> String {
+        let client = self.device.client();
+        format!("{}-direct-conv-{}", client.name(), dtype()).to_lowercase()
+    }
+
+    fn sync(&self) {
+        future::block_on(self.client.sync()).unwrap()
+    }
+
+    fn profile(&self, args: Self::Input) -> Result<ProfileDuration, String> {
+        cubek_test_utils::profile_launch(&self.client, "direct-conv-bench", || self.execute(args))
+    }
+}

--- a/crates/cubek-convolution/src/eval/benchmarks/direct/mod.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/direct/mod.rs
@@ -1,0 +1,72 @@
+mod benchmark;
+mod problem;
+
+pub use benchmark::bench;
+pub use problem::{DirectProblem, DirectStrategy, problems, strategies};
+
+use cubecl::prelude::*;
+use cubek_matmul::definition::MatmulGlobalElems;
+use cubek_test_utils::{CatalogEntry, CategoryWork, ComputeWork, RunSamples};
+
+use crate::definition::Conv2dCost;
+
+pub struct Category;
+
+impl cubek_test_utils::Category for Category {
+    type Problem = DirectProblem;
+    type Strategy = DirectStrategy;
+
+    fn id(&self) -> &'static str {
+        "direct"
+    }
+
+    fn label(&self) -> &'static str {
+        "Direct conv2d"
+    }
+
+    fn problems(&self) -> Vec<CatalogEntry<DirectProblem>> {
+        problems()
+    }
+
+    fn strategies(&self) -> Vec<CatalogEntry<DirectStrategy>> {
+        strategies()
+    }
+
+    fn bench(
+        &self,
+        strategy: &DirectStrategy,
+        problem: &DirectProblem,
+        num_samples: usize,
+    ) -> Result<RunSamples, String> {
+        bench(strategy, problem, num_samples)
+    }
+
+    fn work(&self, problem: &DirectProblem) -> Option<CategoryWork> {
+        let dtype = f32::elem_type_native();
+        let out = problem.out_size();
+
+        let cost = Conv2dCost {
+            batch: problem.batch,
+            channels_in: problem.channels_in,
+            spatial_in: [problem.size; 2],
+            channels_out: problem.channels_out,
+            kernel: [problem.kernel; 2],
+            spatial_out: [out; 2],
+            bias_elems: 0,
+            elems: MatmulGlobalElems {
+                lhs: dtype,
+                rhs: dtype,
+                out: dtype,
+            },
+        };
+
+        let (bytes_read, bytes_written) = cost.traffic();
+
+        Some(CategoryWork {
+            // This routine issues no MMA: judge it against the scalar peak, not `compute_key`.
+            compute: Some(ComputeWork::direct(cost.compute_ops(), dtype)),
+            bytes_read,
+            bytes_written,
+        })
+    }
+}

--- a/crates/cubek-convolution/src/eval/benchmarks/direct/problem.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/direct/problem.rs
@@ -1,0 +1,97 @@
+use cubek_test_utils::CatalogEntry;
+
+#[derive(Clone, Copy)]
+pub struct DirectProblem {
+    pub batch: usize,
+    pub channels_in: usize,
+    pub channels_out: usize,
+    pub size: usize,
+    pub kernel: usize,
+    pub stride: usize,
+}
+
+impl DirectProblem {
+    pub fn padding(&self) -> usize {
+        self.kernel / 2
+    }
+
+    pub fn out_size(&self) -> usize {
+        (self.size + 2 * self.padding() - self.kernel) / self.stride + 1
+    }
+
+    pub fn in_shape(&self) -> [usize; 4] {
+        [self.batch, self.size, self.size, self.channels_in]
+    }
+
+    pub fn weight_shape(&self) -> [usize; 4] {
+        [
+            self.channels_out,
+            self.kernel,
+            self.kernel,
+            self.channels_in,
+        ]
+    }
+
+    pub fn out_shape(&self) -> [usize; 4] {
+        let out = self.out_size();
+        [self.batch, out, out, self.channels_out]
+    }
+}
+
+const LAYERS: [(&str, usize, usize, usize, usize, usize); 14] = [
+    ("stem_3_64_k7s2", 3, 64, 224, 7, 2),
+    ("r1_64_64_k1", 64, 64, 56, 1, 1),
+    ("r1_64_64_k3", 64, 64, 56, 3, 1),
+    ("r1_64_256_k1", 64, 256, 56, 1, 1),
+    ("r1_256_64_k1", 256, 64, 56, 1, 1),
+    ("r2_128_128_k3", 128, 128, 28, 3, 1),
+    ("r2_128_128_k3s2", 128, 128, 56, 3, 2),
+    ("r3_256_256_k3", 256, 256, 14, 3, 1),
+    ("r4_512_512_k3", 512, 512, 7, 3, 1),
+    ("r4_512_2048_k1", 512, 2048, 7, 1, 1),
+    ("c4_32_k3", 4, 32, 56, 3, 1),
+    ("c8_32_k3", 8, 32, 56, 3, 1),
+    ("c16_32_k3", 16, 32, 56, 3, 1),
+    ("c32_32_k3", 32, 32, 56, 3, 1),
+];
+
+fn batch() -> usize {
+    std::env::var("CUBEK_BENCH_BATCH")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1)
+}
+
+pub fn problems() -> Vec<CatalogEntry<DirectProblem>> {
+    let batch = batch();
+
+    LAYERS
+        .iter()
+        .map(|&(id, channels_in, channels_out, size, kernel, stride)| {
+            let problem = DirectProblem {
+                batch,
+                channels_in,
+                channels_out,
+                size,
+                kernel,
+                stride,
+            };
+            let label =
+                format!("b{batch} {channels_in}->{channels_out}c {size}px k{kernel} s{stride}");
+            CatalogEntry::new(id, label, problem)
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum DirectStrategy {
+    Routine,
+}
+
+pub fn strategies() -> Vec<CatalogEntry<DirectStrategy>> {
+    vec![CatalogEntry::new(
+        "routine",
+        "the routine's own choice",
+        DirectStrategy::Routine,
+    )]
+}

--- a/crates/cubek-convolution/src/eval/benchmarks/mod.rs
+++ b/crates/cubek-convolution/src/eval/benchmarks/mod.rs
@@ -7,6 +7,7 @@
 mod benchmark;
 mod correctness;
 pub mod depthwise;
+pub mod direct;
 mod problem;
 mod strategy;
 


### PR DESCRIPTION
The direct routine had no way to be scored against what a machine can actually do. Measuring it meant a harness outside the repo, layer shapes retyped into a script to get arithmetic intensity, and peaks computed from `cores x FMA x lanes x clock` rather than measured.

Fourteen problems: ResNet-50's distinct dense convolutions, plus a low-channel ladder that walks the boundary between the kernel's two regimes and straddles the point where the lane-accumulating path turns on.

**One judgement worth reviewing.** The arithmetic and the traffic come from `Conv2dCost`, but the ceiling deliberately does not. `Conv2dCost::compute_key` names the matmul's probe, because an accelerated convolution issues the MMA a gemm does; this routine issues none, so it is scored against the scalar peak through `ComputeWork::direct`.

Run on a Ryzen 7 5700X, batch 1, f32:

| problem | achieved | binding roof |
|---|---|---|
| 3->64c 224px k7 s2 | 0.087 TFLOPS | compute, 8% |
| 64->64c 56px k1 | 0.126 | **write**, 18% of write peak |
| 64->64c 56px k3 | 0.167 | compute, 16% |
| 64->256c 56px k1 | 0.151 | **write**, 22% |
| 256->64c 56px k1 | 0.224 | compute, 21% |
| 128->128c 28px k3 | 0.220 | compute, 21% |
| 128->128c 56px k3 s2 | 0.209 | compute, 19% |
| 256->256c 14px k3 | 0.233 | compute, 22% |
| 512->512c 7px k3 | 0.190 | compute, 18% |
| 512->2048c 7px k1 | 0.204 | compute, 19% |
| 4->32c 56px k3 | 0.054 | **write**, 14% |
| 8->32c 56px k3 | 0.074 | **write**, 9% |
| 16->32c 56px k3 | 0.068 | compute, 6% |
| 32->32c 56px k3 | 0.107 | compute, 10% |

Two things that table says and a duration cannot. **Four layers are write-bound**, every 1x1 and every very-low-channel one, so work aimed at loads per multiply-add cannot move them. And the compute-bound ones cluster at **16 to 22% of measured peak**, against the 20 to 39% a hand-computed theoretical ceiling had suggested for the same shapes on the same machine.

One strategy today. It is a catalogue axis rather than a constant so the first tunable, the width of the output-channel block, has somewhere to be swept from instead of a rebuild per value.

Stacked on #642.
