### PR TITLE
fix: correct average-pooling backward divisor in ceil mode

### DIFF
--- a/crates/cubek-pool/src/eval/cpu_reference/backward/avg_pool.rs
+++ b/crates/cubek-pool/src/eval/cpu_reference/backward/avg_pool.rs
@@ -65,7 +65,9 @@ pub fn run_avg_pool_backward<const N: usize>(
                         let grad_val = grad_output.get_f32(&out_coords);
 
                         if opts.count_include_pad {
-                            grad_acc += grad_val / (kernel_h * kernel_w) as f32;
+                            let padded_h = kernel_h.min(out_h + 2 * pad_h - oh * stride_h);
+                            let padded_w = kernel_w.min(out_w + 2 * pad_w - ow * stride_w);
+                            grad_acc += grad_val / (padded_h * padded_w) as f32;
                         } else {
                             let ih_diff = (ih_end - ih_start) as f32;
                             let iw_diff = (iw_end - iw_start) as f32;

--- a/crates/cubek-pool/src/kernel/backward/avg_pool2d_backward.rs
+++ b/crates/cubek-pool/src/kernel/backward/avg_pool2d_backward.rs
@@ -84,8 +84,13 @@ fn avg_pool2d_backward_kernel<E: Numeric, N: Size>(
 
                 if begin_w >= iw_start && (iw as u32) < iw_end {
                     if count_include_pad {
-                        grad_acc += grad[index / vector_size]
-                            / Vector::cast_from(kernel_size_0 * kernel_size_1);
+                        // Ceil-mode extensions lie outside the padded input.
+                        let padded_h =
+                            clamp_max(kernel_size_0, border_bottom + padding_0 - oh * stride_0);
+                        let padded_w =
+                            clamp_max(kernel_size_1, border_right + padding_1 - ow * stride_1);
+                        grad_acc +=
+                            grad[index / vector_size] / Vector::cast_from(padded_h * padded_w);
                     } else {
                         let ih_diff = ih_end - ih_start;
                         let iw_diff = iw_end - iw_start;

--- a/crates/cubek-pool/tests/pool/backward/avg_pool2d.rs
+++ b/crates/cubek-pool/tests/pool/backward/avg_pool2d.rs
@@ -1,6 +1,11 @@
-use super::{make_problem, run_pool_backward_test};
+use super::{
+    build_output_tensor, make_problem, output_host_f32, run_pool_backward_test, validate_test,
+};
 use cubecl::zspace::Shape;
-use cubek_pool::definition::AvgPoolOptions;
+use cubek_pool::{
+    definition::AvgPoolOptions, eval::cpu_reference::cpu_reference_pool_backward, pool2d_backward,
+};
+use cubek_test_utils::TestInput;
 
 const AVG_POOL2D_BACKWARD_TOLERANCE: f32 = 0.000001;
 
@@ -83,18 +88,69 @@ fn test_avg_pool2d_backward_non_square_asymmetric() {
 #[test]
 fn test_avg_pool2d_backward_ceil_mode() {
     let client = cubecl::test_device().client();
-    let problem = make_problem(
-        [5, 5],
-        Shape::from([2, 3, 3, 4]),
-        false,
-        AvgPoolOptions::new([2, 2], [2, 2], [0, 0], true, true),
-    );
-    run_pool_backward_test(
-        client,
-        4567,
-        -1.0,
-        1.0,
-        problem,
-        AVG_POOL2D_BACKWARD_TOLERANCE,
-    );
+    for count_include_pad in [true, false] {
+        for (input_size, out_size, kernel, padding, upstream, expected) in [
+            (
+                [1, 5],
+                [1, 3],
+                [1, 2],
+                [0, 0],
+                vec![2.0, 4.0, 8.0],
+                vec![1.0, 1.0, 2.0, 2.0, 8.0],
+            ),
+            // Padded counts: [9, 6, 6, 4]; valid counts: [4, 2, 2, 1].
+            (
+                [3, 3],
+                [2, 2],
+                [3, 3],
+                [1, 1],
+                vec![36.0, 24.0, 24.0, 16.0],
+                if count_include_pad {
+                    vec![4.0; 9]
+                } else {
+                    vec![9.0, 9.0, 12.0, 9.0, 9.0, 12.0, 12.0, 12.0, 16.0]
+                },
+            ),
+        ] {
+            let shape = [1, input_size[0], input_size[1], 1];
+            let out_shape = Shape::from([1, out_size[0], out_size[1], 1]);
+            let problem = make_problem(
+                input_size,
+                out_shape.clone(),
+                false,
+                AvgPoolOptions::new(kernel, kernel, padding, true, count_include_pad),
+            );
+            let (input, input_data) = TestInput::builder(client.clone(), shape)
+                .zeros()
+                .generate_with_f32_host_data();
+            let (grad, grad_data) = TestInput::builder(client.clone(), out_shape)
+                .custom(upstream)
+                .generate_with_f32_host_data();
+            let expected = TestInput::builder(client.clone(), shape)
+                .custom(expected)
+                .f32_host_data();
+            let output = build_output_tensor(&client, shape.to_vec(), input.dtype);
+            pool2d_backward(
+                &client,
+                input.clone().binding(),
+                grad.binding(),
+                output.clone().binding(),
+                problem.mode.clone(),
+                input.dtype,
+            )
+            .unwrap();
+            validate_test(
+                Ok(()),
+                output_host_f32(&client, output),
+                expected.clone(),
+                AVG_POOL2D_BACKWARD_TOLERANCE,
+            );
+            validate_test(
+                Ok(()),
+                cpu_reference_pool_backward(&grad_data, &input_data, problem),
+                expected,
+                AVG_POOL2D_BACKWARD_TOLERANCE,
+            );
+        }
+    }
 }


### PR DESCRIPTION
### Related Issues/PRs

Related to tracel-ai/burn#5604 and tracel-ai/burn#5653.

Fixes the same average-pooling gradient mismatch in CubeK by excluding ceil-mode extensions beyond the padded input from the backward divisor.

### Changes

Changed files:

- crates/cubek-pool/src/kernel/backward/avg_pool2d_backward.rs: clip the padded divisor for each window so backward matches forward
- crates/cubek-pool/src/eval/cpu_reference/backward/avg_pool.rs: correct the CPU reference, which repeated the same defect
- crates/cubek-pool/tests/pool/backward/avg_pool2d.rs: update the existing ceil-mode test to check the kernel and CPU reference against independently calculated gradients, covering overhang, actual padding, both counting settings, and nonuniform upstream gradients

### Testing

- Reproduced the CUDA failure before the fix: final gradient 4, expected 8
- CubeK CUDA pooling suite passed: 55 tests, 10 existing skips
- Burn CUDA pooling tests passed with a local dependency override: 8 autodiff tests, including checkpointing, and 5 forward tests
- All checks related to this PR's changes passed

### Validate your PR with Burn

Validated in tracel-ai/burn#5653, which now pins CubeK to this PR’s commit SHA.