### PR TITLE
fix(matmul): update cubecl to the Metal single-simdgroup miscompile fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "darling",
  "inflections",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=f3e3bd9e015d74c9627a3485edd10e2dd14268ec#f3e3bd9e015d74c9627a3485edd10e2dd14268ec"
+source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -612,7 +612,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -791,7 +791,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "cubecl-llvm"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cc",
  "cubecl-core",
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cubecl-common",
  "darling",
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "darling",
  "inflections",
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -892,7 +892,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "buildid",
  "bytemuck",
@@ -921,7 +921,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.3"
-source = "git+https://github.com/tracel-ai/cubecl?rev=c9c49039288164a00d58e5e21c10d617e0e3a5e1#c9c49039288164a00d58e5e21c10d617e0e3a5e1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=359770be3c9fe69c0b0f4c6f7697062a86bbf4a8#359770be3c9fe69c0b0f4c6f7697062a86bbf4a8"
 dependencies = [
  "derive-new",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ cubek-tile = { path = "crates/cubek-tile", version = "=0.3.0-pre.3", default-fea
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 # cubecl-ir = { path = "../cubecl/crates/cubecl-ir", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec", default-features = false }
-cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "f3e3bd9e015d74c9627a3485edd10e2dd14268ec", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "c9c49039288164a00d58e5e21c10d617e0e3a5e1", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "c9c49039288164a00d58e5e21c10d617e0e3a5e1", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "c9c49039288164a00d58e5e21c10d617e0e3a5e1", default-features = false }
+cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "c9c49039288164a00d58e5e21c10d617e0e3a5e1", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.3", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ cubek-tile = { path = "crates/cubek-tile", version = "=0.3.0-pre.3", default-fea
 # cubecl-environment = { path = "../cubecl/crates/cubecl-environment", default-features = false }
 # cubecl-ir = { path = "../cubecl/crates/cubecl-ir", default-features = false }
 ### For the main cubek branch. ###
-cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "c9c49039288164a00d58e5e21c10d617e0e3a5e1", default-features = false }
-cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "c9c49039288164a00d58e5e21c10d617e0e3a5e1", default-features = false }
-cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "c9c49039288164a00d58e5e21c10d617e0e3a5e1", default-features = false }
-cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "c9c49039288164a00d58e5e21c10d617e0e3a5e1", default-features = false }
+cubecl = { git = "https://github.com/tracel-ai/cubecl", rev = "359770be3c9fe69c0b0f4c6f7697062a86bbf4a8", default-features = false }
+cubecl-common = { git = "https://github.com/tracel-ai/cubecl", rev = "359770be3c9fe69c0b0f4c6f7697062a86bbf4a8", default-features = false }
+cubecl-environment = { git = "https://github.com/tracel-ai/cubecl", rev = "359770be3c9fe69c0b0f4c6f7697062a86bbf4a8", default-features = false }
+cubecl-ir = { git = "https://github.com/tracel-ai/cubecl", rev = "359770be3c9fe69c0b0f4c6f7697062a86bbf4a8", default-features = false }
 ### For releases ###
 # cubecl = { version = "=0.11.0-pre.3", default-features = false }
 # cubecl-common = { version = "=0.11.0-pre.3", default-features = false }

--- a/crates/cubek-matmul/tests/multi_level/basic/plane_accelerated.rs
+++ b/crates/cubek-matmul/tests/multi_level/basic/plane_accelerated.rs
@@ -242,9 +242,6 @@ fn ordered_double_mma() {
     );
 }
 
-// Small k with an output width off the line size once made the Metal compiler corrupt rows
-// 4..7 of some 8x8 output tiles (a `max_total_threads_per_threadgroup(32)` miscompile), so a
-// single launch could pass by luck; the loop makes the check meaningful.
 #[test]
 fn simple_cyclic_cmma_small_k_and_partial_line_width_rows_stay_correct() {
     use crate::harness::{f32_elems, rect};

--- a/crates/cubek-matmul/tests/multi_level/basic/plane_accelerated.rs
+++ b/crates/cubek-matmul/tests/multi_level/basic/plane_accelerated.rs
@@ -241,3 +241,20 @@ fn ordered_double_mma() {
         MultiLevel::OrderedDoubleMma(Default::default()).into(),
     );
 }
+
+// Small k with an output width off the line size once made the Metal compiler corrupt rows
+// 4..7 of some 8x8 output tiles (a `max_total_threads_per_threadgroup(32)` miscompile), so a
+// single launch could pass by luck; the loop makes the check meaningful.
+#[test]
+fn simple_cyclic_cmma_small_k_and_partial_line_width_rows_stay_correct() {
+    use crate::harness::{f32_elems, rect};
+    for _ in 0..20 {
+        for (m, n, k) in [(382, 10, 1), (382, 10, 3), (4096, 14, 5)] {
+            test_matmul_strategy(
+                client(),
+                rect(m, n, k, f32_elems()),
+                MultiLevel::SimpleCyclicCmma(Default::default()).into(),
+            );
+        }
+    }
+}

--- a/crates/cubek-tile/src/tile/base.rs
+++ b/crates/cubek-tile/src/tile/base.rs
@@ -898,11 +898,7 @@ impl<T: Numeric> Tile<T> {
     /// share a slot, so every spill happens, then one barrier, then every add: two barriers for the
     /// drain however many tiles it has. That is the whole reason the size is a setting
     /// ([`Resident`]).
-    pub fn drained_into<Out: Numeric>(
-        &self,
-        dest: &Tile<Out>,
-        #[comptime] cells: Option<Level>,
-    ) {
+    pub fn drained_into<Out: Numeric>(&self, dest: &Tile<Out>, #[comptime] cells: Option<Level>) {
         match cells {
             // A grid below the drain: one region of `cells` per tile of it.
             Some(cells) => self.drain_grid(dest, cells),


### PR DESCRIPTION
## What

Bumps cubecl to `c9c49039` (branch `fix/corrupt-kernel-fix`), which stops the Metal code generator from declaring `[[max_total_threads_per_threadgroup(32)]]`, and adds a regression test for the matmul corruption that bound caused.

## Why

With a bound of exactly one simdgroup, Apple's Metal compiler miscompiles the stage-load path of `SimpleCyclicCmma`: rows 4..7 of some 8x8 output tiles come back corrupted (silently wrong values, or NaN when the pool holds garbage). It reproduces standalone in a Metal harness with the emitted MSL, disappears with a bound of 64, and is unaffected by barriers. It surfaced as nondeterministic NaN failures of burn's `burn-linalg` LU tests on the macOS CI runner.

The new test loops `SimpleCyclicCmma` over `[382,10,1]`, `[382,10,3]` and `[4096,14,5]` in f32; on the previous cubecl it failed on the first launch almost every run, and it passes 3 of 3 runs on Metal with the bump.

## Validate your PR with burn.

It is important that you make sure that you don't introduce any bugs in burn.

### Instructions

- [x] Create a new branch or fork of the [burn repo](https://github.com/Tracel-AI/burn)
- [x] Update the main Cargo.toml with this PR hash.
- [x] Fix any broken tests or compilation errors in burn.
- [ ] Submit a PR in burn with your fixes and link it here.

burn's full `burn-linalg` Metal CI command (`--features metal,std,fusion`) passes against this cubecl rev (209 tests, block-dispatch LU tests green 3 of 3 runs); the burn PR bumping both revs follows.